### PR TITLE
Add borrowing methods to `StoreId`

### DIFF
--- a/compiler/hash-intrinsics/src/intrinsics.rs
+++ b/compiler/hash-intrinsics/src/intrinsics.rs
@@ -780,14 +780,10 @@ impl DefinedIntrinsics {
                 .into_iter(),
             );
             let ret = env.new_void_ty();
-            add(
-                "debug_print",
-                FnTy::builder().params(params).return_ty(ret).build(),
-                |env, args| {
-                    stream_less_writeln!("{}", args[1]);
-                    Ok(env.new_void_term())
-                },
-            )
+            add("debug_print", FnTy::builder().params(params).return_ty(ret).build(), |_, args| {
+                stream_less_writeln!("{}", args[1]);
+                Ok(Term::void())
+            })
         };
 
         let print_fn_directives = {
@@ -810,7 +806,7 @@ impl DefinedIntrinsics {
                             env.stores().directives().get(fn_def_id.into()).unwrap_or_default();
                         stream_less_writeln!("{:?}", directives.directives);
                     }
-                    Ok(env.new_void_term())
+                    Ok(Term::void())
                 },
             )
         };

--- a/compiler/hash-semantics/src/passes/resolution/exprs.rs
+++ b/compiler/hash-semantics/src/passes/resolution/exprs.rs
@@ -188,26 +188,26 @@ impl<'tc> ResolutionPass<'tc> {
                 self.current_source_info().with_source_id(source_id, || {
                     ResolutionPass::new(self.sem_env()).pass_source()
                 })?;
-                self.new_void_term()
+                Term::void()
             }
 
             // No-ops (not supported or handled earlier):
             ast::Expr::TraitDef(_)
             | ast::Expr::MergeDeclaration(_)
             | ast::Expr::ImplDef(_)
-            | ast::Expr::TraitImpl(_) => self.new_void_term(),
+            | ast::Expr::TraitImpl(_) => Term::void(),
 
             ast::Expr::StructDef(_) => {
                 self.resolve_data_def_inner_terms(node)?;
-                self.new_void_term()
+                Term::void()
             }
             ast::Expr::EnumDef(_) => {
                 self.resolve_data_def_inner_terms(node)?;
-                self.new_void_term()
+                Term::void()
             }
             ast::Expr::ModDef(mod_def) => {
                 self.resolve_ast_mod_def_inner_terms(node.with_body(mod_def))?;
-                self.new_void_term()
+                Term::void()
             }
         };
 
@@ -594,7 +594,7 @@ impl<'tc> ResolutionPass<'tc> {
     ) -> SemanticResult<TermId> {
         let expression = match node.expr.as_ref() {
             Some(expr) => self.make_term_from_ast_expr(expr.ast_ref())?,
-            None => self.new_void_term(),
+            None => Term::void(),
         };
         Ok(self.new_term(Term::Return(ReturnTerm { expression })))
     }
