### PR TITLE
target: avoid awkward API for querying sizes/max/mins when handling bigints

### DIFF
--- a/compiler/hash-codegen-llvm/src/translation/builder.rs
+++ b/compiler/hash-codegen-llvm/src/translation/builder.rs
@@ -570,7 +570,7 @@ impl<'a, 'b, 'm> BlockBuilderMethods<'a, 'b> for LLVMBuilder<'a, 'b, 'm> {
             (CheckedOp::Mul, false) => "llvm.umul",
         };
 
-        let size = int_ty.size(ptr_width).unwrap();
+        let size = int_ty.size(ptr_width);
         let intrinsic_name = format!("{}.with.overflow.i{}", intrinsic_prefix, size.bits());
 
         let result = self.call_intrinsic(&intrinsic_name, &[lhs, rhs]);

--- a/compiler/hash-exhaustiveness/src/range.rs
+++ b/compiler/hash-exhaustiveness/src/range.rs
@@ -276,8 +276,8 @@ impl<'tc> ExhaustivenessChecker<'tc> {
     /// last byte is that identifies the sign.
     fn signed_bias(&self, ty: TyId) -> u128 {
         if let Some(ty) = self.try_use_ty_as_int_ty(ty) {
-            let ptr_width = self.env().target().ptr_size();
-            if let Some(size) = ty.size(ptr_width) && ty.is_signed()  {
+            if ty.is_signed() && !ty.is_bigint() {
+                let size = ty.size(self.target().ptr_size());
                 let bits = size.bits() as u128;
                 return 1u128 << (bits - 1);
             }

--- a/compiler/hash-lower/src/build/matches/candidate.rs
+++ b/compiler/hash-lower/src/build/matches/candidate.rs
@@ -323,13 +323,13 @@ impl<'tcx> BodyBuilder<'tcx> {
                         (Some(('\u{0000}' as u128, '\u{10FFFF}' as u128, Size::from_bytes(4))), 0)
                     }
                     IrTy::Int(int_ty) => {
-                        let size = int_ty.size(ptr_width).unwrap();
+                        let size = int_ty.size(ptr_width);
                         let max = size.truncate(u128::MAX);
                         let bias = 1u128 << (size.bits() - 1);
                         (Some((0, max, size)), bias)
                     }
                     IrTy::UInt(uint_ty) => {
-                        let size = uint_ty.size(ptr_width).unwrap();
+                        let size = uint_ty.size(ptr_width);
                         let max = size.truncate(u128::MAX);
                         (Some((0, max, size)), 0)
                     }

--- a/compiler/hash-lower/src/build/rvalue.rs
+++ b/compiler/hash-lower/src/build/rvalue.rs
@@ -146,7 +146,7 @@ impl<'tcx> BodyBuilder<'tcx> {
     fn min_value_of_ty(&self, ty: IrTy) -> Operand {
         let value = if let IrTy::Int(signed_ty) = ty {
             let ptr_width = self.settings.target().ptr_size();
-            let size = signed_ty.size(ptr_width).unwrap().bits();
+            let size = signed_ty.size(ptr_width).bits();
             let n = 1 << (size - 1);
 
             // Create and intern the constant

--- a/compiler/hash-source/src/constant.rs
+++ b/compiler/hash-source/src/constant.rs
@@ -470,7 +470,7 @@ impl IntConstant {
     /// N.B. The scalar value assumes that the values are in big
     /// endian order.
     pub fn from_scalar(value: [u8; 16], ty: IntTy, ptr_width: Size) -> Self {
-        let size = ty.size(ptr_width).unwrap();
+        let size = ty.size(ptr_width);
 
         // compute the correct slice that we need to use in order to
         // construct the correct integer value.
@@ -744,7 +744,7 @@ impl fmt::Display for InternedInt {
 /// Convert a given `i128` value with an associated [IntTy] and convert
 /// it into an IntConstantValue.
 pub fn u128_to_int_const(value: u128, kind: IntTy, ptr_width: Size) -> InternedInt {
-    let size = kind.size(ptr_width).unwrap().bytes() as usize;
+    let size = kind.size(ptr_width).bytes() as usize;
     let is_signed = kind.is_signed();
 
     let value = IntConstantValue::from_le_bytes(&value.to_le_bytes()[0..size], is_signed);
@@ -944,26 +944,26 @@ mod tests {
     #[test]
     fn test_max_signed_int_value() {
         // Pointer width is always described using a number of bytes
-        assert_eq!(SIntTy::ISize.max(Size::from_bytes(8)), Some(BigInt::from(isize::MAX)));
-        assert_eq!(SIntTy::ISize.min(Size::from_bytes(8)), Some(BigInt::from(isize::MIN)));
+        assert_eq!(SIntTy::ISize.max(Size::from_bytes(8)), BigInt::from(isize::MAX));
+        assert_eq!(SIntTy::ISize.min(Size::from_bytes(8)), BigInt::from(isize::MIN));
 
-        assert_eq!(SIntTy::ISize.max(Size::from_bytes(4)), Some(BigInt::from(i32::MAX)));
-        assert_eq!(SIntTy::ISize.min(Size::from_bytes(4)), Some(BigInt::from(i32::MIN)));
+        assert_eq!(SIntTy::ISize.max(Size::from_bytes(4)), BigInt::from(i32::MAX));
+        assert_eq!(SIntTy::ISize.min(Size::from_bytes(4)), BigInt::from(i32::MIN));
 
         // Check that computing the size of each type with pointer widths
         // is consistent.
-        assert_eq!(SIntTy::ISize.size(Size::from_bytes(8)), Some(Size::from_bytes(8)));
-        assert_eq!(SIntTy::ISize.size(Size::from_bytes(4)), Some(Size::from_bytes(4)));
+        assert_eq!(SIntTy::ISize.size(Size::from_bytes(8)), Size::from_bytes(8));
+        assert_eq!(SIntTy::ISize.size(Size::from_bytes(4)), Size::from_bytes(4));
     }
 
     #[test]
     fn test_max_unsigned_int_value() {
         // We don't check `min()` for unsigned since this always
         // returns 0.
-        assert_eq!(UIntTy::USize.max(Size::from_bytes(8)), Some(BigInt::from(usize::MAX)));
-        assert_eq!(UIntTy::USize.max(Size::from_bytes(4)), Some(BigInt::from(u32::MAX)));
+        assert_eq!(UIntTy::USize.max(Size::from_bytes(8)), BigInt::from(usize::MAX));
+        assert_eq!(UIntTy::USize.max(Size::from_bytes(4)), BigInt::from(u32::MAX));
 
-        assert_eq!(UIntTy::USize.size(Size::from_bytes(4)), Some(Size::from_bytes(4)));
-        assert_eq!(UIntTy::USize.size(Size::from_bytes(8)), Some(Size::from_bytes(8)));
+        assert_eq!(UIntTy::USize.size(Size::from_bytes(4)), Size::from_bytes(4));
+        assert_eq!(UIntTy::USize.size(Size::from_bytes(8)), Size::from_bytes(8));
     }
 }

--- a/compiler/hash-target/src/primitives.rs
+++ b/compiler/hash-target/src/primitives.rs
@@ -64,15 +64,15 @@ pub enum UIntTy {
 impl UIntTy {
     /// Get the size of [IntTy] in bytes. Returns [None] for
     /// [UIntTy::UBig] variants
-    pub fn size(&self, ptr_width: Size) -> Option<Size> {
+    pub fn size(&self, ptr_width: Size) -> Size {
         match self {
-            UIntTy::U8 => Some(Size::from_bytes(1)),
-            UIntTy::U16 => Some(Size::from_bytes(2)),
-            UIntTy::U32 => Some(Size::from_bytes(4)),
-            UIntTy::U64 => Some(Size::from_bytes(8)),
-            UIntTy::USize => Some(ptr_width),
-            UIntTy::U128 => Some(Size::from_bytes(16)),
-            UIntTy::UBig => None,
+            UIntTy::U8 => Size::from_bytes(1),
+            UIntTy::U16 => Size::from_bytes(2),
+            UIntTy::U32 => Size::from_bytes(4),
+            UIntTy::U64 => Size::from_bytes(8),
+            UIntTy::USize => ptr_width,
+            UIntTy::U128 => Size::from_bytes(16),
+            UIntTy::UBig => panic!("ubig has no defined size"),
         }
     }
 
@@ -95,18 +95,18 @@ impl UIntTy {
     /// Function to get the largest possible integer represented within this
     /// type. For sizes `ibig` and `ubig` there is no defined max and so the
     /// function returns [None].
-    pub fn max(&self, ptr_width: Size) -> Option<BigInt> {
+    pub fn max(&self, ptr_width: Size) -> BigInt {
         match self {
-            UIntTy::U8 => Some(BigInt::from(u8::MAX)),
-            UIntTy::U16 => Some(BigInt::from(u16::MAX)),
-            UIntTy::U32 => Some(BigInt::from(u32::MAX)),
-            UIntTy::U64 => Some(BigInt::from(u64::MAX)),
-            UIntTy::U128 => Some(BigInt::from(u128::MAX)),
+            UIntTy::U8 => BigInt::from(u8::MAX),
+            UIntTy::U16 => BigInt::from(u16::MAX),
+            UIntTy::U32 => BigInt::from(u32::MAX),
+            UIntTy::U64 => BigInt::from(u64::MAX),
+            UIntTy::U128 => BigInt::from(u128::MAX),
             UIntTy::USize => {
                 let max = !0u64 >> (64 - (ptr_width.bits()));
-                Some(BigInt::from(max))
+                BigInt::from(max)
             }
-            UIntTy::UBig => None,
+            UIntTy::UBig => panic!("ubig has no defined max"),
         }
     }
 
@@ -192,15 +192,15 @@ pub enum SIntTy {
 impl SIntTy {
     /// Get the size of [IntTy] in bytes. Returns [None] for
     /// [UIntTy::UBig] variants
-    pub fn size(&self, ptr_width: Size) -> Option<Size> {
+    pub fn size(&self, ptr_width: Size) -> Size {
         match self {
-            SIntTy::I8 => Some(Size::from_bytes(1)),
-            SIntTy::I16 => Some(Size::from_bytes(2)),
-            SIntTy::I32 => Some(Size::from_bytes(4)),
-            SIntTy::I64 => Some(Size::from_bytes(8)),
-            SIntTy::ISize => Some(ptr_width),
-            SIntTy::I128 => Some(Size::from_bytes(16)),
-            SIntTy::IBig => None,
+            SIntTy::I8 => Size::from_bytes(1),
+            SIntTy::I16 => Size::from_bytes(2),
+            SIntTy::I32 => Size::from_bytes(4),
+            SIntTy::I64 => Size::from_bytes(8),
+            SIntTy::ISize => ptr_width,
+            SIntTy::I128 => Size::from_bytes(16),
+            SIntTy::IBig => panic!("Cannot get size of IBig"),
         }
     }
 
@@ -223,37 +223,37 @@ impl SIntTy {
     /// Function to get the largest possible integer represented within this
     /// type. For sizes `ibig` and `ubig` there is no defined max and so the
     /// function returns [None].
-    pub fn max(&self, ptr_width: Size) -> Option<BigInt> {
+    pub fn max(&self, ptr_width: Size) -> BigInt {
         match self {
-            SIntTy::I8 => Some(BigInt::from(i8::MAX)),
-            SIntTy::I16 => Some(BigInt::from(i16::MAX)),
-            SIntTy::I32 => Some(BigInt::from(i32::MAX)),
-            SIntTy::I64 => Some(BigInt::from(i64::MAX)),
-            SIntTy::I128 => Some(BigInt::from(i128::MAX)),
+            SIntTy::I8 => BigInt::from(i8::MAX),
+            SIntTy::I16 => BigInt::from(i16::MAX),
+            SIntTy::I32 => BigInt::from(i32::MAX),
+            SIntTy::I64 => BigInt::from(i64::MAX),
+            SIntTy::I128 => BigInt::from(i128::MAX),
             SIntTy::ISize => {
                 // convert the size to a signed integer
                 let max = (1u64 << (ptr_width.bits() - 1)) - 1;
-                Some(BigInt::from(max))
+                BigInt::from(max)
             }
-            SIntTy::IBig => None,
+            SIntTy::IBig => panic!("Cannot get max of IBig"),
         }
     }
 
     /// Function to get the most minimum integer represented within this
     /// type. For sizes `ibig` and `ubig` there is no defined minimum and so the
     /// function returns [None].
-    pub fn min(&self, ptr_width: Size) -> Option<BigInt> {
+    pub fn min(&self, ptr_width: Size) -> BigInt {
         match self {
-            SIntTy::I8 => Some(BigInt::from(i8::MIN)),
-            SIntTy::I16 => Some(BigInt::from(i16::MIN)),
-            SIntTy::I32 => Some(BigInt::from(i32::MIN)),
-            SIntTy::I64 => Some(BigInt::from(i64::MIN)),
-            SIntTy::I128 => Some(BigInt::from(i128::MIN)),
+            SIntTy::I8 => BigInt::from(i8::MIN),
+            SIntTy::I16 => BigInt::from(i16::MIN),
+            SIntTy::I32 => BigInt::from(i32::MIN),
+            SIntTy::I64 => BigInt::from(i64::MIN),
+            SIntTy::I128 => BigInt::from(i128::MIN),
             SIntTy::ISize => {
                 let min = (i64::MAX) << (ptr_width.bits() - 1);
-                Some(BigInt::from(min))
+                BigInt::from(min)
             }
-            SIntTy::IBig => None,
+            SIntTy::IBig => panic!("Cannot get min of IBig"),
         }
     }
 
@@ -345,10 +345,36 @@ impl IntTy {
         }
     }
 
+    /// Compute the `numeric` min of a given [IntTy] which is the smallest
+    /// integer that can be written for the int. The [u128] is used as an
+    /// encoding to represent both signed and unsigned integers. In order
+    /// to compute the true value of the min, the bias from the `IntTy`
+    /// must be applied to the value.
+    pub fn numeric_min(&self, ptr_size: Size) -> u128 {
+        let size = self.size(ptr_size);
+
+        match self {
+            IntTy::Int(_) => size.truncate(size.signed_int_min() as u128),
+            IntTy::UInt(_) => 0,
+        }
+    }
+
+    /// Compute the `numeric` max of a given [IntTy] which is the largest
+    /// integer that can be written for the int. The [u128] is used as an
+    /// encoding to represent both signed and unsigned integers. In order
+    /// to compute the true value of the max, the bias from the `IntTy`
+    /// must be applied to the value.
+    pub fn numeric_max(&self, ptr_size: Size) -> u128 {
+        match self {
+            IntTy::Int(_) => self.size(ptr_size).signed_int_max() as u128,
+            IntTy::UInt(_) => self.size(ptr_size).unsigned_int_max(),
+        }
+    }
+
     /// Function to get the largest possible integer represented within this
     /// type. For sizes `ibig` and `ubig` there is no defined max and so the
     /// function returns [None].
-    pub fn max(&self, ptr_width: Size) -> Option<BigInt> {
+    pub fn max(&self, ptr_width: Size) -> BigInt {
         match self {
             IntTy::Int(ty) => ty.max(ptr_width),
             IntTy::UInt(ty) => ty.max(ptr_width),
@@ -358,15 +384,15 @@ impl IntTy {
     /// Function to get the most minimum integer represented within this
     /// type. For sizes `ibig` there is no defined minimum and so the
     /// function returns [None].
-    pub fn min(&self, ptr_width: Size) -> Option<BigInt> {
+    pub fn min(&self, ptr_width: Size) -> BigInt {
         match self {
             IntTy::Int(ty) => ty.min(ptr_width),
-            IntTy::UInt(ty) => Some(ty.min()),
+            IntTy::UInt(ty) => ty.min(),
         }
     }
 
     /// Function to get the size of the integer type in bytes.
-    pub fn size(&self, ptr_width: Size) -> Option<Size> {
+    pub fn size(&self, ptr_width: Size) -> Size {
         match self {
             IntTy::Int(ty) => ty.size(ptr_width),
             IntTy::UInt(ty) => ty.size(ptr_width),
@@ -384,7 +410,7 @@ impl IntTy {
     }
 
     /// Check if the type is a [BigInt] variant, i.e. `ibig` or `ubig`.
-    pub fn is_big_sized_integral(self) -> bool {
+    pub fn is_bigint(self) -> bool {
         matches!(self, IntTy::Int(SIntTy::IBig) | IntTy::UInt(UIntTy::UBig))
     }
 

--- a/compiler/hash-target/src/size.rs
+++ b/compiler/hash-target/src/size.rs
@@ -69,6 +69,20 @@ impl Size {
         self.value * 8
     }
 
+    /// Performs a truncation on `value` to `self` bits, and then sign extends
+    /// it to 128 bits.
+    pub fn sign_extend(self, value: u128) -> u128 {
+        let size = self.bits();
+
+        // Can't sign extend to 0 bits.
+        if size == 0 {
+            return 0;
+        }
+
+        let shift = 128 - size;
+        (((value << shift) as i128) >> shift) as u128
+    }
+
     /// Truncates `value` to `self` bits.
     #[inline]
     pub fn truncate(self, value: u128) -> u128 {
@@ -84,11 +98,24 @@ impl Size {
         (value << shift) >> shift
     }
 
+    /// Get the maximum signed integer value that is
+    /// representable within this size.
+    #[inline]
+    pub fn signed_int_max(&self) -> i128 {
+        i128::MAX >> (128 - self.bits())
+    }
+
     /// Get the maximum unsigned integer value that is
     /// representable within this size.
     #[inline]
     pub fn unsigned_int_max(&self) -> u128 {
         u128::MAX >> (128 - self.bits())
+    }
+
+    /// Get the minimum signed integer value that is
+    /// representable within this size.
+    pub fn signed_int_min(&self) -> i128 {
+        self.sign_extend(1_u128 << (self.bits() - 1)) as i128
     }
 
     /// Take the current [Size] and align it to a specified [Alignment].

--- a/compiler/hash-tir/src/lits.rs
+++ b/compiler/hash-tir/src/lits.rs
@@ -169,10 +169,14 @@ impl Display for LitPat {
                 // integer constant don't store usize values.
                 let dummy_size = Size::ZERO;
 
-                if let Some(min) = kind.min(dummy_size) && min == value {
-                    write!(f, "{kind}::MIN")
-                } else if let Some(max) = kind.max(dummy_size) && max == value {
-                    write!(f, "{kind}::MAX")
+                if !kind.is_bigint() {
+                    if kind.min(dummy_size) == value {
+                        write!(f, "{kind}::MIN")
+                    } else if kind.max(dummy_size) == value {
+                        write!(f, "{kind}::MAX")
+                    } else {
+                        write!(f, "{lit}")
+                    }
                 } else {
                     write!(f, "{lit}")
                 }


### PR DESCRIPTION
Change `IntTy::size()` `IntTy::min()` and `IntTy::max()` functions to
avoid returning an `Option<..>`. It is now assumed that querying this
information on `ubig` and `ibig` types is an invalid operation, and hence
will panic.

Additionally, added `numeric_min()` and `numeric_max()` to compute the
min and maximum values in the form of a `u128`. This is useful for exhaustiveness
and other parts of the compiler where the min/max is needed in an encoded
form.
