### PR TITLE
tc: Make TIR stores static and implement convenience methods for IDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,6 +794,7 @@ dependencies = [
  "hash-target",
  "hash-utils",
  "indexmap",
+ "lazy_static",
  "num-bigint",
  "textwrap",
  "typed-builder",

--- a/compiler/hash-tir/Cargo.toml
+++ b/compiler/hash-tir/Cargo.toml
@@ -12,6 +12,7 @@ num-bigint = "0.4"
 textwrap = "0.16"
 utility-types = "0.0.2"
 typed-builder = "0.11"
+lazy_static = "1.4"
 
 hash-ast = { path = "../hash-ast" }
 hash-source = { path = "../hash-source" }

--- a/compiler/hash-tir/src/args.rs
+++ b/compiler/hash-tir/src/args.rs
@@ -16,7 +16,7 @@ use super::{
     params::ParamIndex,
     pats::PatId,
 };
-use crate::terms::TermId;
+use crate::{impl_sequence_store_id, terms::TermId};
 
 /// An argument to a parameter.
 ///
@@ -42,6 +42,8 @@ impl From<Arg> for ArgData {
 new_sequence_store_key!(pub ArgsId);
 pub type ArgId = (ArgsId, usize);
 pub type ArgsStore = DefaultSequenceStore<ArgsId, Arg>;
+
+impl_sequence_store_id!(ArgsId, Arg, args);
 
 /// A pattern or a capture.
 ///
@@ -95,6 +97,7 @@ impl From<PatArg> for PatArgData {
 new_sequence_store_key!(pub PatArgsId);
 pub type PatArgId = (PatArgsId, usize);
 pub type PatArgsStore = DefaultSequenceStore<PatArgsId, PatArg>;
+impl_sequence_store_id!(PatArgsId, PatArg, pat_args);
 
 /// Some kind of arguments, either [`PatArgsId`] or [`ArgsId`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, From)]

--- a/compiler/hash-tir/src/data.rs
+++ b/compiler/hash-tir/src/data.rs
@@ -5,7 +5,9 @@ use std::fmt::Display;
 
 use hash_utils::{
     new_sequence_store_key, new_store_key,
-    store::{DefaultSequenceStore, DefaultStore, SequenceStore, SequenceStoreKey, Store},
+    store::{
+        CloneStore, DefaultSequenceStore, DefaultStore, SequenceStore, SequenceStoreKey, Store,
+    },
 };
 use textwrap::indent;
 use utility_types::omit;
@@ -16,7 +18,9 @@ use super::{
     pats::Spread,
     tys::TyId,
 };
-use crate::{params::ParamsId, symbols::Symbol, terms::TermId};
+use crate::{
+    impl_sequence_store_id, impl_single_store_id, params::ParamsId, symbols::Symbol, terms::TermId,
+};
 
 /// A constructor of a data-type definition.
 ///
@@ -56,6 +60,7 @@ pub struct CtorDef {
 new_sequence_store_key!(pub CtorDefsId);
 pub type CtorDefsStore = DefaultSequenceStore<CtorDefsId, CtorDef>;
 pub type CtorDefId = (CtorDefsId, usize);
+impl_sequence_store_id!(CtorDefsId, CtorDef, ctor_defs);
 
 /// A constructor term.
 ///
@@ -172,6 +177,7 @@ pub struct DataDef {
 }
 new_store_key!(pub DataDefId);
 pub type DataDefStore = DefaultStore<DataDefId, DataDef>;
+impl_single_store_id!(DataDefId, DataDef, data_def);
 
 /// A type pointing to a data-type definition.
 ///

--- a/compiler/hash-tir/src/environment/env.rs
+++ b/compiler/hash-tir/src/environment/env.rs
@@ -44,7 +44,6 @@ macro_rules! env {
                 }
             }
         }
-
     };
 }
 

--- a/compiler/hash-tir/src/environment/stores.rs
+++ b/compiler/hash-tir/src/environment/stores.rs
@@ -112,3 +112,159 @@ impl Stores {
         WithStores::new(self, value)
     }
 }
