### PR TITLE
support open ranges in patterns, i.e. `4..`, `..<5` `..`, etc

### DIFF
--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -876,9 +876,11 @@ define_tree! {
     #[node]
     pub struct RangePat {
         /// Initial bound of the range
-        pub lo: Child!(Lit),
+        pub lo: OptionalChild!(Lit),
+
         /// Upper bound of the range
-        pub hi: Child!(Lit),
+        pub hi: OptionalChild!(Lit),
+
         /// Whether the `end` is included or not
         pub end: RangeEnd,
     }

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -1035,15 +1035,16 @@ impl AstVisitor for AstTreeGenerator {
         node: ast::AstNodeRef<ast::RangePat>,
     ) -> Result<Self::RangePatRet, Self::Error> {
         let walk::RangePat { lo, hi } = walk::walk_range_pat(self, node)?;
+        let mut branches = vec![];
 
-        Ok(TreeNode::branch(
-            "range",
-            vec![
-                TreeNode::branch("lo", vec![lo]),
-                TreeNode::branch("hi", vec![hi]),
-                TreeNode::leaf(labelled("end", format!("{}", node.body().end), "`")),
-            ],
-        ))
+        if let Some(lo) = lo {
+            branches.push(TreeNode::branch("lo", vec![lo]))
+        }
+        if let Some(hi) = hi {
+            branches.push(TreeNode::branch("hi", vec![hi]))
+        }
+        branches.push(TreeNode::leaf(labelled("end", format!("{}", node.body().end), "`")));
+        Ok(TreeNode::branch("range", branches))
     }
 
     type OrPatRet = TreeNode;

--- a/compiler/hash-exhaustiveness/src/range.rs
+++ b/compiler/hash-exhaustiveness/src/range.rs
@@ -274,7 +274,7 @@ impl<'tc> ExhaustivenessChecker<'tc> {
     /// the bias is set to be just at the end of the signed boundary
     /// of the integer size, in other words at the position where the
     /// last byte is that identifies the sign.
-    fn signed_bias(&self, ty: TyId) -> u128 {
+    pub(crate) fn signed_bias(&self, ty: TyId) -> u128 {
         if let Some(ty) = self.try_use_ty_as_int_ty(ty) {
             if ty.is_signed() && !ty.is_bigint() {
                 let size = ty.size(self.target().ptr_size());
@@ -350,7 +350,9 @@ impl<'tc> ExhaustivenessChecker<'tc> {
             self.diagnostics.add_warning(ExhaustivenessWarning::OverlappingRangeEnd {
                 range: id,
                 overlaps: pat,
-                overlapping_term: hi,
+                // `hi` will always be present since it is artificially constructed, and hence
+                // the `unwrap` is safe.
+                overlapping_term: hi.unwrap(),
             })
         }
     }

--- a/compiler/hash-fmt/src/lib.rs
+++ b/compiler/hash-fmt/src/lib.rs
@@ -620,9 +620,17 @@ where
     ) -> Result<Self::RangePatRet, Self::Error> {
         let ast::RangePat { end, lo, hi } = node.body();
 
-        self.visit_lit(lo.ast_ref())?;
+        if let Some(lo) = lo {
+            self.visit_lit(lo.ast_ref())?;
+        }
+
         self.write(format!("{}", end))?;
-        self.visit_lit(hi.ast_ref())
+
+        if let Some(hi) = hi {
+            self.visit_lit(hi.ast_ref())?;
+        }
+
+        Ok(())
     }
 
     type DerefExprRet = ();

--- a/compiler/hash-intrinsics/src/utils.rs
+++ b/compiler/hash-intrinsics/src/utils.rs
@@ -21,6 +21,7 @@ use crate::primitives::AccessToPrimitives;
 ///
 /// @@Future: maybe use `IntTy` and `FloatTy` for integer and float types
 /// instead?
+#[derive(Clone, Copy)]
 pub enum LitTy {
     I8,
     U8,
@@ -38,6 +39,27 @@ pub enum LitTy {
     F64,
     Bool,
     Char,
+}
+
+impl LitTy {
+    /// Check if the type is an integer type.
+    pub fn is_int(&self) -> bool {
+        matches!(
+            self,
+            LitTy::I8
+                | LitTy::U8
+                | LitTy::I16
+                | LitTy::U16
+                | LitTy::I32
+                | LitTy::U32
+                | LitTy::I64
+                | LitTy::U64
+                | LitTy::U128
+                | LitTy::I128
+                | LitTy::IBig
+                | LitTy::UBig
+        )
+    }
 }
 
 impl From<LitTy> for IntTy {
@@ -268,6 +290,42 @@ pub trait PrimitiveUtils: AccessToPrimitives {
         match self.get_term(term) {
             Term::Ctor(CtorTerm { ctor, .. }) if ctor == self.get_bool_ctor(true) => Some(true),
             Term::Ctor(CtorTerm { ctor, .. }) if ctor == self.get_bool_ctor(false) => Some(false),
+            _ => None,
+        }
+    }
+
+    /// Function used to compute the maximum value of a numeric pattern. This is
+    /// useful when normalising numeric patterns in various contexts where
+    /// we need to know the maximum value of a pattern. Specifically, if a
+    /// range pattern is provided with an open end, we need to know the
+    /// maximum value of the pattern in order to know what the open end
+    /// should be.
+    fn numeric_max_val_of_lit(&self, ty: TyId) -> Option<u128> {
+        match self.try_use_ty_as_lit_ty(ty)? {
+            // There is no maximum value for big integers.
+            LitTy::UBig | LitTy::IBig => None,
+            ty if ty.is_int() => {
+                let int_ty: IntTy = ty.into();
+                Some(int_ty.numeric_max(self.target().ptr_size()))
+            }
+            LitTy::Char => Some(std::char::MAX as u128),
+            // @@Todo: if we implement float ranges, we would need to return `Infinity` here
+            _ => None,
+        }
+    }
+
+    /// Function used to compute the minimum value of a numeric pattern. This is
+    /// a mirror of the [`Self::numeric_max_val`] function.
+    fn numeric_min_val_of_lit(&self, ty: TyId) -> Option<u128> {
+        match self.try_use_ty_as_lit_ty(ty)? {
+            // There is no minimum value for big integers.
+            LitTy::UBig | LitTy::IBig => None,
+            ty if ty.is_int() => {
+                let int_ty: IntTy = ty.into();
+                Some(int_ty.numeric_min(self.target().ptr_size()))
+            }
+            LitTy::Char => Some(0),
+            // @@Todo: if we implement float ranges, we would need to return `-Infinity` here
             _ => None,
         }
     }

--- a/compiler/hash-lower/src/build/matches/candidate.rs
+++ b/compiler/hash-lower/src/build/matches/candidate.rs
@@ -336,10 +336,10 @@ impl<'tcx> BodyBuilder<'tcx> {
                     // we have to convert the `lo` term into the actual value, by getting
                     // the literal term from this term, and then converting the stored value
                     // into a u128...
-                    let lo_val = self.evaluate_const_pat(lo).1 ^ bias;
+                    let lo_val = self.evaluate_range_lit(lo, range_ty, false).1 ^ bias;
 
                     if lo_val <= min {
-                        let hi_val = self.evaluate_const_pat(hi).1 ^ bias;
+                        let hi_val = self.evaluate_range_lit(hi, range_ty, true).1 ^ bias;
 
                         // In this situation, we have an irrefutable pattern, so we can
                         // always go down this path

--- a/compiler/hash-lower/src/build/matches/const_range.rs
+++ b/compiler/hash-lower/src/build/matches/const_range.rs
@@ -4,7 +4,10 @@
 use std::cmp::Ordering;
 
 use hash_ast::ast;
-use hash_ir::ir::{compare_constant_values, Const};
+use hash_ir::{
+    ir::{compare_constant_values, Const},
+    ty::IrTy,
+};
 use hash_tir::pats::RangePat;
 
 use crate::build::BodyBuilder;
@@ -18,19 +21,25 @@ use crate::build::BodyBuilder;
 pub(super) struct ConstRange {
     /// The lower value of the range.
     pub lo: Const,
+
     /// The upper value of the range.
     pub hi: Const,
+
     /// If the range includes the `hi` or not.
     pub end: ast::RangeEnd,
+
+    /// The type of the range. This is stored for convience when computing
+    /// the range.
+    pub ty: IrTy,
 }
 
 impl ConstRange {
     /// Create a [ConstRange] from [RangePat].
-    pub fn from_range(range: &RangePat, builder: &BodyBuilder) -> Self {
-        let (lo, _) = builder.evaluate_const_pat(range.lo);
-        let (hi, _) = builder.evaluate_const_pat(range.hi);
+    pub fn from_range(range: &RangePat, ty: IrTy, builder: &BodyBuilder) -> Self {
+        let (lo, _) = builder.evaluate_range_lit(range.lo, ty, false);
+        let (hi, _) = builder.evaluate_range_lit(range.hi, ty, true);
 
-        Self { lo, hi, end: range.end }
+        Self { lo, hi, end: range.end, ty }
     }
 
     /// Check if a [Const] is within the range.

--- a/compiler/hash-parser/src/parser/lit.rs
+++ b/compiler/hash-parser/src/parser/lit.rs
@@ -22,7 +22,6 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
                 TokenKind::StrLit(value) => Lit::Str(StrLit { data: value }),
                 TokenKind::Keyword(Keyword::False) => Lit::Bool(BoolLit { data: false }),
                 TokenKind::Keyword(Keyword::True) => Lit::Bool(BoolLit { data: true }),
-
                 _ => self.err_with_location(
                     ParseErrorKind::ExpectedLit,
                     None,

--- a/compiler/hash-semantics/src/passes/resolution/pats.rs
+++ b/compiler/hash-semantics/src/passes/resolution/pats.rs
@@ -331,10 +331,12 @@ impl ResolutionPass<'_> {
             ast::Pat::Wild(_) => {
                 self.new_pat(Pat::Binding(BindingPat { name: Symbol::fresh(), is_mutable: false }))
             }
-            ast::Pat::Range(range_pat) => {
-                let start = self.make_lit_pat_from_non_bool_ast_lit(range_pat.lo.ast_ref());
-                let end = self.make_lit_pat_from_non_bool_ast_lit(range_pat.hi.ast_ref());
-                self.new_pat(Pat::Range(RangePat { lo: start, hi: end, end: range_pat.end }))
+            ast::Pat::Range(ast::RangePat { lo, hi, end }) => {
+                let lo =
+                    lo.as_ref().map(|lo| self.make_lit_pat_from_non_bool_ast_lit(lo.ast_ref()));
+                let hi =
+                    hi.as_ref().map(|hi| self.make_lit_pat_from_non_bool_ast_lit(hi.ast_ref()));
+                self.new_pat(Pat::Range(RangePat { lo, hi, end: *end }))
             }
         };
 

--- a/compiler/hash-source/src/constant.rs
+++ b/compiler/hash-source/src/constant.rs
@@ -695,6 +695,17 @@ counter! {
     method_visibility:,
 }
 
+impl InternedInt {
+    /// Convert a bias encoded `u128` value with an associated [IntTy] and
+    /// convert it into an IntConstantValue.
+    pub fn from_u128(value: u128, kind: IntTy, ptr_size: Size) -> Self {
+        let size = kind.size(ptr_size).bytes() as usize;
+        let is_signed = kind.is_signed();
+        let value = IntConstantValue::from_le_bytes(&value.to_le_bytes()[0..size], is_signed);
+        CONSTANT_MAP.create_int(IntConstant { value, suffix: None })
+    }
+}
+
 impl fmt::Display for IntConstantValue {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -739,16 +750,6 @@ impl fmt::Display for InternedInt {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", CONSTANT_MAP.lookup_int(*self))
     }
-}
-
-/// Convert a given `i128` value with an associated [IntTy] and convert
-/// it into an IntConstantValue.
-pub fn u128_to_int_const(value: u128, kind: IntTy, ptr_width: Size) -> InternedInt {
-    let size = kind.size(ptr_width).bytes() as usize;
-    let is_signed = kind.is_signed();
-
-    let value = IntConstantValue::from_le_bytes(&value.to_le_bytes()[0..size], is_signed);
-    CONSTANT_MAP.create_int(IntConstant { value, suffix: None })
 }
 
 // -------------------- Strings --------------------

--- a/compiler/hash-tir/src/pats.rs
+++ b/compiler/hash-tir/src/pats.rs
@@ -40,10 +40,10 @@ pub struct Spread {
 #[derive(Copy, Clone, Debug)]
 pub struct RangePat {
     /// The beginning of the range.
-    pub lo: LitPat,
+    pub lo: Option<LitPat>,
 
     /// The end of the range.
-    pub hi: LitPat,
+    pub hi: Option<LitPat>,
 
     /// If the range includes the `end` or not.
     pub end: RangeEnd,
@@ -131,12 +131,14 @@ impl fmt::Display for Spread {
 
 impl fmt::Display for RangePat {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.lo)?;
+        self.lo.map_or(Ok(()), |lo| write!(f, "{}", lo))?;
+
         match self.end {
             RangeEnd::Included => write!(f, "..")?,
             RangeEnd::Excluded => write!(f, "..<")?,
         }
-        write!(f, "{}", self.hi)
+
+        self.hi.map_or(Ok(()), |hi| write!(f, "{}", hi))
     }
 }
 

--- a/compiler/hash-tir/src/utils/mod.rs
+++ b/compiler/hash-tir/src/utils/mod.rs
@@ -29,7 +29,7 @@ macro_rules! utils {
 utils! {
   data_utils: DataUtils,
   def_utils: DefUtils,
-  param_utils: ParamUtils     ,
+  param_utils: ParamUtils,
   fn_utils: FnUtils,
   mod_utils: ModUtils,
   stack_utils: StackUtils,

--- a/compiler/hash-typecheck/src/inference.rs
+++ b/compiler/hash-typecheck/src/inference.rs
@@ -1578,8 +1578,11 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
 
     /// Infer a range pattern.
     pub fn infer_range_pat(&self, range_pat: RangePat, annotation_ty: TyId) -> TcResult<()> {
-        self.infer_lit(&range_pat.lo.into(), annotation_ty)?;
-        self.infer_lit(&range_pat.hi.into(), annotation_ty)?;
+        let RangePat { lo, hi, .. } = range_pat;
+
+        lo.map(|lo| self.infer_lit(&lo.into(), annotation_ty)).transpose()?;
+        hi.map(|hi| self.infer_lit(&hi.into(), annotation_ty)).transpose()?;
+
         Ok(())
     }
 

--- a/compiler/hash-typecheck/src/normalisation.rs
+++ b/compiler/hash-typecheck/src/normalisation.rs
@@ -37,7 +37,6 @@ use hash_utils::{
         CloneStore, PartialStore, SequenceStore, SequenceStoreKey, Store, TrivialSequenceStoreKey,
     },
 };
-use num_bigint::BigInt;
 
 use crate::{
     errors::{TcError, TcResult},
@@ -1038,20 +1037,29 @@ impl<'tc, T: AccessToTypechecking> NormalisationOps<'tc, T> {
     fn match_literal_to_range<U: PartialOrd>(
         &self,
         value: U,
-        start: U,
-        end: U,
+        maybe_start: Option<U>,
+        maybe_end: Option<U>,
         range_end: RangeEnd,
     ) -> MatchResult {
+        // If the start isn't provided, we don't need to check
+        // that the value is larger than the start, as it will
+        // always succeed.
+        if let Some(start) = maybe_start && start < value {
+            return MatchResult::Failed;
+        }
+
+        // If the end isn't provided, we can assume that the subject will
+        // always match.
         if range_end == RangeEnd::Included {
-            if start <= value && value <= end {
-                MatchResult::Successful
-            } else {
+            if let Some(end) = maybe_end && end > value {
                 MatchResult::Failed
+            } else {
+                MatchResult::Successful
             }
-        } else if start <= value && value < end {
-            MatchResult::Successful
-        } else {
+        } else if let Some(end) = maybe_end && end >= value {
             MatchResult::Failed
+        } else {
+            MatchResult::Successful
         }
     }
 
@@ -1143,63 +1151,44 @@ impl<'tc, T: AccessToTypechecking> NormalisationOps<'tc, T> {
                 // If we know both of the range ends, then we can simply evaluate it
                 // using the value. If not, we then create the `min` or `max` values
                 // that are missing based on the type of the literal.
-                if let Some(lo) = lo && let Some(hi) = hi {
-                    match (lit_term, lo, hi) {
-                        (Lit::Int(value), LitPat::Int(lo), LitPat::Int(hi)) => Ok(self
-                            .match_literal_to_range(
-                                value.value(),
-                                lo.value(),
-                                hi.value(),
-                                end
-                            )),
-                        (Lit::Char(value), LitPat::Char(lo), LitPat::Char(hi)) => Ok(self
-                            .match_literal_to_range(
-                                value.value(),
-                                lo.value(),
-                                hi.value(),
-                                end
-                            )),
-                        _ => Ok(MatchResult::Stuck),
-                    }
-                } else {
-                    // @@Future: ideally, we shouldn't need to compute min/max intervals here. We could just 
-                    // compute them as the term structure is being traversed, maybe this is something to 
-                    // do later on?
-                    let get_int_ty = || {
-                        let ty = self.try_get_inferred_ty(evaluated_id).unwrap();
-                        self.try_use_ty_as_int_ty(ty).unwrap()
-                    };
 
-                    // It is an invariant for this to be a big-int, since you cannot have 
-                    // open ranges on big ints.
-                    let (value, lo, hi) = match (lit_term, lo, hi) {
-                        (Lit::Int(value), Some(LitPat::Int(lo)), None) => {
-                            let int_ty = get_int_ty();
-                            let ptr_size = self.target().ptr_size();
-                            (value.value(), lo.value(), int_ty.max(ptr_size))
-                        }
-                        (Lit::Int(value), None, Some(LitPat::Int(hi))) => {
-                            let int_ty = get_int_ty();
-                            let ptr_size = self.target().ptr_size();
-                            (value.value(), int_ty.min(ptr_size), hi.value())
-                        }
-                        (Lit::Char(value), Some(LitPat::Char(lo)), None) => {
-                            (BigInt::from(value.value() as u128), BigInt::from(lo.value() as u128), BigInt::from(std::char::MAX as u128))
-                        }
-                        (Lit::Char(value), None, Some(LitPat::Char(hi))) => {
-                            (BigInt::from(value.value() as u128), BigInt::from(0), BigInt::from(hi.value() as u128))
-                        }
-                        _ => return Ok(MatchResult::Stuck),
-                    };
-
-                    Ok(self
-                        .match_literal_to_range(
-                            value,
-                            lo,
-                            hi,
-                            end
-                        ))
+                // Disallow open excluded ranges to be parameterless. This isn't strictly
+                // necessary, but it is strange to write `..<` and mean to match
+                // everything but the end. This is checked and reported as an
+                // error in untyped-semantics.
+                if end == RangeEnd::Excluded {
+                    debug_assert!(hi.is_some())
                 }
+
+                Ok(match (lit_term, lo, hi) {
+                    (Lit::Int(value), Some(LitPat::Int(lo)), Some(LitPat::Int(hi))) => self
+                        .match_literal_to_range(
+                            value.value(),
+                            Some(lo.value()),
+                            Some(hi.value()),
+                            end,
+                        ),
+                    (Lit::Char(value), Some(LitPat::Char(lo)), Some(LitPat::Char(hi))) => self
+                        .match_literal_to_range(
+                            value.value(),
+                            Some(lo.value()),
+                            Some(hi.value()),
+                            end,
+                        ),
+                    (Lit::Int(value), Some(LitPat::Int(lo)), None) => {
+                        self.match_literal_to_range(value.value(), Some(lo.value()), None, end)
+                    }
+                    (Lit::Int(value), None, Some(LitPat::Int(hi))) => {
+                        self.match_literal_to_range(value.value(), None, Some(hi.value()), end)
+                    }
+                    (Lit::Char(value), Some(LitPat::Char(lo)), None) => {
+                        self.match_literal_to_range(value.value(), Some(lo.value()), None, end)
+                    }
+                    (Lit::Char(value), None, Some(LitPat::Char(hi))) => {
+                        self.match_literal_to_range(value.value(), None, Some(hi.value()), end)
+                    }
+                    _ => MatchResult::Stuck,
+                })
             }
             (_, Pat::Range(_)) => Ok(MatchResult::Stuck),
 

--- a/tests/cases/exhaustiveness/open_ranges.hash
+++ b/tests/cases/exhaustiveness/open_ranges.hash
@@ -1,0 +1,30 @@
+// run=fail, warnings=compare, stage=typecheck
+
+match_int := (value: i32) -> i32 => {
+    match value {
+        .. => 0,
+        _ => 1 // ~WARNING: unreachable pattern
+    }
+}
+
+match_int := (value: i32) -> i32 => {
+    match value {
+        ..< => 0, // ~ERROR: pattern `i32::MAX` not covered
+    }
+}
+
+
+match_int2 := (value: i32) -> i32 => {
+    match value {
+        5.. => 0,
+        ..4 => 1,
+        _ => 2 // ~WARNING: unreachable pattern
+    }
+}
+
+match_char := (value: char) -> i32 => {
+    match value {
+        'a'.. => 0,
+        'c'..< => 1, // ~WARNING: unreachable pattern
+    }
+}

--- a/tests/cases/exhaustiveness/open_ranges.hash
+++ b/tests/cases/exhaustiveness/open_ranges.hash
@@ -7,12 +7,6 @@ match_int := (value: i32) -> i32 => {
     }
 }
 
-match_int := (value: i32) -> i32 => {
-    match value {
-        ..< => 0, // ~ERROR: pattern `i32::MAX` not covered
-    }
-}
-
 
 match_int2 := (value: i32) -> i32 => {
     match value {
@@ -25,6 +19,6 @@ match_int2 := (value: i32) -> i32 => {
 match_char := (value: char) -> i32 => {
     match value {
         'a'.. => 0,
-        'c'..< => 1, // ~WARNING: unreachable pattern
+        'c'.. => 1, // ~WARNING: unreachable pattern
     }
 }

--- a/tests/cases/exhaustiveness/open_ranges.stderr
+++ b/tests/cases/exhaustiveness/open_ranges.stderr
@@ -1,16 +1,9 @@
-error[0083]: non-exhaustive patterns: `i32::MAX` not covered
-  --> $DIR/open_ranges.hash:11:11
-10 |   match_int := (value: i32) -> i32 => {
-11 |       match value {
-   |             ^^^^^ pattern `i32::MAX` not covered
-12 |           ..< => 0, // ~ERROR: pattern `i32::MAX` not covered
-
 error[0083]: non-exhaustive patterns: `'\0'..'`'` not covered
-  --> $DIR/open_ranges.hash:26:11
-25 |   match_char := (value: char) -> i32 => {
-26 |       match value {
+  --> $DIR/open_ranges.hash:20:11
+19 |   match_char := (value: char) -> i32 => {
+20 |       match value {
    |             ^^^^^ pattern `'\0'..'`'` not covered
-27 |           'a'.. => 0,
+21 |           'a'.. => 0,
 
 warn: pattern is unreachable
  --> $DIR/open_ranges.hash:6:9
@@ -20,15 +13,15 @@ warn: pattern is unreachable
 7 |       }
 
 warn: pattern is unreachable
-  --> $DIR/open_ranges.hash:21:9
-20 |           ..4 => 1,
-21 |           _ => 2 // ~WARNING: unreachable pattern
+  --> $DIR/open_ranges.hash:15:9
+14 |           ..4 => 1,
+15 |           _ => 2 // ~WARNING: unreachable pattern
    |           ^ 
-22 |       }
+16 |       }
 
 warn: pattern is unreachable
-  --> $DIR/open_ranges.hash:28:9
-27 |           'a'.. => 0,
-28 |           'c'..< => 1, // ~WARNING: unreachable pattern
-   |           ^^^^^^ 
-29 |       }
+  --> $DIR/open_ranges.hash:22:9
+21 |           'a'.. => 0,
+22 |           'c'.. => 1, // ~WARNING: unreachable pattern
+   |           ^^^^^ 
+23 |       }

--- a/tests/cases/exhaustiveness/open_ranges.stderr
+++ b/tests/cases/exhaustiveness/open_ranges.stderr
@@ -1,0 +1,34 @@
+error[0083]: non-exhaustive patterns: `i32::MAX` not covered
+  --> $DIR/open_ranges.hash:11:11
+10 |   match_int := (value: i32) -> i32 => {
+11 |       match value {
+   |             ^^^^^ pattern `i32::MAX` not covered
+12 |           ..< => 0, // ~ERROR: pattern `i32::MAX` not covered
+
+error[0083]: non-exhaustive patterns: `'\0'..'`'` not covered
+  --> $DIR/open_ranges.hash:26:11
+25 |   match_char := (value: char) -> i32 => {
+26 |       match value {
+   |             ^^^^^ pattern `'\0'..'`'` not covered
+27 |           'a'.. => 0,
+
+warn: pattern is unreachable
+ --> $DIR/open_ranges.hash:6:9
+5 |           .. => 0,
+6 |           _ => 1 // ~WARNING: unreachable pattern
+  |           ^ 
+7 |       }
+
+warn: pattern is unreachable
+  --> $DIR/open_ranges.hash:21:9
+20 |           ..4 => 1,
+21 |           _ => 2 // ~WARNING: unreachable pattern
+   |           ^ 
+22 |       }
+
+warn: pattern is unreachable
+  --> $DIR/open_ranges.hash:28:9
+27 |           'a'.. => 0,
+28 |           'c'..< => 1, // ~WARNING: unreachable pattern
+   |           ^^^^^^ 
+29 |       }

--- a/tests/cases/parser/patterns/incomplere_exclusive_range_pat.hash
+++ b/tests/cases/parser/patterns/incomplere_exclusive_range_pat.hash
@@ -1,7 +1,0 @@
-// run=fail, stage=parse
-
-main := () => {
-    match k {
-        1..< => {};
-    }
-};

--- a/tests/cases/parser/patterns/incomplere_exclusive_range_pat.stderr
+++ b/tests/cases/parser/patterns/incomplere_exclusive_range_pat.stderr
@@ -1,6 +1,0 @@
-error: expected an arrow `=>` 
- --> $DIR/incomplere_exclusive_range_pat.hash:5:10
-4 |       match k {
-5 |           1..< => {};
-  |            ^ 
-6 |       }

--- a/tests/cases/parser/patterns/incomplete_range_pat.hash
+++ b/tests/cases/parser/patterns/incomplete_range_pat.hash
@@ -1,7 +1,0 @@
-// run=fail, stage=parse
-
-main := () => {
-    match k {
-        1.. => {};
-    }
-};

--- a/tests/cases/parser/patterns/incomplete_range_pat.stderr
+++ b/tests/cases/parser/patterns/incomplete_range_pat.stderr
@@ -1,6 +1,0 @@
-error: expected an arrow `=>` 
- --> $DIR/incomplete_range_pat.hash:5:10
-4 |       match k {
-5 |           1.. => {};
-  |            ^ 
-6 |       }

--- a/tests/cases/semantics/incomplete_range_ending.hash
+++ b/tests/cases/semantics/incomplete_range_ending.hash
@@ -1,0 +1,10 @@
+// stage=semantic, run=fail
+
+main := () => {
+  t := 1;
+
+  match t {
+    5..< => {},
+    _ => {}
+  }
+}

--- a/tests/cases/semantics/incomplete_range_ending.stderr
+++ b/tests/cases/semantics/incomplete_range_ending.stderr
@@ -1,0 +1,6 @@
+error: incomplete range ending, ranges that specify a `..<` must specify an ending range operand
+ --> $DIR/incomplete_range_ending.hash:7:5
+6 |     match t {
+7 |       5..< => {},
+  |       ^^^^ add an ending range operand here
+8 |       _ => {}


### PR DESCRIPTION
- target: avoid awkward API for querying sizes/max/mins when handling bigints
- parser+ast: support open ranges, i.e. omit start and or end
- tir: specify `RangePat` `lo` and `hi` values as optionals
- exhaustiveness: support open pattern ranges
- tc: support open ranges in patterns
- lower: support open ranges in lowering
- tests: add tests for open ranges in patterns and remove outdated tests


- [x] #893 should be merged first.
