### PR TITLE
Remove unnecessary parentheses from formatting

### DIFF
--- a/compiler/hash-tir/src/data.rs
+++ b/compiler/hash-tir/src/data.rs
@@ -316,7 +316,7 @@ impl Display for DataDef {
         write!(
             f,
             "datatype [name={}] {} {{\n{}}}",
-            (self.name),
+            self.name,
             if self.params.len() > 0 { format!("<{}>", self.params) } else { "".to_string() },
             indent(&ctors, "  ")
         )

--- a/compiler/hash-tir/src/defs.rs
+++ b/compiler/hash-tir/src/defs.rs
@@ -71,8 +71,8 @@ impl<T> Display for DefMember<T> {
         write!(
             f,
             "{}: {}{}",
-            (self.name),
-            (self.ty),
+            self.name,
+            self.ty,
             self.value.map(|x| format!(" = {}", x)).unwrap_or_else(|| "".to_string())
         )
     }
@@ -83,8 +83,8 @@ impl Display for DefMemberData {
         write!(
             f,
             "{}: {}{}",
-            (self.name),
-            (self.ty),
+            self.name,
+            self.ty,
             self.value.map(|x| format!(" = {}", x)).unwrap_or_else(|| "".to_string())
         )
     }

--- a/compiler/hash-tir/src/mods.rs
+++ b/compiler/hash-tir/src/mods.rs
@@ -139,7 +139,7 @@ impl Display for ModDef {
                 write!(
                     f,
                     "mod [name={}, type=file, src=\"{:?}\"] {{\n{}}}",
-                    (self.name),
+                    self.name,
                     source_name,
                     indent(&members, "  ")
                 )
@@ -148,7 +148,7 @@ impl Display for ModDef {
                 write!(
                     f,
                     "mod [name={}, type=transparent] {{\n{}}}",
-                    (self.name),
+                    self.name,
                     indent(&members, "  ")
                 )
             }

--- a/compiler/hash-tir/src/params.rs
+++ b/compiler/hash-tir/src/params.rs
@@ -75,8 +75,8 @@ impl fmt::Display for Param {
         write!(
             f,
             "{}: {}{}",
-            (self.name),
-            (self.ty),
+            self.name,
+            self.ty,
             if let Some(default) = self.default {
                 format!(" = {}", default)
             } else {

--- a/compiler/hash-typecheck/src/errors.rs
+++ b/compiler/hash-typecheck/src/errors.rs
@@ -252,17 +252,16 @@ impl<'tc> TcErrorReporter<'tc> {
                         location,
                         format!(
                             "cannot use this as a subject of a dereference operation. It is of type `{}` which is not a reference type.",
-                            (*actual_subject_ty)
+                            *actual_subject_ty
                         )
                     );
                 }
             }
             TcError::MismatchingTypes { expected, actual, inferred_from } => {
-                let error = reporter.error().code(HashErrorCode::TypeMismatch).title(format!(
-                    "expected type `{}` but got `{}`",
-                    (*expected),
-                    (*actual),
-                ));
+                let error = reporter
+                    .error()
+                    .code(HashErrorCode::TypeMismatch)
+                    .title(format!("expected type `{}` but got `{}`", *expected, *actual,));
                 if let Some(location) = inferred_from.and_then(|term| locations.get_location(term))
                 {
                     error.add_labelled_span(
@@ -280,8 +279,7 @@ impl<'tc> TcErrorReporter<'tc> {
             TcError::UndecidableEquality { a, b } => {
                 let error = reporter.error().code(HashErrorCode::TypeMismatch).title(format!(
                     "cannot determine if expressions `{}` and `{}` are equal",
-                    (*a),
-                    (*b),
+                    *a, *b,
                 ));
                 if let Some(location) = locations.get_location(a) {
                     error.add_labelled_span(
@@ -465,8 +463,7 @@ impl<'tc> TcErrorReporter<'tc> {
                 let error =
                     reporter.error().code(HashErrorCode::InvalidCallSubject).title(format!(
                         "expected a {}, but got type `{}` instead",
-                        kind_name,
-                        (*inferred_term_ty)
+                        kind_name, *inferred_term_ty
                     ));
 
                 if let Some(location) = locations.get_location(term) {
@@ -493,8 +490,7 @@ impl<'tc> TcErrorReporter<'tc> {
                         location,
                         format!(
                             "term has type `{}`. Property `{}` is not present on this type",
-                            (*term_ty),
-                            *property,
+                            *term_ty, *property,
                         ),
                     );
                 }
@@ -545,8 +541,7 @@ impl<'tc> TcErrorReporter<'tc> {
                 let error =
                     reporter.error().code(HashErrorCode::ParameterLengthMismatch).title(format!(
                         "expected array of length {} but got array of length {}",
-                        (*expected_len),
-                        (*got_len)
+                        *expected_len, *got_len
                     ));
                 if let Some(location) = locations.get_location(expected_len) {
                     error.add_labelled_span(location, "expected array length");
@@ -570,11 +565,10 @@ impl<'tc> TcErrorReporter<'tc> {
                 }
             }
             TcError::MismatchingPats { a, b } => {
-                let error = reporter.error().code(HashErrorCode::TypeMismatch).title(format!(
-                    "expected pattern `{}`, but got pattern `{}`",
-                    (*a),
-                    (*b)
-                ));
+                let error = reporter
+                    .error()
+                    .code(HashErrorCode::TypeMismatch)
+                    .title(format!("expected pattern `{}`, but got pattern `{}`", *a, *b));
                 if let Some(location) = locations.get_location(a) {
                     error.add_labelled_span(location, "expected pattern");
                 }
@@ -585,8 +579,8 @@ impl<'tc> TcErrorReporter<'tc> {
             TcError::MismatchingFns { a, b } => {
                 let error = reporter.error().code(HashErrorCode::TypeMismatch).title(format!(
                     "expected function `{}`, but got function `{}`. Functions are only equal if they refer to the same function definition",
-                    (*a),
-                    (*b)
+                    *a,
+                    *b
                 ));
                 if let Some(location) = locations.get_location(a) {
                     error.add_labelled_span(location, "expected function");
@@ -620,11 +614,10 @@ impl<'tc> TcErrorReporter<'tc> {
                 }
             }
             TcError::NeedMoreTypeAnnotationsToUnify { src, target } => {
-                let error = reporter.error().code(HashErrorCode::TypeMismatch).title(format!(
-                    "cannot unify `{}` with `{}`",
-                    (*src),
-                    (*target)
-                ));
+                let error = reporter
+                    .error()
+                    .code(HashErrorCode::TypeMismatch)
+                    .title(format!("cannot unify `{}` with `{}`", *src, *target));
                 if let Some(location) = locations.get_location(src) {
                     error.add_labelled_span(location, "cannot unify this type");
                 }

--- a/compiler/hash-typecheck/src/normalisation.rs
+++ b/compiler/hash-typecheck/src/normalisation.rs
@@ -339,7 +339,7 @@ impl<'tc, T: AccessToTypechecking> NormalisationOps<'tc, T> {
                                     // pure
                                     info!(
                                         "Found a function term that is not typed as a function: {}",
-                                        (fn_call.subject)
+                                        fn_call.subject
                                     );
                                     Ok(ControlFlow::Break(()))
                                 }


### PR DESCRIPTION
Done after the change `s/self.env().with//g`