+
+thread_local! {
+    /// TIR stores are stored in a thread local variable, which is globally accessible.
+    /// For now, typechecking is single-threaded, so this is fine.
+    pub static STORES: Stores = Stores::new();
+}
+
+/// A trait for a store ID which can be used to access a store in `STORES`.
+pub trait StoreId: Sized + Copy {
+    type Value;
+    type ValueRef: ?Sized;
+
+    /// Get the value associated with this ID.
+    fn value(self) -> Self::Value;
+
+    /// Map the value associated with this ID to a new value.
+    fn map<R>(self, f: impl FnOnce(&Self::ValueRef) -> R) -> R;
+
+    /// Modify the value associated with this ID.
+    fn modify<R>(self, f: impl FnOnce(&mut Self::ValueRef) -> R) -> R;
+
+    /// Set the value associated with this ID.
+    fn set(self, value: Self::Value);
+}
+
+/// A trait for a sequence store ID which can be used to access a store in
+/// `STORES`.
+pub trait SequenceStoreId: StoreId {
+    type ValueElement;
+
+    /// Create a new value in the store from the given iterator of functions.
+    fn create_with<F: FnOnce((Self, usize)) -> Self::ValueElement, I: IntoIterator<Item = F>>(
+        values: I,
+    ) -> Self
+    where
+        I::IntoIter: ExactSizeIterator;
+}
+
+/// A trait for a store ID containing single items which can be used to access a
+/// store in `STORES`.
+pub trait SingleStoreId: StoreId {
+    /// Create a new value in the store from the given function.
+    fn create_with<F: FnOnce(Self) -> Self::Value>(&self, value: F) -> Self;
+}
+
+/// Automatically implement `StoreId` and `SequenceStoreId` for a sequence store
+/// ID type.
+#[macro_export]
+macro_rules! impl_sequence_store_id {
+    ($id:ty, $value:ty, $store_name:ident) => {
+        impl $crate::environment::stores::StoreId for $id {
+            type Value = Vec<$value>;
+            type ValueRef = [$value];
+
+            fn value(self) -> Self::Value {
+                $crate::environment::stores::STORES
+                    .with(|stores| stores.$store_name().get_vec(self))
+            }
+
+            fn map<R>(self, f: impl FnOnce(&Self::ValueRef) -> R) -> R {
+                $crate::environment::stores::STORES
+                    .with(|stores| stores.$store_name().map_fast(self, f))
+            }
+
+            fn modify<R>(self, f: impl FnOnce(&mut Self::ValueRef) -> R) -> R {
+                $crate::environment::stores::STORES
+                    .with(|stores| stores.$store_name().modify_fast(self, f))
+            }
+
+            fn set(self, value: Self::Value) {
+                $crate::environment::stores::STORES
+                    .with(|stores| stores.$store_name().set_from_slice_cloned(self, &value));
+            }
+        }
+
+        impl $crate::environment::stores::SequenceStoreId for $id {
+            type ValueElement = $value;
+
+            fn create_with<
+                F: FnOnce((Self, usize)) -> Self::ValueElement,
+                I: IntoIterator<Item = F>,
+            >(
+                values: I,
+            ) -> Self
+            where
+                I::IntoIter: ExactSizeIterator,
+            {
+                $crate::environment::stores::STORES
+                    .with(|stores| stores.$store_name().create_from_iter_with(values))
+            }
+        }
+
+        impl $crate::environment::stores::StoreId for ($id, usize) {
+            type Value = $value;
+            type ValueRef = $value;
+
+            fn value(self) -> Self::Value {
+                $crate::environment::stores::STORES
+                    .with(|stores| stores.$store_name().get_element(self))
+            }
+
+            fn map<R>(self, f: impl FnOnce(&Self::ValueRef) -> R) -> R {
+                $crate::environment::stores::STORES
+                    .with(|stores| stores.$store_name().map_fast(self.0, |v| f(&v[self.1])))
+            }
+
+            fn modify<R>(self, f: impl FnOnce(&mut Self::ValueRef) -> R) -> R {
+                $crate::environment::stores::STORES
+                    .with(|stores| stores.$store_name().modify_fast(self.0, |v| f(&mut v[self.1])))
+            }
+
+            fn set(self, value: Self::Value) {
+                $crate::environment::stores::STORES
+                    .with(|stores| stores.$store_name().set_at_index(self.0, self.1, value));
+            }
+        }
+    };
+}
+
+/// Automatically implement `StoreId` and `SingleStoreId` for a single store ID
+/// type.
+#[macro_export]
+macro_rules! impl_single_store_id {
+    ($id:ty, $value:ty, $store_name:ident) => {
+        impl $crate::environment::stores::StoreId for $id {
+            type Value = $value;
+            type ValueRef = $value;
+
+            fn value(self) -> Self::Value {
+                $crate::environment::stores::STORES.with(|stores| stores.$store_name().get(self))
+            }
+
+            fn map<R>(self, f: impl FnOnce(&Self::Value) -> R) -> R {
+                $crate::environment::stores::STORES
+                    .with(|stores| stores.$store_name().map_fast(self, f))
+            }
+
+            fn modify<R>(self, f: impl FnOnce(&mut Self::Value) -> R) -> R {
+                $crate::environment::stores::STORES
+                    .with(|stores| stores.$store_name().modify_fast(self, f))
+            }
+
+            fn set(self, value: Self::Value) {
+                $crate::environment::stores::STORES
+                    .with(|stores| stores.$store_name().set(self, value));
+            }
+        }
+
+        impl $crate::environment::stores::SingleStoreId for $id {
+            fn create_with<F: FnOnce(Self) -> Self::Value>(&self, value: F) -> Self {
+                $crate::environment::stores::STORES
+                    .with(|stores| stores.$store_name().create_with(value))
+            }
+        }
+    };
+}