@@ -742,7 +742,7 @@ impl<'tc> ResolutionPass<'tc> {
                     }
                     (None, true) => {
                         let statements = self.new_term_list(statements);
-                        let return_value = self.new_void_term();
+                        let return_value = Term::void();
                         Ok(self.new_term(Term::Block(BlockTerm {
                             statements,
                             return_value,

--- a/compiler/hash-tir/src/environment/stores.rs
+++ b/compiler/hash-tir/src/environment/stores.rs
@@ -96,8 +96,10 @@ pub trait StoreId: Sized + Copy {
     type ValueBorrow: Deref<Target = Self::ValueRef>;
     type ValueBorrowMut: DerefMut<Target = Self::ValueRef>;
 
+    /// Borrow the value associated with this ID.
     fn borrow(self) -> Self::ValueBorrow;
 
+    /// Borrow the value associated with this ID mutably.
     fn borrow_mut(self) -> Self::ValueBorrowMut;
 
     /// Get the value associated with this ID.

--- a/compiler/hash-tir/src/scopes.rs
+++ b/compiler/hash-tir/src/scopes.rs
@@ -5,18 +5,15 @@
 
 use core::fmt;
 
-
 use hash_utils::store::{Store, TrivialSequenceStoreKey};
-use parking_lot::{
-    MappedRwLockReadGuard, MappedRwLockWriteGuard,
-};
+use parking_lot::{MappedRwLockReadGuard, MappedRwLockWriteGuard};
 use textwrap::indent;
 use utility_types::omit;
 
 use super::{pats::Pat, terms::Term};
 use crate::{
     context::Decl,
-    environment::stores::{StoreId},
+    environment::stores::StoreId,
     mods::ModDefId,
     pats::PatId,
     symbols::Symbol,

--- a/compiler/hash-tir/src/scopes.rs
+++ b/compiler/hash-tir/src/scopes.rs
@@ -5,14 +5,18 @@
 
 use core::fmt;
 
+
 use hash_utils::store::{Store, TrivialSequenceStoreKey};
+use parking_lot::{
+    MappedRwLockReadGuard, MappedRwLockWriteGuard,
+};
 use textwrap::indent;
 use utility_types::omit;
 
 use super::{pats::Pat, terms::Term};
 use crate::{
     context::Decl,
-    environment::stores::StoreId,
+    environment::stores::{StoreId},
     mods::ModDefId,
     pats::PatId,
     symbols::Symbol,
@@ -118,6 +122,16 @@ pub struct StackMemberId(pub StackId, pub usize);
 impl StoreId for StackMemberId {
     type Value = Decl;
     type ValueRef = Decl;
+    type ValueBorrow = MappedRwLockReadGuard<'static, Decl>;
+    type ValueBorrowMut = MappedRwLockWriteGuard<'static, Decl>;
+
+    fn borrow(self) -> Self::ValueBorrow {
+        MappedRwLockReadGuard::map(self.0.borrow(), |stack| &stack.members[self.1])
+    }
+
+    fn borrow_mut(self) -> Self::ValueBorrowMut {
+        MappedRwLockWriteGuard::map(self.0.borrow_mut(), |stack| &mut stack.members[self.1])
+    }
 
     fn value(self) -> Self::Value {
         self.0.map(|stack| stack.members[self.1])

--- a/compiler/hash-tir/src/terms.rs
+++ b/compiler/hash-tir/src/terms.rs
@@ -9,7 +9,7 @@ use hash_utils::store::{SequenceStore, SequenceStoreKey, Store, TrivialSequenceS
 use super::{casting::CastTerm, holes::Hole, symbols::Symbol, tys::TypeOfTerm};
 use crate::{
     access::AccessTerm,
-    args::{Arg, ArgsId},
+    args::Arg,
     arrays::{ArrayTerm, IndexTerm},
     control::{LoopControlTerm, LoopTerm, MatchTerm, ReturnTerm},
     data::CtorTerm,

--- a/compiler/hash-tir/src/terms.rs
+++ b/compiler/hash-tir/src/terms.rs
@@ -4,14 +4,16 @@ use core::fmt;
 use std::fmt::Debug;
 
 use derive_more::From;
-use hash_utils::store::{SequenceStore, Store, TrivialSequenceStoreKey};
+use hash_utils::store::{SequenceStore, SequenceStoreKey, Store, TrivialSequenceStoreKey};
 
 use super::{casting::CastTerm, holes::Hole, symbols::Symbol, tys::TypeOfTerm};
 use crate::{
     access::AccessTerm,
+    args::{Arg, ArgsId},
     arrays::{ArrayTerm, IndexTerm},
     control::{LoopControlTerm, LoopTerm, MatchTerm, ReturnTerm},
     data::CtorTerm,
+    environment::stores::{SequenceStoreValue, SingleStoreValue},
     fns::{FnCallTerm, FnDefId},
     lits::Lit,
     refs::{DerefTerm, RefTerm},
@@ -174,5 +176,15 @@ impl fmt::Display for TermListId {
             write!(f, "{}", term)?;
         }
         Ok(())
+    }
+}
+
+impl Term {
+    pub fn is_void(&self) -> bool {
+        matches!(self, Term::Tuple(tuple_term) if tuple_term.data.is_empty())
+    }
+
+    pub fn void() -> TermId {
+        Term::create(Term::Tuple(TupleTerm { data: Arg::empty_seq() }))
     }
 }

--- a/compiler/hash-tir/src/utils/common.rs
+++ b/compiler/hash-tir/src/utils/common.rs
@@ -471,11 +471,6 @@ pub trait CommonUtils: AccessToEnv {
         self.stores().ty().create(Ty::Tuple(TupleTy { data: self.new_empty_params() }))
     }
 
-    /// Create a new empty tuple term.
-    fn new_void_term(&self) -> TermId {
-        self.stores().term().create(Term::Tuple(TupleTerm { data: self.new_empty_args() }))
-    }
-
     /// Create a new variable type.
     fn new_var_ty(&self, symbol: Symbol) -> TyId {
         self.stores().ty().create(Ty::Var(symbol))

--- a/compiler/hash-tir/src/utils/common.rs
+++ b/compiler/hash-tir/src/utils/common.rs
@@ -21,7 +21,7 @@ use crate::{
     scopes::StackMemberId,
     symbols::{Symbol, SymbolData},
     terms::{Term, TermId, TermListId},
-    tuples::{TupleTerm, TupleTy},
+    tuples::TupleTy,
     tys::{Ty, TyId, UniverseTy},
 };
 

--- a/compiler/hash-typecheck/src/normalisation.rs
+++ b/compiler/hash-typecheck/src/normalisation.rs
@@ -610,7 +610,7 @@ impl<'tc, T: AccessToTypechecking> NormalisationOps<'tc, T> {
             _ => panic!("Invalid assign {}", &assign_term),
         }
 
-        full_evaluation_to(self.new_void_term())
+        full_evaluation_to(Term::void())
     }
 
     /// Evaluate a match term.
@@ -668,7 +668,7 @@ impl<'tc, T: AccessToTypechecking> NormalisationOps<'tc, T> {
             )? {
                 MatchResult::Successful => {
                     // All good
-                    evaluation_to(self.new_void_term())
+                    evaluation_to(Term::void())
                 }
                 MatchResult::Failed => {
                     panic!("Non-exhaustive let-binding: {}", &decl_term)
@@ -699,7 +699,7 @@ impl<'tc, T: AccessToTypechecking> NormalisationOps<'tc, T> {
                 Err(e) => return Err(e),
             }
         }
-        full_evaluation_to(self.new_void_term())
+        full_evaluation_to(Term::void())
     }
 
     /// Evaluate a term and use it as a type.


### PR DESCRIPTION
This PR adds `borrow()` and `borrow_mut()` on types implementing `StoreId`. This is an alternative to using `map()`. For example, `term_id.map(|t| t.to_string())` can be turned into `term_id.borrow().to_string()`. Sometimes it is handy and more ergonomic to avoid closures.

This PR also adds `Term::void()` as a starting point for deprecating store methods that depend on `Env`.