--- a/compiler/hash-tir/src/fns.rs
+++ b/compiler/hash-tir/src/fns.rs
@@ -4,7 +4,7 @@ use std::fmt::Display;
 
 use hash_utils::{
     new_store_key,
-    store::{DefaultStore, Store},
+    store::{CloneStore, DefaultStore, Store},
 };
 use typed_builder::TypedBuilder;
 use utility_types::omit;
@@ -15,7 +15,9 @@ use super::{
     tys::Ty,
     utils::common::CommonUtils,
 };
-use crate::{args::ArgsId, params::ParamsId, symbols::Symbol, terms::TermId, tys::TyId};
+use crate::{
+    args::ArgsId, impl_single_store_id, params::ParamsId, symbols::Symbol, terms::TermId, tys::TyId,
+};
 
 /// A function type.
 ///
@@ -112,6 +114,7 @@ new_store_key!(pub FnDefId);
 
 /// Function definitions live in a store
 pub type FnDefStore = DefaultStore<FnDefId, FnDef>;
+impl_single_store_id!(FnDefId, FnDef, fn_def);
 
 /// A function call.
 #[derive(Debug, Clone, Copy)]

--- a/compiler/hash-tir/src/mods.rs
+++ b/compiler/hash-tir/src/mods.rs
@@ -5,7 +5,7 @@ use std::fmt::Display;
 use hash_source::SourceId;
 use hash_utils::{
     new_sequence_store_key, new_store, new_store_key,
-    store::{DefaultSequenceStore, SequenceStore, Store},
+    store::{CloneStore, DefaultSequenceStore, SequenceStore, Store},
 };
 use textwrap::indent;
 use utility_types::omit;
@@ -15,7 +15,7 @@ use super::{
     environment::env::{AccessToEnv, WithEnv},
     fns::FnDefId,
 };
-use crate::symbols::Symbol;
+use crate::{impl_sequence_store_id, impl_single_store_id, symbols::Symbol};
 
 /// The kind of a module.
 ///
@@ -99,6 +99,7 @@ pub struct ModMember {
 new_sequence_store_key!(pub ModMembersId);
 pub type ModMembersStore = DefaultSequenceStore<ModMembersId, ModMember>;
 pub type ModMemberId = (ModMembersId, usize);
+impl_sequence_store_id!(ModMembersId, ModMember, mod_members);
 
 /// A module definition.
 ///
@@ -119,6 +120,7 @@ pub struct ModDef {
 
 new_store_key!(pub ModDefId);
 new_store!(pub ModDefStore<ModDefId, ModDef>);
+impl_single_store_id!(ModDefId, ModDef, mod_def);
 
 impl Display for WithEnv<'_, &ModDef> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/compiler/hash-tir/src/params.rs
+++ b/compiler/hash-tir/src/params.rs
@@ -16,7 +16,7 @@ use super::{
     locations::IndexedLocationTarget,
     terms::TermId,
 };
-use crate::{symbols::Symbol, tys::TyId};
+use crate::{impl_sequence_store_id, symbols::Symbol, tys::TyId};
 
 // @@Todo: examples
 
@@ -44,6 +44,7 @@ impl From<Param> for ParamData {
 new_sequence_store_key!(pub ParamsId);
 pub type ParamId = (ParamsId, usize);
 pub type ParamsStore = DefaultSequenceStore<ParamsId, Param>;
+impl_sequence_store_id!(ParamsId, Param, params);
 
 /// An index of a parameter of a parameter list.
 ///

--- a/compiler/hash-tir/src/pats.rs
+++ b/compiler/hash-tir/src/pats.rs
@@ -19,7 +19,7 @@ use super::{
     symbols::Symbol,
     tuples::TuplePat,
 };
-use crate::arrays::ArrayPat;
+use crate::{arrays::ArrayPat, impl_sequence_store_id, impl_single_store_id};
 
 /// A spread "pattern" (not part of [`Pat`]), which can appear in list patterns,
 /// tuple patterns, and constructor patterns.
@@ -89,9 +89,11 @@ impl Pat {
 
 new_store_key!(pub PatId);
 new_store!(pub PatStore<PatId, Pat>);
+impl_single_store_id!(PatId, Pat, pat);
 
 new_sequence_store_key!(pub PatListId);
 pub type PatListStore = DefaultSequenceStore<PatListId, PatOrCapture>;
+impl_sequence_store_id!(PatListId, PatOrCapture, pat_list);
 
 impl fmt::Display for WithEnv<'_, Spread> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/compiler/hash-tir/src/symbols.rs
+++ b/compiler/hash-tir/src/symbols.rs
@@ -5,10 +5,11 @@ use std::fmt::Display;
 use hash_source::identifier::Identifier;
 use hash_utils::{
     new_store_key,
-    store::{DefaultStore, Store, StoreKey},
+    store::{CloneStore, DefaultStore, Store, StoreKey},
 };
 
 use super::environment::env::{AccessToEnv, WithEnv};
+use crate::impl_single_store_id;
 
 /// The data carried by a symbol.
 ///
@@ -43,6 +44,7 @@ pub struct SymbolData {
 
 new_store_key!(pub Symbol);
 pub type SymbolStore = DefaultStore<Symbol, SymbolData>;
+impl_single_store_id!(Symbol, SymbolData, symbol);
 
 impl Display for WithEnv<'_, Symbol> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/compiler/hash-tir/src/terms.rs
+++ b/compiler/hash-tir/src/terms.rs
@@ -22,6 +22,7 @@ use crate::{
     control::{LoopControlTerm, LoopTerm, MatchTerm, ReturnTerm},
     data::CtorTerm,
     fns::{FnCallTerm, FnDefId},
+    impl_sequence_store_id, impl_single_store_id,
     lits::Lit,
     refs::{DerefTerm, RefTerm},
     scopes::{AssignTerm, BlockTerm, DeclTerm},
@@ -102,9 +103,11 @@ pub enum Term {
 
 new_store_key!(pub TermId);
 pub type TermStore = DefaultStore<TermId, Term>;
+impl_single_store_id!(TermId, Term, term);
 
 new_sequence_store_key!(pub TermListId);
 pub type TermListStore = DefaultSequenceStore<TermListId, TermId>;
+impl_sequence_store_id!(TermListId, TermId, term_list);
 
 impl fmt::Display for WithEnv<'_, &UnsafeTerm> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/compiler/hash-tir/src/tys.rs
+++ b/compiler/hash-tir/src/tys.rs
@@ -6,7 +6,7 @@ use std::fmt::Debug;
 use derive_more::From;
 use hash_utils::{
     new_store_key,
-    store::{CloneStore, DefaultStore},
+    store::{CloneStore, DefaultStore, Store},
 };
 
 use super::{
@@ -14,7 +14,9 @@ use super::{
     holes::Hole,
     symbols::Symbol,
 };
-use crate::{data::DataTy, fns::FnTy, refs::RefTy, terms::TermId, tuples::TupleTy};
+use crate::{
+    data::DataTy, fns::FnTy, impl_single_store_id, refs::RefTy, terms::TermId, tuples::TupleTy,
+};
 
 /// The type of types, i.e. a universe.
 #[derive(Debug, Clone, Copy)]
@@ -58,6 +60,7 @@ pub enum Ty {
 
 new_store_key!(pub TyId);
 pub type TyStore = DefaultStore<TyId, Ty>;
+impl_single_store_id!(TyId, Ty, ty);
 
 /// Infer the type of the given term, returning its type.
 #[derive(Debug, Clone, Copy)]


### PR DESCRIPTION
This PR implements the first two task items of #816.
First, it adds a `STORES` thread local variable which provides static access to TIR stores without requiring `Env`. It also adds a few traits for `XId` types to implement, which allow dereferencing to the actual data, modifying the data, as well as creating data inside `STORES`.

Code should not be modified yet to use `STORES` or these new traits, because they are not currently utilised in the rest of the compiler.