### PR TITLE
Make IR as static as possible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,6 +616,7 @@ dependencies = [
  "hash-tir",
  "hash-utils",
  "html-escape",
+ "lazy_static",
 ]
 
 [[package]]

--- a/compiler/hash-codegen-llvm/src/ctx.rs
+++ b/compiler/hash-codegen-llvm/src/ctx.rs
@@ -158,7 +158,7 @@ impl<'b> HasCtxMethods<'b> for CodeGenCtx<'b, '_> {
     }
 
     fn layout_computer(&self) -> LayoutComputer<'_> {
-        LayoutComputer::new(self.layouts(), self.ir_ctx())
+        LayoutComputer::new(self.layouts())
     }
 
     fn cg_ctx(&self) -> &CodeGenStorage {

--- a/compiler/hash-codegen-llvm/src/lib.rs
+++ b/compiler/hash-codegen-llvm/src/lib.rs
@@ -30,7 +30,7 @@ use hash_codegen::{
         misc::MiscBuilderMethods, ty::TypeBuilderMethods, HasCtxMethods,
     },
 };
-use hash_ir::{ir::BodySource, ty::IrTy, IrStorage};
+use hash_ir::{ir::BodySource, IrStorage};
 use hash_pipeline::{
     interface::{CompilerOutputStream, CompilerResult, StageMetrics},
     settings::CompilerSettings,
@@ -38,7 +38,7 @@ use hash_pipeline::{
 };
 use hash_reporting::writer::ReportWriter;
 use hash_source::{identifier::IDENTS, ModuleId};
-use hash_storage::store::Store;
+use hash_storage::store::{statics::StoreId, Store};
 use hash_utils::{
     stream_writeln,
     timing::{time_item, AccessToMetrics},
@@ -266,12 +266,7 @@ impl<'b, 'm> LLVMBackend<'b> {
             }
 
             // Get the instance of the function.
-            let instance = self.ir_storage.ctx.map_ty(body.info().ty(), |ty| {
-                let IrTy::FnDef { instance, .. } = ty else {
-                    panic!("ir-body has non-function type")
-                };
-                *instance
-            });
+            let instance = body.info().ty().borrow().as_instance();
 
             // So, we create the mangled symbol name, and then call `predefine()` which
             // should create the function ABI from the instance, with the correct
@@ -301,12 +296,7 @@ impl<'b, 'm> LLVMBackend<'b> {
             }
 
             // Get the instance of the function.
-            let instance = ir.ctx.map_ty(body.info().ty(), |ty| {
-                let IrTy::FnDef { instance, .. } = ty else {
-                    panic!("ir-body has non-function type")
-                };
-                *instance
-            });
+            let instance = body.info().ty().borrow().as_instance();
 
             // @@ErrorHandling: we should be able to handle the error here
             codegen_ir_body::<LLVMBuilder>(instance, body, ctx).unwrap();

--- a/compiler/hash-codegen-llvm/src/lib.rs
+++ b/compiler/hash-codegen-llvm/src/lib.rs
@@ -271,7 +271,7 @@ impl<'b, 'm> LLVMBackend<'b> {
             // So, we create the mangled symbol name, and then call `predefine()` which
             // should create the function ABI from the instance, with the correct
             // attributes and linkage, etc.
-            let symbol_name = compute_symbol_name(&self.ir_storage.ctx, instance);
+            let symbol_name = compute_symbol_name(instance);
 
             let abis = self.codegen_storage.abis();
             let abi = abis.create_fn_abi(ctx, instance);

--- a/compiler/hash-codegen-llvm/src/lib.rs
+++ b/compiler/hash-codegen-llvm/src/lib.rs
@@ -302,9 +302,7 @@ impl<'b, 'm> LLVMBackend<'b> {
             codegen_ir_body::<LLVMBuilder>(instance, body, ctx).unwrap();
 
             // Check if we should dump the generated LLVM IR
-            if ir.ctx.map_instance(instance, |instance| {
-                instance.attributes.contains(IDENTS.dump_llvm_ir)
-            }) {
+            if instance.borrow().attributes.contains(IDENTS.dump_llvm_ir) {
                 let mut stdout = self.stdout.clone();
                 let func = FunctionPrinter::new(body.info.name(), ctx.get_fn(instance));
 

--- a/compiler/hash-codegen-llvm/src/translation/builder.rs
+++ b/compiler/hash-codegen-llvm/src/translation/builder.rs
@@ -24,7 +24,7 @@ use hash_codegen::{
 };
 use hash_ir::ty::{IrTy, IrTyId};
 use hash_source::constant::{IntTy, SIntTy, UIntTy};
-use hash_storage::store::Store;
+use hash_storage::store::{statics::StoreId, Store};
 use inkwell::{
     basic_block::BasicBlock,
     types::{AnyType, AnyTypeEnum, AsTypeRef, BasicTypeEnum},
@@ -546,7 +546,7 @@ impl<'a, 'b, 'm> BlockBuilderMethods<'a, 'b> for LLVMBuilder<'a, 'b, 'm> {
     ) -> (Self::Value, Self::Value) {
         let ptr_width = self.target().ptr_size();
 
-        let int_ty = self.ir_ctx().map_ty(ty, |ty| match ty {
+        let int_ty = ty.map(|ty| match ty {
             IrTy::Int(ty @ SIntTy::ISize) => IntTy::Int(ty.normalise(ptr_width)),
             IrTy::Int(int_ty) => IntTy::Int(*int_ty),
             IrTy::UInt(ty @ UIntTy::USize) => IntTy::UInt(ty.normalise(ptr_width)),

--- a/compiler/hash-codegen-llvm/src/translation/constants.rs
+++ b/compiler/hash-codegen-llvm/src/translation/constants.rs
@@ -131,7 +131,7 @@ impl<'b, 'm> ConstValueBuilderMethods<'b> for CodeGenCtx<'b, 'm> {
             (s, global)
         });
 
-        let byte_slice_ty = self.ir_ctx().tys().common_tys.byte_slice;
+        let byte_slice_ty = self.ir_ctx().common_tys.byte_slice;
         let ptr = global_str.as_pointer_value().const_cast(
             self.type_ptr_to(self.layout_of(byte_slice_ty).llvm_ty(self)).into_pointer_type(),
         );

--- a/compiler/hash-codegen-llvm/src/translation/constants.rs
+++ b/compiler/hash-codegen-llvm/src/translation/constants.rs
@@ -1,12 +1,9 @@
 //! Implements all of the constant building methods.
 use hash_codegen::{
     target::{abi::Scalar, data_layout::HasDataLayout},
-    traits::{
-        constants::ConstValueBuilderMethods, layout::LayoutMethods, ty::TypeBuilderMethods,
-        HasCtxMethods,
-    },
+    traits::{constants::ConstValueBuilderMethods, layout::LayoutMethods, ty::TypeBuilderMethods},
 };
-use hash_ir::ir::Const;
+use hash_ir::{ir::Const, ty::COMMON_IR_TYS};
 use hash_source::constant::{InternedStr, CONSTANT_MAP};
 use inkwell::{module::Linkage, types::BasicTypeEnum, values::AnyValueEnum};
 
@@ -131,7 +128,7 @@ impl<'b, 'm> ConstValueBuilderMethods<'b> for CodeGenCtx<'b, 'm> {
             (s, global)
         });
 
-        let byte_slice_ty = self.ir_ctx().common_tys.byte_slice;
+        let byte_slice_ty = COMMON_IR_TYS.byte_slice;
         let ptr = global_str.as_pointer_value().const_cast(
             self.type_ptr_to(self.layout_of(byte_slice_ty).llvm_ty(self)).into_pointer_type(),
         );

--- a/compiler/hash-codegen-llvm/src/translation/intrinsics.rs
+++ b/compiler/hash-codegen-llvm/src/translation/intrinsics.rs
@@ -10,7 +10,7 @@ use hash_codegen::{
 };
 use hash_ir::ty::{IrTy, IrTyId};
 use hash_source::identifier::{Identifier, IDENTS};
-use hash_storage::store::CloneStore;
+use hash_storage::store::{statics::StoreId, CloneStore};
 use inkwell::values::{AnyValueEnum, UnnamedAddress};
 
 use super::LLVMBuilder;
@@ -321,8 +321,7 @@ impl<'b, 'm> IntrinsicBuilderMethods<'b> for LLVMBuilder<'_, 'b, 'm> {
         let IrTy::FnDef { instance, .. } = self.ir_ctx.tys().get(ty) else {
             panic!("unable to resolve intrinsic function type");
         };
-        let name = self.ir_ctx.instances().name_of(instance);
-
+        let name = instance.borrow().name();
         let result_ref = PlaceRef::new(self, result, fn_abi.ret_abi.info);
 
         // if we can simply resolve the intrinsic then we can just call it directly...

--- a/compiler/hash-codegen-llvm/src/translation/intrinsics.rs
+++ b/compiler/hash-codegen-llvm/src/translation/intrinsics.rs
@@ -8,9 +8,9 @@ use hash_codegen::{
         intrinsics::IntrinsicBuilderMethods, ty::TypeBuilderMethods, BackendTypes,
     },
 };
-use hash_ir::ty::{IrTy, IrTyId};
+use hash_ir::ty::IrTyId;
 use hash_source::identifier::{Identifier, IDENTS};
-use hash_storage::store::{statics::StoreId, CloneStore};
+use hash_storage::store::statics::StoreId;
 use inkwell::values::{AnyValueEnum, UnnamedAddress};
 
 use super::LLVMBuilder;
@@ -317,11 +317,7 @@ impl<'b, 'm> IntrinsicBuilderMethods<'b> for LLVMBuilder<'_, 'b, 'm> {
         //
         // However, since we haven't formally defined any "special" intrinsics yet, we
         // don't expect for the resolution to fail.
-
-        let IrTy::FnDef { instance, .. } = self.ir_ctx.tys().get(ty) else {
-            panic!("unable to resolve intrinsic function type");
-        };
-        let name = instance.borrow().name();
+        let name = ty.borrow().as_instance().borrow().name();
         let result_ref = PlaceRef::new(self, result, fn_abi.ret_abi.info);
 
         // if we can simply resolve the intrinsic then we can just call it directly...

--- a/compiler/hash-codegen-llvm/src/translation/layouts.rs
+++ b/compiler/hash-codegen-llvm/src/translation/layouts.rs
@@ -8,7 +8,7 @@ use hash_codegen::{
     },
     traits::layout::LayoutMethods,
 };
-use hash_ir::{ty::IrTyId, write::WriteIr};
+use hash_ir::ty::IrTyId;
 
 use super::{ty::TyMemoryRemap, LLVMBuilder};
 use crate::ctx::CodeGenCtx;
@@ -100,7 +100,7 @@ impl<'m> ExtendedLayoutMethods<'m> for &Layout {
                     Some(TyMemoryRemap { remap: None, .. }) => {
                         self.shape.memory_index(index) as u64
                     }
-                    None => panic!("cannot find remapped layout for `{}`", ty.for_fmt(ctx.ir_ctx)),
+                    None => panic!("cannot find remapped layout for `{}`", ty),
                 }
             }
         }

--- a/compiler/hash-codegen-llvm/src/translation/misc.rs
+++ b/compiler/hash-codegen-llvm/src/translation/misc.rs
@@ -29,7 +29,7 @@ impl<'b, 'm> CodeGenCtx<'b, 'm> {
             return *fn_val;
         }
 
-        let name = compute_symbol_name(self.ir_ctx, instance);
+        let name = compute_symbol_name(instance);
         let abis = self.cg_ctx().abis();
         let fn_abi = abis.create_fn_abi(self, instance);
 

--- a/compiler/hash-codegen-llvm/src/translation/misc.rs
+++ b/compiler/hash-codegen-llvm/src/translation/misc.rs
@@ -7,7 +7,7 @@ use hash_codegen::{
 };
 use hash_ir::ty::InstanceId;
 use hash_source::identifier::IDENTS;
-use hash_storage::store::Store;
+use hash_storage::store::{statics::StoreId, Store};
 use inkwell::{
     module::Linkage,
     values::{AnyValue, FunctionValue, UnnamedAddress},
@@ -103,11 +103,9 @@ impl<'b, 'm> MiscBuilderMethods<'b> for CodeGenCtx<'b, 'm> {
 
         // If the instance has the "foreign" attribute, then we need to
         // specify that the linkage is external.
-        self.ir_ctx.map_instance(instance, |instance| {
-            if instance.attributes.contains(IDENTS.foreign) {
-                decl.set_linkage(Linkage::External);
-            }
-        });
+        if instance.borrow().attributes.contains(IDENTS.foreign) {
+            decl.set_linkage(Linkage::External);
+        }
 
         // We insert the function into the cache so that we can
         // reference it later on...

--- a/compiler/hash-codegen-llvm/src/translation/ty.rs
+++ b/compiler/hash-codegen-llvm/src/translation/ty.rs
@@ -15,6 +15,7 @@ use hash_codegen::{
     traits::{layout::LayoutMethods, ty::TypeBuilderMethods, HasCtxMethods},
 };
 use hash_ir::ty::IrTy;
+use hash_storage::store::statics::StoreId;
 use hash_utils::smallvec::{smallvec, SmallVec};
 use inkwell as llvm;
 use llvm::types::{AnyTypeEnum, AsTypeRef, BasicType, BasicTypeEnum, MetadataType, VectorType};
@@ -348,7 +349,7 @@ impl<'m> ExtendedTyBuilderMethods<'m> for TyInfo {
                         // of LLVM builds.
                         let name: Option<String> = match ty {
                             IrTy::Adt(adt) => {
-                                ctx.ir_ctx().map_adt(*adt, |_, adt| {
+                                adt.map(|adt| {
                                     // We don't create a name for tuple types, they are just
                                     // regarded
                                     // as opaque structs

--- a/compiler/hash-codegen-llvm/src/translation/ty.rs
+++ b/compiler/hash-codegen-llvm/src/translation/ty.rs
@@ -320,14 +320,10 @@ impl<'m> ExtendedTyBuilderMethods<'m> for TyInfo {
         }
 
         match abi {
-            AbiRepresentation::Scalar(scalar) => {
-                let ty = ctx.ir_ctx().map_ty(self.ty, |ty| match ty {
-                    IrTy::Ref(ty, _, _) => ctx.type_ptr_to(ctx.layout_of(*ty).llvm_ty(ctx)),
-                    _ => self.scalar_llvm_type_at(ctx, scalar, Size::ZERO),
-                });
-
-                ty
-            }
+            AbiRepresentation::Scalar(scalar) => self.ty.map(|ty| match ty {
+                IrTy::Ref(ty, _, _) => ctx.type_ptr_to(ctx.layout_of(*ty).llvm_ty(ctx)),
+                _ => self.scalar_llvm_type_at(ctx, scalar, Size::ZERO),
+            }),
             AbiRepresentation::Vector { elements, kind } => {
                 ctx.type_vector(self.scalar_llvm_type_at(ctx, kind, Size::ZERO), elements)
             }
@@ -341,7 +337,7 @@ impl<'m> ExtendedTyBuilderMethods<'m> for TyInfo {
 
             _ => {
                 ctx.map_layout(self.layout, |layout| {
-                    ctx.ir_ctx().map_ty(self.ty, |ty| {
+                    self.ty.map(|ty| {
                         // Firstly, we want to compute the name of the type that we are going
                         // to create.
                         //

--- a/compiler/hash-codegen/src/lower/abi.rs
+++ b/compiler/hash-codegen/src/lower/abi.rs
@@ -6,7 +6,7 @@ use hash_abi::{
 };
 use hash_ir::ty::{Instance, InstanceId, IrTy, IrTyId, Mutability, RefKind};
 use hash_layout::compute::LayoutError;
-use hash_storage::store::{statics::StoreId, CloneStore};
+use hash_storage::store::statics::StoreId;
 use hash_target::abi::{Scalar, ScalarKind};
 
 use crate::traits::{layout::LayoutMethods, HasCtxMethods};
@@ -83,7 +83,7 @@ pub fn compute_fn_abi_from_instance<'b, Ctx: HasCtxMethods<'b> + LayoutMethods<'
     ctx: &Ctx,
     instance: InstanceId,
 ) -> Result<FnAbi, FnAbiError> {
-    let Instance { params, ret_ty, abi, .. } = ctx.ir_ctx().instances().get(instance);
+    let Instance { params, ret_ty, abi, .. } = instance.value();
 
     // map the ABI to a calling convention whilst making any adjustments according
     // to the target.

--- a/compiler/hash-codegen/src/lower/abi.rs
+++ b/compiler/hash-codegen/src/lower/abi.rs
@@ -6,7 +6,7 @@ use hash_abi::{
 };
 use hash_ir::ty::{Instance, InstanceId, IrTy, IrTyId, Mutability, RefKind};
 use hash_layout::compute::LayoutError;
-use hash_storage::store::{statics::StoreId, CloneStore, SequenceStore};
+use hash_storage::store::{statics::StoreId, CloneStore};
 use hash_target::abi::{Scalar, ScalarKind};
 
 use crate::traits::{layout::LayoutMethods, HasCtxMethods};
@@ -112,12 +112,12 @@ pub fn compute_fn_abi_from_instance<'b, Ctx: HasCtxMethods<'b> + LayoutMethods<'
     };
 
     let fn_abi = FnAbi {
-        args: ctx.ir_ctx().tls().map_fast(params, |tys| {
-            tys.iter()
-                .enumerate()
-                .map(|(i, ty)| make_arg_abi(*ty, Some(i)))
-                .collect::<Result<_, _>>()
-        })?,
+        args: params
+            .borrow()
+            .iter()
+            .enumerate()
+            .map(|(i, ty)| make_arg_abi(*ty, Some(i)))
+            .collect::<Result<_, _>>()?,
         ret_abi: make_arg_abi(ret_ty, None)?,
         calling_convention,
     };

--- a/compiler/hash-codegen/src/lower/abi.rs
+++ b/compiler/hash-codegen/src/lower/abi.rs
@@ -5,8 +5,8 @@ use hash_abi::{
     ArgAbi, ArgAttributeFlag, ArgAttributes, ArgExtension, CallingConvention, FnAbi, PassMode,
 };
 use hash_ir::ty::{Instance, InstanceId, IrTy, IrTyId, Mutability, RefKind};
-use hash_layout::compute::{LayoutComputer, LayoutError};
-use hash_storage::store::{CloneStore, SequenceStore};
+use hash_layout::compute::LayoutError;
+use hash_storage::store::{statics::StoreId, CloneStore, SequenceStore};
 use hash_target::abi::{Scalar, ScalarKind};
 
 use crate::traits::{layout::LayoutMethods, HasCtxMethods};
@@ -15,7 +15,6 @@ use crate::traits::{layout::LayoutMethods, HasCtxMethods};
 /// [Layout] and [Scalar] information. This is required to do since
 /// the scalar maybe a pair of values.
 fn adjust_arg_attributes(
-    ctx: &LayoutComputer,
     attributes: &mut ArgAttributes,
     ty: IrTyId,
     scalar: Scalar,
@@ -47,7 +46,7 @@ fn adjust_arg_attributes(
 
     // If the pointer type is a read-only, then we can set the "read_only"
     // attribute.
-    ctx.ir_ctx().map_ty(ty, |ty| {
+    ty.map(|ty| {
         let IrTy::Ref(_, mutability, kind) = ty else {
             return;
         };
@@ -99,7 +98,7 @@ pub fn compute_fn_abi_from_instance<'b, Ctx: HasCtxMethods<'b> + LayoutMethods<'
 
         let mut arg = ArgAbi::new(&lc, info, |scalar| {
             let mut attributes = ArgAttributes::new();
-            adjust_arg_attributes(&lc, &mut attributes, ty, scalar, is_return);
+            adjust_arg_attributes(&mut attributes, ty, scalar, is_return);
             attributes
         });
 

--- a/compiler/hash-codegen/src/lower/locals.rs
+++ b/compiler/hash-codegen/src/lower/locals.rs
@@ -12,7 +12,7 @@ use hash_ir::{
     visitor::{ImmutablePlaceContext, IrVisitorMut, MutablePlaceContext, PlaceContext},
 };
 use hash_layout::TyInfo;
-use hash_storage::store::{SequenceStore, SequenceStoreKey};
+use hash_storage::store::{statics::StoreId, SequenceStoreKey};
 use hash_utils::{graph::dominators::Dominators, index_vec::IndexVec};
 
 use super::{operands::OperandRef, place::PlaceRef, FnBuilder};
@@ -242,10 +242,6 @@ impl<'ir, 'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> IrVisitorMut<'ir>
             return;
         }
 
-        // we want to check if any of the projections affect the
-        // base local, if so then we need to check it as a local...
-        let projections = self.fn_builder.ctx.ir_ctx().projections().get_vec(place.projections);
-
         let mut base_ctx = if ctx.is_mutating() {
             PlaceContext::Mutable(MutablePlaceContext::Projection)
         } else {
@@ -258,7 +254,7 @@ impl<'ir, 'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> IrVisitorMut<'ir>
         let mut index_locals = vec![];
 
         // loop over the projections in reverse order
-        for projection in projections.iter().rev() {
+        for projection in place.projections.borrow().iter().rev() {
             // @@Todo: if the projection yields a ZST, then we can
             // also short-circuit here.
 

--- a/compiler/hash-codegen/src/lower/locals.rs
+++ b/compiler/hash-codegen/src/lower/locals.rs
@@ -203,10 +203,6 @@ impl<'ir, 'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> LocalKindAnalyser<'ir, '
 impl<'ir, 'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> IrVisitorMut<'ir>
     for LocalKindAnalyser<'ir, 'a, 'b, Builder>
 {
-    fn ctx(&self) -> &'ir hash_ir::IrCtx {
-        self.fn_builder.ctx.ir_ctx()
-    }
-
     fn visit_assign_statement(&mut self, place: &ir::Place, value: &ir::RValue, reference: IrRef) {
         if let Some(local) = place.as_local() {
             self.assign(local, reference);

--- a/compiler/hash-codegen/src/lower/operands.rs
+++ b/compiler/hash-codegen/src/lower/operands.rs
@@ -296,7 +296,7 @@ impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
         match operand {
             ir::Operand::Place(place) => self.codegen_consume_operand(builder, *place),
             ir::Operand::Const(ref constant) => {
-                let ty = constant.ty(builder.ir_ctx());
+                let ty = constant.ty();
                 let info = builder.layout_of(ty);
 
                 let value = match constant {

--- a/compiler/hash-codegen/src/lower/operands.rs
+++ b/compiler/hash-codegen/src/lower/operands.rs
@@ -3,7 +3,7 @@
 
 use hash_ir::ir;
 use hash_layout::TyInfo;
-use hash_storage::store::SequenceStore;
+use hash_storage::store::{statics::StoreId, SequenceStore};
 use hash_target::{abi::AbiRepresentation, alignment::Alignment};
 
 use super::{locals::LocalRef, place::PlaceRef, utils, FnBuilder};
@@ -190,7 +190,7 @@ impl<'a, 'b, V: CodeGenObject> OperandRef<V> {
     /// Apply a dereference operation on a [OperandRef], effectively
     /// producing a [PlaceRef].
     pub fn deref<Builder: LayoutMethods<'b>>(self, builder: &Builder) -> PlaceRef<V> {
-        let projected_ty = builder.ir_ctx().map_ty(self.info.ty, |ty| ty.on_deref()).unwrap();
+        let projected_ty = self.info.ty.borrow().on_deref().unwrap();
 
         // If we have a pair, then we move the extra data into the place ref.
         let (ptr_value, extra) = match self.value {

--- a/compiler/hash-codegen/src/lower/place.rs
+++ b/compiler/hash-codegen/src/lower/place.rs
@@ -114,9 +114,9 @@ impl<'a, 'b, V: CodeGenObject> PlaceRef<V> {
         // the variant, and then store it within the specified field.
         if let Some(field) = maybe_field {
             let ptr = self.project_field(builder, field);
-            let (_, value) = builder.ir_ctx().map_ty(self.info.ty, |ty| {
-                ty.discriminant_for_variant(builder.ir_ctx(), discriminant).unwrap()
-            });
+            let (_, value) = builder
+                .ir_ctx()
+                .map_ty(self.info.ty, |ty| ty.discriminant_for_variant(discriminant).unwrap());
 
             builder.store(
                 builder.const_uint_big(builder.backend_ty_from_info(ptr.info), value),
@@ -150,7 +150,7 @@ impl<'a, 'b, V: CodeGenObject> PlaceRef<V> {
         match variants {
             Variants::Single { index } => {
                 let value = builder.ir_ctx().map_ty(self.info.ty, |ty| {
-                    ty.discriminant_for_variant(builder.ir_ctx(), index)
+                    ty.discriminant_for_variant(index)
                         .map_or(index.raw() as u128, |(_, value)| value)
                 });
 

--- a/compiler/hash-codegen/src/lower/place.rs
+++ b/compiler/hash-codegen/src/lower/place.rs
@@ -2,12 +2,11 @@
 //! IR.
 
 use hash_ir::{
-    ir,
+    ir::{self, ProjectionId},
     ty::{IrTyId, PlaceTy, VariantIdx},
-    write::WriteIr,
 };
 use hash_layout::{LayoutShape, Variants};
-use hash_storage::store::{statics::StoreId, SequenceStore};
+use hash_storage::store::statics::StoreId;
 use hash_target::{
     abi::{AbiRepresentation, ScalarKind},
     alignment::Alignment,
@@ -18,7 +17,7 @@ use crate::{
     layout::TyInfo,
     traits::{
         builder::BlockBuilderMethods, constants::ConstValueBuilderMethods, ty::TypeBuilderMethods,
-        CodeGenObject, HasCtxMethods,
+        CodeGenObject,
     },
 };
 
@@ -310,7 +309,7 @@ impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
     /// Compute the type and layout of a [ir::Place]. This deals with
     /// all projections that occur on the [ir::Place].
     pub fn compute_place_ty_info(&self, builder: &Builder, place: ir::Place) -> TyInfo {
-        let place_ty = PlaceTy::from_place(place, &self.body.declarations, self.ctx.ir_ctx());
+        let place_ty = PlaceTy::from_place(place, &self.body.declarations);
         builder.layout_of(place_ty.ty)
     }
 
@@ -325,8 +324,7 @@ impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
         place: ir::Place,
     ) -> PlaceRef<Builder::Value> {
         // copy the projections from the place.
-        let projections = builder.ir_ctx().projections().get_vec(place.projections);
-
+        let projections = place.projections.value();
         let mut base = 0;
 
         let mut codegen_base = match self.locals[place.local] {
@@ -337,8 +335,7 @@ impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
 
                     // we have to copy a slice of the projections where
                     // we omit the first projection (which is a deref).
-                    let projections =
-                        builder.ir_ctx().projections().create_from_slice(&projections[1..]);
+                    let projections = ProjectionId::from_slice(&projections[1..]);
 
                     let codegen_base = self.codegen_consume_operand(
                         builder,
@@ -347,7 +344,7 @@ impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
 
                     codegen_base.deref(builder)
                 } else {
-                    panic!("using operand local `{}` as place", place.for_fmt(self.ctx.ir_ctx()))
+                    panic!("using operand local `{place}` as place")
                 }
             }
         };
@@ -361,8 +358,7 @@ impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
                 }
                 ir::PlaceProjection::Field(index) => codegen_base.project_field(builder, index),
                 ir::PlaceProjection::Index(index) => {
-                    let index_operand: ir::Operand =
-                        ir::Place::from_local(index, builder.ir_ctx()).into();
+                    let index_operand: ir::Operand = ir::Place::from_local(index).into();
                     let index = self.codegen_operand(builder, &index_operand);
 
                     let value = index.immediate_value();
@@ -381,8 +377,8 @@ impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
                 ir::PlaceProjection::SubSlice { from, .. } => {
                     let mut sub_slice =
                         codegen_base.project_index(builder, builder.const_usize(from as u64));
-                    let projected_ty = PlaceTy::from_ty(codegen_base.info.ty)
-                        .projection_ty(builder.ir_ctx(), *projection);
+                    let projected_ty =
+                        PlaceTy::from_ty(codegen_base.info.ty).projection_ty(*projection);
 
                     // @@Verify: if the size of the array is not known, do we
                     // have to do record the size of this slice using `extra_value`?

--- a/compiler/hash-codegen/src/lower/rvalue.rs
+++ b/compiler/hash-codegen/src/lower/rvalue.rs
@@ -300,10 +300,10 @@ impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
                     return OperandRef { value, info: cast_ty };
                 }
 
-                let in_cast_ty = CastTy::from_ty(self.ctx.ir_ctx(), operand.info.ty)
-                    .expect("expected cast-able type for cast");
-                let out_cast_ty = CastTy::from_ty(self.ctx.ir_ctx(), cast_ty.ty)
-                    .expect("expected cast-able type for cast");
+                let in_cast_ty =
+                    CastTy::from_ty(operand.info.ty).expect("expected cast-able type for cast");
+                let out_cast_ty =
+                    CastTy::from_ty(cast_ty.ty).expect("expected cast-able type for cast");
 
                 let in_ty = builder.immediate_backend_ty(operand.info);
                 let value = operand.immediate_value();

--- a/compiler/hash-codegen/src/lower/rvalue.rs
+++ b/compiler/hash-codegen/src/lower/rvalue.rs
@@ -6,7 +6,7 @@ use std::cmp::Ordering;
 use hash_ir::{
     cast::{CastTy, IntCastKind},
     ir::{self, BinOp, RValue},
-    ty::{self, IrTyId, RefKind, VariantIdx},
+    ty::{self, IrTyId, RefKind, VariantIdx, COMMON_IR_TYS},
 };
 use hash_storage::store::statics::StoreId;
 
@@ -190,7 +190,7 @@ impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
 
     /// Compute the type of an [RValue].
     pub fn ty_of_rvalue(&self, value: &RValue) -> IrTyId {
-        value.ty(&self.body.declarations, self.ctx.ir_ctx())
+        value.ty(&self.body.declarations)
     }
 
     /// Emit code for a [ir::RValue] that will return an [OperandRef].
@@ -218,7 +218,7 @@ impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
 
                 OperandRef {
                     value: OperandValue::Immediate(value),
-                    info: builder.layout_of(self.ctx.ir_ctx().common_tys.usize),
+                    info: builder.layout_of(COMMON_IR_TYS.usize),
                 }
             }
             ir::RValue::UnaryOp(operator, ref operand) => {
@@ -265,11 +265,7 @@ impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
 
                 OperandRef {
                     value: OperandValue::Immediate(result),
-                    info: builder.layout_of(operator.ty(
-                        self.ctx.ir_ctx(),
-                        lhs.info.ty,
-                        rhs.info.ty,
-                    )),
+                    info: builder.layout_of(operator.ty(lhs.info.ty, rhs.info.ty)),
                 }
             }
             ir::RValue::CheckedBinaryOp(operator, box (ref lhs, ref rhs)) => {
@@ -350,7 +346,7 @@ impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
 
                 OperandRef {
                     value: OperandValue::Immediate(size),
-                    info: builder.layout_of(self.ctx.ir_ctx().common_tys.usize),
+                    info: builder.layout_of(COMMON_IR_TYS.usize),
                 }
             }
             ir::RValue::Ref(_, place, kind) => {

--- a/compiler/hash-codegen/src/lower/terminator.rs
+++ b/compiler/hash-codegen/src/lower/terminator.rs
@@ -434,8 +434,7 @@ impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
                 return;
             }
             PassMode::Direct(_) | PassMode::Pair(..) => {
-                let op = self
-                    .codegen_consume_operand(builder, ir::Place::return_place(self.ctx.ir_ctx()));
+                let op = self.codegen_consume_operand(builder, ir::Place::return_place());
 
                 if let OperandValue::Ref(value, alignment) = op.value {
                     let ty = builder.backend_ty_from_info(op.info);

--- a/compiler/hash-codegen/src/lower/terminator.rs
+++ b/compiler/hash-codegen/src/lower/terminator.rs
@@ -10,7 +10,7 @@
 //! whether two blocks have been merged together.
 
 use hash_abi::{ArgAbi, FnAbiId, PassMode};
-use hash_ir::{intrinsics::Intrinsic, ir, lang_items::LangItem};
+use hash_ir::{intrinsics::Intrinsic, ir, lang_items::LangItem, ty::COMMON_IR_TYS};
 use hash_pipeline::settings::{CodeGenBackend, OptimisationLevel};
 use hash_source::constant::CONSTANT_MAP;
 use hash_storage::store::{statics::StoreId, Store};
@@ -474,7 +474,7 @@ impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
 
             // If this type is a `bool`, then we can generate conditional
             // branches rather than an `icmp` and `br`.
-            if self.ctx.ir_ctx().common_tys.bool == ty {
+            if COMMON_IR_TYS.bool == ty {
                 match value {
                     0 => builder.conditional_branch(
                         subject.immediate_value(),

--- a/compiler/hash-codegen/src/lower/terminator.rs
+++ b/compiler/hash-codegen/src/lower/terminator.rs
@@ -150,9 +150,7 @@ impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
         // If this is an intrinsic, we will generate the required code
         // for the intrinsic here...
         if is_intrinsic {
-            maybe_intrinsic = Some(self.ctx.ir_ctx().map_instance(instance, |instance| {
-                Intrinsic::from_str_name(instance.name().into()).unwrap()
-            }));
+            maybe_intrinsic = Intrinsic::from_str_name(instance.borrow().name().into());
 
             // We exit early for transmute since we don't need to compute the ABI
             // or any information about the return destination.

--- a/compiler/hash-codegen/src/symbols/mangle.rs
+++ b/compiler/hash-codegen/src/symbols/mangle.rs
@@ -24,9 +24,9 @@
 //! which prevent the function function from being "mangled", then
 //! we have to avoid mangling the symbol name.
 
-use hash_ir::{ty::InstanceId, IrCtx};
+use hash_ir::ty::InstanceId;
 use hash_source::{identifier::IDENTS, InteractiveId, ModuleId};
-use hash_storage::store::{Store, StoreKey};
+use hash_storage::store::{statics::StoreId, StoreKey};
 
 use super::{push_string_encoded_count, ALPHANUMERIC_BASE};
 
@@ -61,13 +61,13 @@ impl Mangler {
 /// ```text
 /// <module_id>::<function_name>(is_generic? instance-id)
 /// ```
-pub fn compute_symbol_name(ctx: &IrCtx, instance_id: InstanceId) -> String {
+pub fn compute_symbol_name(instance_id: InstanceId) -> String {
     // @@Todo: allow for certain symbol names to be exported
     // without mangling. This is useful for debugging purposes.
 
     let m = &mut Mangler { out: String::new() };
 
-    ctx.instances().map_fast(instance_id, |instance| {
+    instance_id.map(|instance| {
         if !instance.attributes.contains(IDENTS.no_mangle)
             && !instance.attributes.contains(IDENTS.foreign)
         {

--- a/compiler/hash-codegen/src/traits/mod.rs
+++ b/compiler/hash-codegen/src/traits/mod.rs
@@ -84,7 +84,7 @@ pub trait HasCtxMethods<'b>: HasDataLayout {
 
     /// Create a [LayoutComputer] for the current context.
     fn layout_computer(&self) -> LayoutComputer<'_> {
-        LayoutComputer::new(self.layouts(), self.ir_ctx())
+        LayoutComputer::new(self.layouts())
     }
 
     /// Returns a reference to the [LayoutCtx].

--- a/compiler/hash-codegen/src/traits/ty.rs
+++ b/compiler/hash-codegen/src/traits/ty.rs
@@ -4,6 +4,7 @@ use hash_abi::FnAbi;
 use hash_ir::ty::{IrTy, IrTyId};
 use hash_layout::TyInfo;
 use hash_source::constant::FloatTy;
+use hash_storage::store::statics::StoreId;
 use hash_target::abi::{AddressSpace, Integer};
 
 use super::{layout::LayoutMethods, BackendTypes};
@@ -127,6 +128,6 @@ pub trait TypeBuilderMethods<'b>: BackendTypes + LayoutMethods<'b> {
     /// Check whether a given type has additional hidden metadata like the
     /// size of a slice or a string.
     fn ty_has_hidden_metadata(&self, ty: IrTyId) -> bool {
-        self.ir_ctx().map_ty(ty, |ty| matches!(ty, IrTy::Slice(_) | IrTy::Str))
+        ty.map(|ty| matches!(ty, IrTy::Slice(_) | IrTy::Str))
     }
 }

--- a/compiler/hash-ir/Cargo.toml
+++ b/compiler/hash-ir/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 bitflags = "2.0.0-rc.1"
 fixedbitset = "0.4.2"
 html-escape = "0.2.12"
+lazy_static = "1.4.0"
 
 hash-ast = { path = "../hash-ast" }
 hash-intrinsics = { path = "../hash-intrinsics" }

--- a/compiler/hash-ir/src/cast.rs
+++ b/compiler/hash-ir/src/cast.rs
@@ -8,7 +8,6 @@ use hash_storage::store::CloneStore;
 
 use crate::{
     ty::{IrTy, IrTyId},
-    write::WriteIr,
     IrCtx,
 };
 
@@ -45,8 +44,7 @@ impl CastKind {
             (Some(CastTy::Float), Some(CastTy::Float)) => Self::FloatToFloat,
             _ => panic!(
                 "attempting to cast between non-primitive types: src: `{}`, dest: `{}`",
-                src.fmt_with_opts(ctx, false),
-                dest.fmt_with_opts(ctx, false)
+                src, dest
             ),
         }
     }

--- a/compiler/hash-ir/src/cast.rs
+++ b/compiler/hash-ir/src/cast.rs
@@ -4,12 +4,9 @@
 //! this module provides the [CastKind] type which is used to classify
 //! casts at the top level within RValue positions.
 
-use hash_storage::store::CloneStore;
+use hash_storage::store::statics::StoreId;
 
-use crate::{
-    ty::{IrTy, IrTyId},
-    IrCtx,
-};
+use crate::ty::{IrTy, IrTyId};
 
 /// A [CastKind] represents all of the different kind of casts that
 /// are permitted in the language. For now, this is just limited to
@@ -33,9 +30,9 @@ pub enum CastKind {
 
 impl CastKind {
     /// Classify the kind of cast between two types.
-    pub fn classify(ctx: &IrCtx, src: IrTyId, dest: IrTyId) -> Self {
-        let src_ty = CastTy::from_ty(ctx, src);
-        let dest_ty = CastTy::from_ty(ctx, dest);
+    pub fn classify(src: IrTyId, dest: IrTyId) -> Self {
+        let src_ty = CastTy::from_ty(src);
+        let dest_ty = CastTy::from_ty(dest);
 
         match (src_ty, dest_ty) {
             (Some(CastTy::Int(_)), Some(CastTy::Int(_))) => Self::IntToInt,
@@ -93,14 +90,14 @@ pub enum CastTy {
 impl CastTy {
     /// Convert a [IrTy] into a [CastTy] if it is a primitive type. The function
     /// will return [`None`] if the conversion fails.
-    pub fn from_ty(ctx: &IrCtx, ty: IrTyId) -> Option<Self> {
-        match ctx.tys().get(ty) {
+    pub fn from_ty(ty: IrTyId) -> Option<Self> {
+        ty.map(|ty| match ty {
             IrTy::Int(_) => Some(Self::Int(IntCastKind::Int)),
             IrTy::UInt(_) => Some(Self::Int(IntCastKind::UInt)),
             IrTy::Char => Some(Self::Int(IntCastKind::Char)),
             IrTy::Bool => Some(Self::Int(IntCastKind::Bool)),
             IrTy::Float(_) => Some(Self::Float),
             _ => None,
-        }
+        })
     }
 }

--- a/compiler/hash-ir/src/ir.rs
+++ b/compiler/hash-ir/src/ir.rs
@@ -783,7 +783,7 @@ impl RValue {
             }
             RValue::CheckedBinaryOp(op, box (lhs, rhs)) => {
                 let ty = op.ty(ctx, lhs.ty(locals, ctx), rhs.ty(locals, ctx));
-                ctx.tys().create(IrTy::tuple(ctx, &[ty, ctx.tys().common_tys.bool]))
+                ctx.tys().create(IrTy::tuple(&[ty, ctx.tys().common_tys.bool]))
             }
             RValue::Cast(_, _, ty) => *ty,
             RValue::Len(_) => ctx.tys().common_tys.usize,

--- a/compiler/hash-ir/src/ir.rs
+++ b/compiler/hash-ir/src/ir.rs
@@ -15,8 +15,8 @@ use hash_source::{
     SourceId,
 };
 use hash_storage::{
-    new_sequence_store_key_direct,
-    store::{statics::StoreId, DefaultSequenceStore, SequenceStore, SequenceStoreKey, Store},
+    static_sequence_store_indirect,
+    store::{SequenceStore, SequenceStoreKey, Store},
 };
 use hash_utils::{
     graph::dominators::Dominators,
@@ -27,6 +27,7 @@ use hash_utils::{
 use crate::{
     basic_blocks::BasicBlocks,
     cast::CastKind,
+    ir_stores,
     ty::{AdtId, IrTy, IrTyId, Mutability, PlaceTy, RefKind, ToIrTy, VariantIdx},
     IrCtx,
 };
@@ -1436,13 +1437,12 @@ impl BodyInfo {
     }
 }
 
-new_sequence_store_key_direct!(pub ProjectionId, ProjectionElementId, derives = [Debug], el_derives = [Debug]);
-
-/// Stores all collections of projections that can occur on a place.
-///
-/// This is used to efficiently represent [Place]s that might have many
-/// projections, and to easily copy them when duplicating places.
-pub type ProjectionStore = DefaultSequenceStore<ProjectionId, PlaceProjection>;
+static_sequence_store_indirect!(
+    store = pub ProjectionStore,
+    id = pub ProjectionId[PlaceProjection],
+    store_name = projections,
+    store_source = ir_stores()
+);
 
 /// An [IrRef] is a reference to where a particular item occurs within
 /// the [Body]. The [IrRef] stores an associated [BasicBlock] and an

--- a/compiler/hash-ir/src/lib.rs
+++ b/compiler/hash-ir/src/lib.rs
@@ -24,10 +24,7 @@ use std::{
 };
 
 use hash_source::entry_point::EntryPointState;
-use hash_storage::{
-    store::{SequenceStore, SequenceStoreKey},
-    stores,
-};
+use hash_storage::{store::SequenceStoreKey, stores};
 use hash_tir::{
     data::{DataDefId, DataTy},
     fns::FnDefId,
@@ -35,7 +32,7 @@ use hash_tir::{
 };
 use hash_utils::fxhash::FxHashMap;
 use intrinsics::Intrinsics;
-use ir::{Body, Local, Place, PlaceProjection, ProjectionStore};
+use ir::{Body, ProjectionStore};
 use lang_items::LangItems;
 use ty::{AdtStore, CommonIrTys, InstanceId, InstanceStore, IrTyId, IrTyListStore, IrTyStore};
 
@@ -199,41 +196,8 @@ impl IrCtx {
         self.lang_items.borrow_mut()
     }
 
-    /// Get a reference to the [IrTyStore].
-    pub fn tys(&self) -> &IrTyStore {
-        ir_stores().tys()
-    }
-
     /// Get a reference to the semantic types conversion cache.
     pub fn ty_cache(&self) -> &TyCache {
         &self.ty_cache
-    }
-
-    /// Get a reference to the [AdtStore]
-    pub fn adts(&self) -> &AdtStore {
-        ir_stores().adts()
-    }
-
-    /// Get a reference to the instance store.
-    pub fn instances(&self) -> &InstanceStore {
-        ir_stores().instances()
-    }
-
-    /// Get a reference to the [ProjectionStore]
-    pub fn projections(&self) -> &ProjectionStore {
-        ir_stores().projections()
-    }
-
-    /// Perform a map on a [Place] by reading all of the [PlaceProjection]s
-    /// that are associated with the [Place] and then applying the provided
-    /// function.
-    pub fn map_place<T>(
-        &self,
-        place: Place,
-        map: impl FnOnce(Local, &[PlaceProjection]) -> T,
-    ) -> T {
-        let Place { local, projections } = place;
-
-        self.projections().map_fast(projections, |projections| map(local, projections))
     }
 }

--- a/compiler/hash-ir/src/lib.rs
+++ b/compiler/hash-ir/src/lib.rs
@@ -34,7 +34,7 @@ use hash_utils::fxhash::FxHashMap;
 use intrinsics::Intrinsics;
 use ir::{Body, ProjectionStore};
 use lang_items::LangItems;
-use ty::{AdtStore, CommonIrTys, InstanceId, InstanceStore, IrTyId, IrTyListStore, IrTyStore};
+use ty::{AdtStore, InstanceId, InstanceStore, IrTyId, IrTyListStore, IrTyStore};
 
 /// Storage that is used by the lowering stage. This stores all of the
 /// generated [Body]s and all of the accompanying data for the bodies.
@@ -130,9 +130,6 @@ pub type TyCache = RefCell<FxHashMap<TyCacheEntry, IrTyId>>;
 /// projections, etc.
 #[derive(Default)]
 pub struct IrCtx {
-    /// Commonly used types, stored in a table.
-    pub common_tys: CommonIrTys,
-
     /// Cache for the [IrTyId]s that are created from [TyId]s.
     ty_cache: TyCache,
 
@@ -171,7 +168,6 @@ impl IrCtx {
         Self {
             lang_items: RefCell::new(lang_items),
             intrinsics: RefCell::new(intrinsics),
-            common_tys: CommonIrTys::new(),
             ty_cache: RefCell::new(FxHashMap::default()),
         }
     }

--- a/compiler/hash-ir/src/ty.rs
+++ b/compiler/hash-ir/src/ty.rs
@@ -294,9 +294,8 @@ impl IrTy {
                 .map(|(idx, ty)| AdtField { name: idx.into(), ty })
                 .collect(),
         }];
-        let adt = AdtData::new_with_flags("tuple".into(), variants, AdtFlags::TUPLE);
-
-        Self::Adt(AdtData::create(adt))
+        let adt = Adt::new_with_flags("tuple".into(), variants, AdtFlags::TUPLE);
+        Self::Adt(Adt::create(adt))
     }
 
     /// Create a reference type to the provided [IrTy].
@@ -515,7 +514,7 @@ index_vec::define_index_type! {
 /// information about the ADT, which kind of ADT it is, and how it is
 /// represented in memory.
 #[derive(Clone, Debug)]
-pub struct AdtData {
+pub struct Adt {
     /// The name of the ADT
     pub name: Identifier,
 
@@ -537,7 +536,7 @@ pub struct AdtData {
     pub metadata: AdtRepresentation,
 }
 
-impl AdtData {
+impl Adt {
     /// Create a new [AdtData] with the given name and variants.
     pub fn new(name: Identifier, variants: IndexVec<VariantIdx, AdtVariant>) -> Self {
         Self {
@@ -767,7 +766,7 @@ pub struct AdtField {
 static_single_store!(
     store = pub AdtStore,
     id = pub AdtId,
-    value = AdtData,
+    value = Adt,
     store_name = adts,
     store_source = ir_stores(),
     derives = Debug

--- a/compiler/hash-ir/src/ty.rs
+++ b/compiler/hash-ir/src/ty.rs
@@ -481,6 +481,12 @@ static_sequence_store_indirect!(
     store_source = ir_stores()
 );
 
+impl IrTyListId {
+    pub fn seq<I: IntoIterator<Item = IrTyId>>(values: I) -> Self {
+        ir_stores().ty_list().create_from_iter(values)
+    }
+}
+
 /// Macro that is used to create the "common" IR types. Each
 /// entry has an associated name, and then followed by the type
 /// expression that represents the [IrTy].

--- a/compiler/hash-ir/src/visitor.rs
+++ b/compiler/hash-ir/src/visitor.rs
@@ -20,7 +20,6 @@ use crate::{
         Terminator, UnaryOp,
     },
     ty::{IrTyId, Mutability, RefKind, VariantIdx},
-    IrCtx,
 };
 
 /// A [PlaceContext] is a reference of where a a particular [Place] is
@@ -102,9 +101,6 @@ pub enum MetaPlaceContext {
 /// A trait for visiting the IR with a mutable context. This trait should
 /// not be used for when modifications to the IR need to be made in place.
 pub trait IrVisitorMut<'ir>: Sized {
-    /// Return a reference to the [BodyDataStore].
-    fn ctx(&self) -> &'ir IrCtx;
-
     /// The entry point of the visitor. This is called when the visitor
     /// is first initialised.
     fn visit(&mut self, body: &Body) {
@@ -576,9 +572,6 @@ pub mod walk_mut {
 }
 
 pub trait ModifyingIrVisitor<'ir>: Sized {
-    /// Return a reference to the [BodyDataStore].
-    fn store(&self) -> &'ir IrCtx;
-
     /// The entry point of the visitor. This is called when the visitor
     /// is first initialised.
     fn visit(&self, body: &mut Body) {
@@ -1058,9 +1051,4 @@ pub mod walk_modifying {
             visitor.visit_local(local, ctx, reference)
         }
     }
-}
-
-pub trait ModifyingIrVisitorMut<'ir> {
-    /// Return a reference to the [BodyDataStore].
-    fn storage(&self) -> &'ir IrCtx;
 }

--- a/compiler/hash-ir/src/write/graphviz.rs
+++ b/compiler/hash-ir/src/write/graphviz.rs
@@ -95,21 +95,17 @@ impl<'ir> IrGraphWriter<'ir> {
 
                     // We add 1 to the index because the return type is always
                     // located at `0`.
-                    write!(
-                        w,
-                        "{}",
-                        encode_text(&format!("_{}: {}", i + 1, param.ty().for_fmt(self.ctx)))
-                    )?;
+                    write!(w, "{}", encode_text(&format!("_{}: {}", i + 1, param.ty())))?;
                 }
                 writeln!(
                     w,
                     "{}{}",
-                    encode_text(&format!(") -> {} {{", return_ty_decl.ty().for_fmt(self.ctx))),
+                    encode_text(&format!(") -> {} {{", return_ty_decl.ty())),
                     LINE_SEPARATOR
                 )?;
             }
             BodySource::Const => {
-                let header = format!("{}", self.body.info().ty().fmt_with_opts(self.ctx, false));
+                let header = format!("{}", self.body.info().ty());
 
                 // @@Todo: maybe figure out a better format for this?
                 write!(
@@ -132,7 +128,7 @@ impl<'ir> IrGraphWriter<'ir> {
                 w,
                 "{}{local:?}: {};{}",
                 decl.mutability(),
-                encode_text(&format!("{}", decl.ty().fmt_with_opts(self.ctx, false))),
+                encode_text(&format!("{}", decl.ty())),
                 LINE_SEPARATOR
             )?;
         }
@@ -171,7 +167,7 @@ impl<'ir> IrGraphWriter<'ir> {
                         for (value, target) in targets.iter() {
                             // We want to create an a constant from this value
                             // with the type, and then print it.
-                            let value = Const::from_scalar(value, targets.ty, self.ctx);
+                            let value = Const::from_scalar(value, targets.ty);
 
                             writeln!(
                                 w,

--- a/compiler/hash-ir/src/write/graphviz.rs
+++ b/compiler/hash-ir/src/write/graphviz.rs
@@ -5,6 +5,8 @@
 //! a visual representation of the IR in formats such as `pdf`, `svg`, `png`,
 //! etc.
 
+// @@Todo: add unit tests for the graph writer.
+
 use std::io;
 
 use html_escape::encode_text;
@@ -12,7 +14,6 @@ use html_escape::encode_text;
 use crate::{
     ir::{BasicBlock, BasicBlockData, Body, BodySource, Const, TerminatorKind},
     write::WriteIr,
-    IrCtx,
 };
 
 /// Used to separate line statements between each declaration within
@@ -20,9 +21,6 @@ use crate::{
 const LINE_SEPARATOR: &str = r#"<br align="left"/>"#;
 
 pub struct IrGraphWriter<'ir> {
-    /// Store that contains all interned data for the IR.
-    ctx: &'ir IrCtx,
-
     /// The body that is being outputted as a graph
     body: &'ir Body,
 
@@ -57,8 +55,8 @@ impl Default for IrGraphOptions {
 }
 
 impl<'ir> IrGraphWriter<'ir> {
-    pub fn new(ctx: &'ir IrCtx, body: &'ir Body, options: IrGraphOptions) -> Self {
-        Self { ctx, body, options }
+    pub fn new(body: &'ir Body, options: IrGraphOptions) -> Self {
+        Self { body, options }
     }
 
     /// Function that writes the body to the appropriate writer.
@@ -255,7 +253,7 @@ impl<'ir> IrGraphWriter<'ir> {
             write!(
                 w,
                 r#"<tr><td align="left" balign="left">{}</td></tr>"#,
-                encode_text(&format!("{}", statement.for_fmt(self.ctx)))
+                encode_text(&format!("{}", statement))
             )?;
         }
 
@@ -264,7 +262,7 @@ impl<'ir> IrGraphWriter<'ir> {
             write!(
                 w,
                 r#"<tr><td align="left">{}</td></tr>"#,
-                encode_text(&format!("{}", terminator.fmt_with_opts(self.ctx, false)))
+                encode_text(&format!("{}", terminator.with_edges(false)))
             )?;
         }
 
@@ -275,7 +273,6 @@ impl<'ir> IrGraphWriter<'ir> {
 
 /// Dump all of the provided [Body]s to standard output using the `dot` format.
 pub fn dump_ir_bodies(
-    ctx: &IrCtx,
     bodies: &[Body],
     dump_all: bool,
     prelude_is_quiet: bool,
@@ -296,7 +293,7 @@ pub fn dump_ir_bodies(
         }
 
         let opts = IrGraphOptions { use_subgraph: Some(id), ..IrGraphOptions::default() };
-        let dumper = IrGraphWriter::new(ctx, body, opts);
+        let dumper = IrGraphWriter::new(body, opts);
         dumper.write_body(writer)?;
     }
 

--- a/compiler/hash-ir/src/write/mod.rs
+++ b/compiler/hash-ir/src/write/mod.rs
@@ -115,7 +115,7 @@ impl fmt::Display for ForFormatting<'_, Operand> {
         match self.item {
             Operand::Place(place) => write!(f, "{}", place.for_fmt(self.ctx)),
             Operand::Const(ConstKind::Value(Const::Zero(ty))) => {
-                write!(f, "{}", ty.for_fmt(self.ctx))
+                write!(f, "{}", ty)
             }
             Operand::Const(const_value) => write!(f, "const {const_value}"),
         }
@@ -141,7 +141,7 @@ impl fmt::Display for ForFormatting<'_, &RValue> {
             RValue::Len(place) => write!(f, "len({})", place.for_fmt(self.ctx)),
             RValue::Cast(_, op, ty) => {
                 // We write out the type fully for the cast.
-                write!(f, "cast({}, {})", ty.fmt_with_opts(self.ctx, true), op.for_fmt(self.ctx))
+                write!(f, "cast({}, {})", ty, op.for_fmt(self.ctx))
             }
             RValue::UnaryOp(op, operand) => {
                 write!(f, "{op:?}({})", operand.for_fmt(self.ctx))
@@ -174,14 +174,13 @@ impl fmt::Display for ForFormatting<'_, &RValue> {
                     AggregateKind::Enum(adt, index) => {
                         self.ctx.adts().map_fast(*adt, |def| {
                             let name = def.variants.get(*index).unwrap().name;
-
-                            write!(f, "{}::{name}", adt.for_fmt(self.ctx))
+                            write!(f, "{}::{name}", adt)
                         })?;
 
                         fmt_operands(f, '(', ')')
                     }
                     AggregateKind::Struct(adt) => {
-                        write!(f, "{}", adt.for_fmt(self.ctx))?;
+                        write!(f, "{}", adt)?;
                         fmt_operands(f, '(', ')')
                     }
                 }
@@ -257,7 +256,7 @@ impl fmt::Display for ForFormatting<'_, &Terminator> {
 
                         // We want to create an a constant from this value
                         // with the type, and then print it.
-                        let value = Const::from_scalar(value, targets.ty, self.ctx);
+                        let value = Const::from_scalar(value, targets.ty);
 
                         write!(f, "{value} -> {target:?}")?;
                     }

--- a/compiler/hash-ir/src/write/mod.rs
+++ b/compiler/hash-ir/src/write/mod.rs
@@ -10,149 +10,126 @@ pub mod pretty;
 
 use std::fmt;
 
-use hash_storage::store::{SequenceStore, Store};
+use hash_storage::store::statics::StoreId;
 
 use super::ir::*;
-use crate::{
-    ty::{AdtId, IrTy, IrTyId, IrTyListId, Mutability},
-    IrCtx,
-};
+use crate::ty::Mutability;
 
 /// Struct that is used to write interned IR components.
-pub struct ForFormatting<'ir, T> {
+pub struct ForFormatting<T> {
     /// The item that is being printed.
     pub item: T,
 
     /// Whether the formatting implementations should write
     /// edges for IR items, this mostly applies to [Terminator]s.
     pub with_edges: bool,
-
-    /// The storage used to print various IR constructs.
-    pub ctx: &'ir IrCtx,
 }
 
 pub trait WriteIr: Sized {
-    fn for_fmt(self, ctx: &IrCtx) -> ForFormatting<Self> {
-        ForFormatting { item: self, ctx, with_edges: true }
-    }
-
-    fn fmt_with_opts(self, ctx: &IrCtx, with_edges: bool) -> ForFormatting<Self> {
-        ForFormatting { item: self, ctx, with_edges }
+    fn with_edges(self, with_edges: bool) -> ForFormatting<Self> {
+        ForFormatting { item: self, with_edges }
     }
 }
 
-impl WriteIr for &IrTy {}
-impl WriteIr for IrTyId {}
-impl WriteIr for IrTyListId {}
-impl WriteIr for AdtId {}
-
-impl WriteIr for Place {}
-
-impl fmt::Debug for ForFormatting<'_, Place> {
+impl fmt::Debug for Place {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.ctx.projections().map_fast(self.item.projections, |projections| {
+        self.projections.map(|projections| {
             f.debug_struct("Place")
-                .field("local", &self.item.local)
+                .field("local", &self.local)
                 .field("projections", &projections)
                 .finish()
         })
     }
 }
 
-impl fmt::Display for ForFormatting<'_, Place> {
+impl fmt::Display for Place {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.ctx.projections().map_fast(self.item.projections, |projections| {
-            // First we, need to deal with the `deref` projections, since
-            // they need to be printed in reverse
-            for projection in projections.iter().rev() {
-                match projection {
-                    PlaceProjection::Downcast(_) | PlaceProjection::Field(_) => write!(f, "(")?,
-                    PlaceProjection::Deref => write!(f, "(*")?,
-                    PlaceProjection::SubSlice { .. }
-                    | PlaceProjection::ConstantIndex { .. }
-                    | PlaceProjection::Index(_) => {}
-                }
+        // First we, need to deal with the `deref` projections, since
+        // they need to be printed in reverse
+        for projection in self.projections.borrow().iter().rev() {
+            match projection {
+                PlaceProjection::Downcast(_) | PlaceProjection::Field(_) => write!(f, "(")?,
+                PlaceProjection::Deref => write!(f, "(*")?,
+                PlaceProjection::SubSlice { .. }
+                | PlaceProjection::ConstantIndex { .. }
+                | PlaceProjection::Index(_) => {}
             }
+        }
 
-            write!(f, "{:?}", self.item.local)?;
+        write!(f, "{:?}", self.local)?;
 
-            for projection in projections.iter() {
-                match projection {
-                    PlaceProjection::Downcast(index) => write!(f, " as variant#{index})")?,
-                    PlaceProjection::Index(local) => write!(f, "[{local:?}]")?,
-                    PlaceProjection::ConstantIndex { offset, min_length, from_end: true } => {
-                        write!(f, "[-{offset:?} of {min_length:?}]")?;
-                    }
-                    PlaceProjection::ConstantIndex { offset, min_length, from_end: false } => {
-                        write!(f, "[{offset:?} of {min_length:?}]")?;
-                    }
-                    PlaceProjection::SubSlice { from, to, from_end: true } if *to == 0 => {
-                        write!(f, "[{from}:]")?;
-                    }
-                    PlaceProjection::SubSlice { from, to, from_end: false } if *from == 0 => {
-                        write!(f, "[:-{to:?}]")?;
-                    }
-                    PlaceProjection::SubSlice { from, to, from_end: true } => {
-                        write!(f, "[{from}:-{to:?}]")?;
-                    }
-                    PlaceProjection::SubSlice { from, to, from_end: false } => {
-                        write!(f, "[{from:?}:{to:?}]")?;
-                    }
-                    PlaceProjection::Field(index) => write!(f, ".{index})")?,
-                    PlaceProjection::Deref => write!(f, ")")?,
+        for projection in self.projections.borrow().iter() {
+            match projection {
+                PlaceProjection::Downcast(index) => write!(f, " as variant#{index})")?,
+                PlaceProjection::Index(local) => write!(f, "[{local:?}]")?,
+                PlaceProjection::ConstantIndex { offset, min_length, from_end: true } => {
+                    write!(f, "[-{offset:?} of {min_length:?}]")?;
                 }
+                PlaceProjection::ConstantIndex { offset, min_length, from_end: false } => {
+                    write!(f, "[{offset:?} of {min_length:?}]")?;
+                }
+                PlaceProjection::SubSlice { from, to, from_end: true } if *to == 0 => {
+                    write!(f, "[{from}:]")?;
+                }
+                PlaceProjection::SubSlice { from, to, from_end: false } if *from == 0 => {
+                    write!(f, "[:-{to:?}]")?;
+                }
+                PlaceProjection::SubSlice { from, to, from_end: true } => {
+                    write!(f, "[{from}:-{to:?}]")?;
+                }
+                PlaceProjection::SubSlice { from, to, from_end: false } => {
+                    write!(f, "[{from:?}:{to:?}]")?;
+                }
+                PlaceProjection::Field(index) => write!(f, ".{index})")?,
+                PlaceProjection::Deref => write!(f, ")")?,
             }
+        }
 
-            Ok(())
-        })
+        Ok(())
     }
 }
 
-impl WriteIr for Operand {}
-
-impl fmt::Display for ForFormatting<'_, Operand> {
+impl fmt::Display for Operand {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.item {
-            Operand::Place(place) => write!(f, "{}", place.for_fmt(self.ctx)),
+        match self {
+            Operand::Place(place) => write!(f, "{place}"),
             Operand::Const(ConstKind::Value(Const::Zero(ty))) => {
-                write!(f, "{}", ty)
+                write!(f, "{ty}")
             }
             Operand::Const(const_value) => write!(f, "const {const_value}"),
         }
     }
 }
 
-impl WriteIr for &RValue {}
-
-impl fmt::Display for ForFormatting<'_, &RValue> {
+impl fmt::Display for &RValue {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.item {
-            RValue::Use(operand) => write!(f, "{}", operand.for_fmt(self.ctx)),
+        match self {
+            RValue::Use(operand) => write!(f, "{}", operand),
             RValue::BinaryOp(op, operands) => {
                 let (lhs, rhs) = operands.as_ref();
 
-                write!(f, "{op:?}({}, {})", lhs.for_fmt(self.ctx), rhs.for_fmt(self.ctx))
+                write!(f, "{op:?}({}, {})", lhs, rhs)
             }
             RValue::CheckedBinaryOp(op, operands) => {
                 let (lhs, rhs) = operands.as_ref();
 
-                write!(f, "Checked{op:?}({}, {})", lhs.for_fmt(self.ctx), rhs.for_fmt(self.ctx))
+                write!(f, "Checked{op:?}({}, {})", lhs, rhs)
             }
-            RValue::Len(place) => write!(f, "len({})", place.for_fmt(self.ctx)),
+            RValue::Len(place) => write!(f, "len({})", place),
             RValue::Cast(_, op, ty) => {
                 // We write out the type fully for the cast.
-                write!(f, "cast({}, {})", ty, op.for_fmt(self.ctx))
+                write!(f, "cast({}, {})", ty, op)
             }
             RValue::UnaryOp(op, operand) => {
-                write!(f, "{op:?}({})", operand.for_fmt(self.ctx))
+                write!(f, "{op:?}({})", operand)
             }
             RValue::ConstOp(op, operand) => write!(f, "{op:?}({operand:?})"),
             RValue::Discriminant(place) => {
-                write!(f, "discriminant({})", place.for_fmt(self.ctx))
+                write!(f, "discriminant({})", place)
             }
             RValue::Ref(mutability, place, kind) => match mutability {
-                Mutability::Mutable => write!(f, "&mut {kind}{}", place.for_fmt(self.ctx)),
-                Mutability::Immutable => write!(f, "&{kind}{}", place.for_fmt(self.ctx)),
+                Mutability::Mutable => write!(f, "&mut {kind}{}", place),
+                Mutability::Immutable => write!(f, "&{kind}{}", place),
             },
             RValue::Aggregate(aggregate_kind, operands) => {
                 let fmt_operands = |f: &mut fmt::Formatter, start: char, end: char| {
@@ -162,7 +139,7 @@ impl fmt::Display for ForFormatting<'_, &RValue> {
                         if i != 0 {
                             write!(f, ", ")?;
                         }
-                        write!(f, "{}", operand.for_fmt(self.ctx))?;
+                        write!(f, "{operand}")?;
                     }
 
                     write!(f, "{end}")
@@ -172,11 +149,8 @@ impl fmt::Display for ForFormatting<'_, &RValue> {
                     AggregateKind::Tuple(_) => fmt_operands(f, '(', ')'),
                     AggregateKind::Array(_) => fmt_operands(f, '[', ']'),
                     AggregateKind::Enum(adt, index) => {
-                        self.ctx.adts().map_fast(*adt, |def| {
-                            let name = def.variants.get(*index).unwrap().name;
-                            write!(f, "{}::{name}", adt)
-                        })?;
-
+                        let name = adt.borrow().variants.get(*index).unwrap().name;
+                        write!(f, "{}::{name}", adt)?;
                         fmt_operands(f, '(', ')')
                     }
                     AggregateKind::Struct(adt) => {
@@ -189,17 +163,15 @@ impl fmt::Display for ForFormatting<'_, &RValue> {
     }
 }
 
-impl WriteIr for &Statement {}
-
-impl fmt::Display for ForFormatting<'_, &Statement> {
+impl fmt::Display for &Statement {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match &self.item.kind {
+        match &self.kind {
             StatementKind::Nop => write!(f, "nop"),
             StatementKind::Assign(place, value) => {
-                write!(f, "{} = {}", place.for_fmt(self.ctx), value.for_fmt(self.ctx))
+                write!(f, "{} = {}", place, value)
             }
             StatementKind::Discriminate(place, index) => {
-                write!(f, "discriminant({}) = {index}", place.for_fmt(self.ctx))
+                write!(f, "discriminant({}) = {index}", place)
             }
             StatementKind::Live(local) => {
                 write!(f, "live({local:?})")
@@ -213,14 +185,14 @@ impl fmt::Display for ForFormatting<'_, &Statement> {
 
 impl WriteIr for &Terminator {}
 
-impl fmt::Display for ForFormatting<'_, &Terminator> {
+impl fmt::Display for ForFormatting<&Terminator> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.item.kind {
             TerminatorKind::Goto(place) if self.with_edges => write!(f, "goto -> {place:?}"),
             TerminatorKind::Goto(_) => write!(f, "goto"),
             TerminatorKind::Return => write!(f, "return"),
             TerminatorKind::Call { op, args, target, destination } => {
-                write!(f, "{} = {}(", destination.for_fmt(self.ctx), op.for_fmt(self.ctx))?;
+                write!(f, "{} = {}(", destination, op)?;
 
                 // write all of the arguments
                 for (i, arg) in args.iter().enumerate() {
@@ -228,7 +200,7 @@ impl fmt::Display for ForFormatting<'_, &Terminator> {
                         write!(f, ", ")?;
                     }
 
-                    write!(f, "{}", arg.for_fmt(self.ctx))?;
+                    write!(f, "{arg}")?;
                 }
 
                 // Only print the target if there is a target, and if the formatting
@@ -241,7 +213,7 @@ impl fmt::Display for ForFormatting<'_, &Terminator> {
             }
             TerminatorKind::Unreachable => write!(f, "unreachable"),
             TerminatorKind::Switch { value, targets } => {
-                write!(f, "switch({})", value.for_fmt(self.ctx))?;
+                write!(f, "switch({value})")?;
 
                 if self.with_edges {
                     write!(f, " [")?;
@@ -270,12 +242,7 @@ impl fmt::Display for ForFormatting<'_, &Terminator> {
                 Ok(())
             }
             TerminatorKind::Assert { condition, expected, kind, target } => {
-                write!(
-                    f,
-                    "assert({}, {expected:?}, \"{}\")",
-                    condition.for_fmt(self.ctx),
-                    kind.for_fmt(self.ctx)
-                )?;
+                write!(f, "assert({condition}, {expected:?}, \"{kind}\")")?;
 
                 if self.with_edges {
                     write!(f, " -> {target:?}")?;
@@ -287,35 +254,24 @@ impl fmt::Display for ForFormatting<'_, &Terminator> {
     }
 }
 
-impl WriteIr for &AssertKind {}
-
-impl fmt::Display for ForFormatting<'_, &AssertKind> {
+impl fmt::Display for &AssertKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.item {
+        match self {
             AssertKind::DivisionByZero { operand } => {
-                write!(f, "attempt to divide `{}` by zero", operand.for_fmt(self.ctx))
+                write!(f, "attempt to divide `{operand}` by zero")
             }
-            AssertKind::RemainderByZero { operand } => write!(
-                f,
-                "attempt to take the remainder of `{}` by zero",
-                operand.for_fmt(self.ctx)
-            ),
-            AssertKind::Overflow { op, lhs, rhs } => write!(
-                f,
-                "attempt to compute `{lhs} {op} {rhs}`, which would overflow",
-                op = op,
-                lhs = lhs.for_fmt(self.ctx),
-                rhs = rhs.for_fmt(self.ctx)
-            ),
+            AssertKind::RemainderByZero { operand } => {
+                write!(f, "attempt to take the remainder of `{operand}` by zero")
+            }
+            AssertKind::Overflow { op, lhs, rhs } => {
+                write!(f, "attempt to compute `{lhs} {op} {rhs}`, which would overflow",)
+            }
             AssertKind::NegativeOverflow { operand } => {
-                write!(f, "attempt to negate `{}`, which would overflow", operand.for_fmt(self.ctx))
+                write!(f, "attempt to negate `{operand}`, which would overflow")
             }
-            AssertKind::BoundsCheck { len, index } => write!(
-                f,
-                "index out of bounds: the length is `{}` but index is `{}`",
-                len.for_fmt(self.ctx),
-                index.for_fmt(self.ctx)
-            ),
+            AssertKind::BoundsCheck { len, index } => {
+                write!(f, "index out of bounds: the length is `{len}` but index is `{index}`",)
+            }
         }
     }
 }

--- a/compiler/hash-ir/src/write/pretty.rs
+++ b/compiler/hash-ir/src/write/pretty.rs
@@ -61,9 +61,9 @@ impl<'ir> IrBodyWriter<'ir> {
 
                     // We add 1 to the index because the return type is always
                     // located at `0`.
-                    write!(f, "_{}: {}", i + 1, param.ty().for_fmt(self.ctx))?;
+                    write!(f, "_{}: {}", i + 1, param.ty())?;
                 }
-                writeln!(f, ") -> {} {{", return_ty_decl.ty().for_fmt(self.ctx))?;
+                writeln!(f, ") -> {} {{", return_ty_decl.ty())?;
             }
             BodySource::Const => {
                 writeln!(f, "const {} {{", self.body.info().name)?;
@@ -71,12 +71,7 @@ impl<'ir> IrBodyWriter<'ir> {
         }
 
         // Print the return place declaration
-        writeln!(
-            f,
-            "    {}_0: {};",
-            return_ty_decl.mutability(),
-            return_ty_decl.ty().for_fmt(self.ctx)
-        )
+        writeln!(f, "    {}_0: {};", return_ty_decl.mutability(), return_ty_decl.ty())
     }
 
     /// Write the body to the given formatter.
@@ -110,7 +105,7 @@ impl<'ir> IrBodyWriter<'ir> {
         let mut longest_line = 0;
         let rendered_declarations = declarations
             .map(|(local, decl)| {
-                let s = format!("{}{local:?}: {};", decl.mutability(), decl.ty().for_fmt(self.ctx));
+                let s = format!("{}{local:?}: {};", decl.mutability(), decl.ty());
 
                 if let Some(name) = decl.name && !decl.auxiliary() {
                 longest_line = longest_line.max(s.len());

--- a/compiler/hash-ir/src/write/pretty.rs
+++ b/compiler/hash-ir/src/write/pretty.rs
@@ -6,10 +6,7 @@ use hash_source::SourceMap;
 use hash_utils::itertools::Itertools;
 
 use super::WriteIr;
-use crate::{
-    ir::{BasicBlock, Body, BodySource},
-    IrCtx,
-};
+use crate::ir::{BasicBlock, Body, BodySource};
 
 /// [IrBodyWriter] is used to encapsulate the logic of pretty-printing a
 /// [Body] to a [fmt::Formatter]. The [IrBodyWriter] is uses the standalone
@@ -17,17 +14,14 @@ use crate::{
 /// formatting, and additional information about the IR in the style of comments
 /// on each IR line (if additional information exists).
 pub struct IrBodyWriter<'ir> {
-    /// The type context allowing for printing any additional
-    /// metadata about types within the ir.
-    ctx: &'ir IrCtx,
     /// The body that is being printed
     body: &'ir Body,
 }
 
 impl<'ir> IrBodyWriter<'ir> {
     /// Create a new IR writer for the given body.
-    pub fn new(ctx: &'ir IrCtx, body: &'ir Body) -> Self {
-        Self { ctx, body }
+    pub fn new(body: &'ir Body) -> Self {
+        Self { body }
     }
 
     /// Function to deal with a [Body] header which is formatted depending on
@@ -141,13 +135,13 @@ impl<'ir> IrBodyWriter<'ir> {
 
         // Write all of the statements within the block
         for statement in &block_data.statements {
-            writeln!(f, "{: <2$}{};", "", statement.for_fmt(self.ctx), 8)?;
+            writeln!(f, "{: <2$}{};", "", statement, 8)?;
         }
 
         // Write the terminator of the block. If the terminator is
         // not present, this is an invariant but we don't care here.
         if let Some(terminator) = &block_data.terminator {
-            writeln!(f, "{: <2$}{};", "", terminator.fmt_with_opts(self.ctx, true), 8)?;
+            writeln!(f, "{: <2$}{};", "", terminator.with_edges(true), 8)?;
         }
 
         writeln!(f, "{: <1$}}}", "", 4)
@@ -162,7 +156,6 @@ impl fmt::Display for IrBodyWriter<'_> {
 
 /// Dump all of the provided [Body]s to standard output using the `dot` format.
 pub fn dump_ir_bodies(
-    ctx: &IrCtx,
     source_map: &SourceMap,
     bodies: &[Body],
     dump_all: bool,
@@ -192,7 +185,7 @@ pub fn dump_ir_bodies(
             body.info().source(),
             body.info().name(),
             source_map.fmt_location(body.location()),
-            IrBodyWriter::new(ctx, body)
+            IrBodyWriter::new(body)
         )?;
     }
 

--- a/compiler/hash-layout/src/compute.rs
+++ b/compiler/hash-layout/src/compute.rs
@@ -9,7 +9,7 @@ use hash_ir::{
     ty::{AdtData, AdtRepresentation, IrTy, IrTyId, Mutability, RefKind, VariantIdx},
     IrCtx,
 };
-use hash_storage::store::{CloneStore, Store, StoreInternalData};
+use hash_storage::store::{statics::StoreId, CloneStore, Store, StoreInternalData};
 use hash_target::{
     abi::{AbiRepresentation, AddressSpace, Integer, Scalar, ScalarKind, ValidScalarRange},
     alignment::{Alignment, Alignments},
@@ -250,7 +250,7 @@ impl<'l> LayoutComputer<'l> {
                 }))
             }
             IrTy::Array { ty, length: size } => self.compute_layout_of_array(*ty, *size as u64),
-            IrTy::Adt(adt) => self.ir_ctx.map_adt(*adt, |_id, adt| -> Result<_, LayoutError> {
+            IrTy::Adt(adt) => adt.map(|adt| -> Result<_, LayoutError> {
                 // We have to compute the layouts of all of the variants
                 // and all of the fields of the variants
                 let field_layout_table = adt

--- a/compiler/hash-layout/src/compute.rs
+++ b/compiler/hash-layout/src/compute.rs
@@ -170,7 +170,7 @@ impl<'l> LayoutComputer<'l> {
             return Ok(layout);
         }
 
-        let layout = self.ir_ctx.map_ty(ty_id, |ty| match ty {
+        let layout = ty_id.map(|ty| match ty {
             IrTy::Int(ty) => match ty {
                 SIntTy::I8 => Ok(self.common_layouts().i8),
                 SIntTy::I16 => Ok(self.common_layouts().i16),
@@ -210,7 +210,7 @@ impl<'l> LayoutComputer<'l> {
                 }
 
                 // Compute any metadata if we need to.
-                let maybe_metadata = self.ir_ctx().map_ty(*pointee, |ty| match ty {
+                let maybe_metadata = pointee.map(|ty| match ty {
                     IrTy::Str | IrTy::Slice(_) => Some(scalar_unit(ScalarKind::Int {
                         kind: dl.ptr_sized_integer(),
                         signed: false,
@@ -996,7 +996,7 @@ impl<'l> LayoutComputer<'l> {
             return *pointee_info;
         }
 
-        let result = self.ir_ctx().map_ty(info.ty, |ty| match ty {
+        let result = info.ty.map(|ty| match ty {
             IrTy::Fn { .. } if offset == Size::ZERO => {
                 let (size, alignment) = self
                     .layouts()

--- a/compiler/hash-layout/src/compute.rs
+++ b/compiler/hash-layout/src/compute.rs
@@ -6,7 +6,7 @@
 use std::{cmp, iter, num::NonZeroUsize};
 
 use hash_ir::{
-    ty::{AdtData, AdtRepresentation, IrTy, IrTyId, Mutability, RefKind, VariantIdx},
+    ty::{Adt, AdtRepresentation, IrTy, IrTyId, Mutability, RefKind, VariantIdx},
     IrCtx,
 };
 use hash_storage::store::{statics::StoreId, CloneStore, Store, StoreInternalData};
@@ -572,7 +572,7 @@ impl<'l> LayoutComputer<'l> {
     fn compute_layout_of_union(
         &self,
         field_layout_table: IndexVec<VariantIdx, Vec<LayoutId>>,
-        data: &AdtData,
+        data: &Adt,
     ) -> Option<Layout> {
         debug_assert!(data.flags.is_union());
 
@@ -652,7 +652,7 @@ impl<'l> LayoutComputer<'l> {
     fn compute_layout_of_enum(
         &self,
         field_layout_table: IndexVec<VariantIdx, Vec<LayoutId>>,
-        adt: &AdtData,
+        adt: &Adt,
     ) -> Option<Layout> {
         debug_assert!(adt.flags.is_enum());
         let dl = self.data_layout();

--- a/compiler/hash-layout/src/compute.rs
+++ b/compiler/hash-layout/src/compute.rs
@@ -5,10 +5,7 @@
 
 use std::{cmp, iter, num::NonZeroUsize};
 
-use hash_ir::{
-    ty::{Adt, AdtRepresentation, IrTy, IrTyId, Mutability, RefKind, VariantIdx},
-    IrCtx,
-};
+use hash_ir::ty::{Adt, AdtRepresentation, IrTy, IrTyId, Mutability, RefKind, VariantIdx};
 use hash_storage::store::{statics::StoreId, CloneStore, Store, StoreInternalData};
 use hash_target::{
     abi::{AbiRepresentation, AddressSpace, Integer, Scalar, ScalarKind, ValidScalarRange},
@@ -115,9 +112,6 @@ fn invert_memory_mapping(mapping: &[u32]) -> Vec<u32> {
 pub struct LayoutComputer<'l> {
     /// A reference tot the [LayoutCtx].
     layout_ctx: &'l LayoutCtx,
-
-    /// A reference to the [IrCtx].
-    ir_ctx: &'l IrCtx,
 }
 
 impl Store<LayoutId, Layout> for LayoutComputer<'_> {
@@ -128,8 +122,8 @@ impl Store<LayoutId, Layout> for LayoutComputer<'_> {
 
 impl<'l> LayoutComputer<'l> {
     /// Create a new [LayoutCtx].
-    pub fn new(layout_store: &'l LayoutCtx, ir_ctx: &'l IrCtx) -> Self {
-        Self { layout_ctx: layout_store, ir_ctx }
+    pub fn new(layout_store: &'l LayoutCtx) -> Self {
+        Self { layout_ctx: layout_store }
     }
 
     /// Returns a reference to the [LayoutCtx].
@@ -147,11 +141,6 @@ impl<'l> LayoutComputer<'l> {
     /// in the current session.
     pub(crate) fn common_layouts(&self) -> &CommonLayouts {
         &self.layout_ctx.common_layouts
-    }
-
-    /// Returns a reference to the [IrCtx].
-    pub fn ir_ctx(&self) -> &IrCtx {
-        self.ir_ctx
     }
 
     /// This is the entry point of the layout computation engine. From

--- a/compiler/hash-layout/src/lib.rs
+++ b/compiler/hash-layout/src/lib.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use compute::LayoutComputer;
-use hash_ir::ty::{IrTy, IrTyId, ToIrTy, VariantIdx};
+use hash_ir::ty::{IrTy, IrTyId, ToIrTy, VariantIdx, COMMON_IR_TYS};
 use hash_storage::{
     new_store_key,
     store::{statics::StoreId, CloneStore, DefaultStore, FxHashMap, Store, StoreInternalData},
@@ -236,26 +236,26 @@ impl TyInfo {
             IrTy::Ref(pointee, _, _) => {
                 // We just create a `void*` pointer...
                 if field_index == 0 {
-                    return ctx.ir_ctx().common_tys.void_ptr;
+                    return COMMON_IR_TYS.void_ptr;
                 }
 
                 // Deal with loading metadata for the pointer, for now it is either a slice
                 // or a string which only contain the length of the data.
                 pointee.map(|ty| match ty {
-                    IrTy::Str | IrTy::Slice(_) => ctx.ir_ctx().common_tys.usize,
+                    IrTy::Str | IrTy::Slice(_) => COMMON_IR_TYS.usize,
                     ty => {
                         unreachable!("TyInfo::field cannot read metadata for pointer type `{ty:?}`")
                     }
                 })
             }
 
-            IrTy::Str => ctx.ir_ctx().common_tys.u8,
+            IrTy::Str => COMMON_IR_TYS.u8,
             IrTy::Slice(element) | IrTy::Array { ty: element, .. } => *element,
             IrTy::Adt(id) => match layout.variants {
                 Variants::Single { index } => {
                     id.map(|adt| adt.variants[index].fields[field_index].ty)
                 }
-                Variants::Multiple { tag, .. } => tag.kind().to_ir_ty(ctx.ir_ctx()),
+                Variants::Multiple { tag, .. } => tag.kind().to_ir_ty(),
             },
         });
 

--- a/compiler/hash-layout/src/lib.rs
+++ b/compiler/hash-layout/src/lib.rs
@@ -213,9 +213,7 @@ impl TyInfo {
     where
         F: FnOnce(&Self, &IrTy, &Layout) -> T,
     {
-        ctx.ir_ctx()
-            .tys()
-            .map_fast(self.ty, |ty| ctx.map_fast(self.layout, |layout| f(self, ty, layout)))
+        self.ty.map(|ty| ctx.map(self.layout, |layout| f(self, ty, layout)))
     }
 
     /// Compute the type of a "field with in a layout" and return the
@@ -289,7 +287,7 @@ impl TyInfo {
                 self.layout
             }
             Variants::Single { .. } => {
-                let adt = ctx.ir_ctx().tys().get(self.ty).as_adt();
+                let adt = self.ty.borrow().as_adt();
                 let fields = adt.map(|adt| {
                     if adt.variants.is_empty() {
                         panic!("layout::for_variant called on a zero-variant enum")

--- a/compiler/hash-layout/src/write.rs
+++ b/compiler/hash-layout/src/write.rs
@@ -28,7 +28,7 @@ use hash_ir::{
     ty::{IrTy, VariantIdx},
     write::WriteIr,
 };
-use hash_storage::store::Store;
+use hash_storage::store::{statics::StoreId, Store};
 use hash_target::{abi::AbiRepresentation, size::Size};
 use hash_utils::tree_writing::CharacterSet;
 
@@ -685,7 +685,7 @@ impl<'l> LayoutWriter<'l> {
                 // on the type that is being stored.
                 let field_titles = match (layout.abi, ty) {
                     (_, IrTy::Adt(adt)) => {
-                        self.ctx.ir_ctx().map_adt(*adt, |_, adt| {
+                        adt.map(|adt| {
                             // we load in the variant that is specified in the
                             // "layouts" of the type.
                             let variant = match layout.variants {

--- a/compiler/hash-lower/src/build/into.rs
+++ b/compiler/hash-lower/src/build/into.rs
@@ -633,7 +633,7 @@ impl<'tcx> BodyBuilder<'tcx> {
         //
         // Make the call to `malloc`, and then assign the result to a
         // temporary.
-        let ptr = self.temp_place(self.ctx().tys().common_tys.raw_ptr);
+        let ptr = self.temp_place(self.ctx().common_tys.raw_ptr);
         unpack!(block = self.build_fn_call(ptr, block, subject, vec![size_op], span));
 
         // we make a new temporary which is a pointer to the array and assign `ptr`
@@ -668,8 +668,8 @@ impl<'tcx> BodyBuilder<'tcx> {
                 subject,
                 // The first two arguments are the fill-ins for the generic parameters.
                 vec![
-                    Operand::Const(Const::Zero(self.ctx().tys().common_tys.unit).into()),
-                    Operand::Const(Const::Zero(self.ctx().tys().common_tys.unit).into()),
+                    Operand::Const(Const::Zero(self.ctx().common_tys.unit).into()),
+                    Operand::Const(Const::Zero(self.ctx().common_tys.unit).into()),
                     Operand::Place(sized_ptr)
                 ],
                 span

--- a/compiler/hash-lower/src/build/into.rs
+++ b/compiler/hash-lower/src/build/into.rs
@@ -53,7 +53,7 @@ impl<'tcx> BodyBuilder<'tcx> {
 
             Term::Tuple(TupleTerm { data }) => {
                 let ty = self.ty_id_from_tir_term(term);
-                let adt = self.ctx().map_ty_as_adt(ty, |_, id| id);
+                let adt = self.ctx().tys().borrow(ty).as_adt();
                 let aggregate_kind = AggregateKind::Tuple(adt);
 
                 let args = data

--- a/compiler/hash-lower/src/build/into.rs
+++ b/compiler/hash-lower/src/build/into.rs
@@ -9,11 +9,11 @@ use hash_ir::{
         self, AggregateKind, BasicBlock, Const, LogicalBinOp, Operand, Place, RValue, Statement,
         StatementKind, TerminatorKind,
     },
-    ty::{AdtId, IrTy, Mutability, RefKind, VariantIdx},
+    ty::{AdtId, IrTy, IrTyId, Mutability, RefKind, VariantIdx},
 };
 use hash_reporting::macros::panic_on_span;
 use hash_source::{constant::CONSTANT_MAP, identifier::Identifier, location::Span};
-use hash_storage::store::{statics::StoreId, CloneStore, SequenceStoreKey, Store};
+use hash_storage::store::{statics::StoreId, SequenceStoreKey};
 use hash_tir::{
     args::ArgsId,
     arrays::ArrayTerm,
@@ -53,7 +53,7 @@ impl<'tcx> BodyBuilder<'tcx> {
 
             Term::Tuple(TupleTerm { data }) => {
                 let ty = self.ty_id_from_tir_term(term);
-                let adt = self.ctx().tys().borrow(ty).as_adt();
+                let adt = ty.borrow().as_adt();
                 let aggregate_kind = AggregateKind::Tuple(adt);
 
                 let args = data
@@ -80,10 +80,9 @@ impl<'tcx> BodyBuilder<'tcx> {
             }
             Term::Array(ArrayTerm { elements }) => {
                 // We lower literal arrays and tuples as aggregates.
-                let ty_id = self.ty_id_from_tir_term(term);
-                let ty = self.ctx().tys().get(ty_id);
+                let ty = self.ty_id_from_tir_term(term);
 
-                let aggregate_kind = AggregateKind::Array(ty_id);
+                let aggregate_kind = AggregateKind::Array(ty);
                 let args = elements
                     .borrow()
                     .iter()
@@ -93,11 +92,11 @@ impl<'tcx> BodyBuilder<'tcx> {
                     .collect_vec();
 
                 // If it is a list, we have to initialise it with the array elements...
-                if !ty.is_array() {
+                if !ty.borrow().is_array() {
                     self.lower_list_initialisation(
                         destination,
                         block,
-                        &ty,
+                        ty,
                         aggregate_kind,
                         &args,
                         span,
@@ -108,32 +107,21 @@ impl<'tcx> BodyBuilder<'tcx> {
             }
 
             Term::Ctor(ref ctor) => {
-                let id = self.ty_id_from_tir_term(term);
-                let ty = self.ctx().tys().get(id);
+                let ty = self.ty_id_from_tir_term(term);
 
-                match ty {
-                    IrTy::Adt(adt) => {
-                        // This is a constructor call, so we need to handle it as such.
-                        self.constructor_into_dest(destination, block, ctor, adt, span)
-                    }
-                    IrTy::Bool => {
-                        // @@Hack: check which constructor is being called to determine whether
-                        // it is a `true` or `false` value.
-                        let constant =
-                            if ctor.ctor.1 == 0 { Const::Bool(true) } else { Const::Bool(false) };
+                if ty == self.ctx().common_tys.bool {
+                    // @@Hack: check which constructor is being called to determine whether
+                    // it is a `true` or `false` value.
+                    let constant =
+                        if ctor.ctor.1 == 0 { Const::Bool(true) } else { Const::Bool(false) };
 
-                        self.control_flow_graph.push_assign(
-                            block,
-                            destination,
-                            constant.into(),
-                            span,
-                        );
+                    self.control_flow_graph.push_assign(block, destination, constant.into(), span);
 
-                        block.unit()
-                    }
-                    _ => {
-                        panic!("Expected an ADT type for the constructor");
-                    }
+                    block.unit()
+                } else {
+                    let adt = ty.borrow().as_adt();
+                    // This is a constructor call, so we need to handle it as such.
+                    self.constructor_into_dest(destination, block, ctor, adt, span)
                 }
             }
             Term::FnCall(ref fn_term @ FnCallTerm { subject, args, .. }) => {
@@ -244,7 +232,7 @@ impl<'tcx> BodyBuilder<'tcx> {
             }
             Term::Var(symbol) => {
                 let local = self.lookup_local(symbol).unwrap();
-                let place = Place::from_local(local, self.ctx());
+                let place = Place::from_local(local);
                 self.control_flow_graph.push_assign(block, destination, place.into(), span);
 
                 block.unit()
@@ -277,9 +265,7 @@ impl<'tcx> BodyBuilder<'tcx> {
                 block.unit()
             }
             Term::Return(ReturnTerm { expression }) => {
-                unpack!(
-                    block = self.term_into_dest(Place::return_place(self.ctx()), block, expression)
-                );
+                unpack!(block = self.term_into_dest(Place::return_place(), block, expression));
 
                 // In either case, we want to mark that the function has reached the
                 // **terminating** statement of this block and we needn't continue looking
@@ -442,7 +428,7 @@ impl<'tcx> BodyBuilder<'tcx> {
     ) -> BlockAnd<()> {
         let CtorTerm { ctor, ctor_args, .. } = subject;
 
-        let aggregate_kind = self.ctx().adts().map_fast(adt_id, |adt| {
+        let aggregate_kind = adt_id.map(|adt| {
             if adt.flags.is_enum() || adt.flags.is_union() {
                 AggregateKind::Enum(adt_id, VariantIdx::from_usize(ctor.1))
             } else {
@@ -496,7 +482,7 @@ impl<'tcx> BodyBuilder<'tcx> {
         // We don't need to perform this check for arrays since they don't need
         // to have a specific amount of arguments to the constructor.
         let fields: Vec<_> = if aggregate_kind.is_adt() {
-            let adt_id = aggregate_kind.adt_id();
+            let adt = aggregate_kind.adt_id();
 
             // We have to evaluate each field in the specified source
             // order despite the aggregate potentially having a different
@@ -517,7 +503,7 @@ impl<'tcx> BodyBuilder<'tcx> {
                 field_names.push(*name);
             }
 
-            self.ctx().adts().map_fast(adt_id, |adt| {
+            adt.map(|adt| {
                 let variant = if let AggregateKind::Enum(_, index) = aggregate_kind {
                     &adt.variants[index]
                 } else {
@@ -613,13 +599,13 @@ impl<'tcx> BodyBuilder<'tcx> {
         &mut self,
         destination: Place,
         mut block: BasicBlock,
-        ty: &IrTy,
+        ty: IrTyId,
         aggregate_kind: AggregateKind,
         args: &[(Identifier, TermId)],
         span: Span,
     ) -> BlockAnd<()> {
         let ptr_width = self.settings.target().ptr_size();
-        let element_ty = ty.element_ty(self.ctx()).unwrap();
+        let element_ty = ty.borrow().element_ty().unwrap();
         let size = self.ctx.size_of(element_ty).unwrap() * args.len();
         let const_size = CONSTANT_MAP.create_usize_int(size, ptr_width);
         let size_op = Operand::Const(Const::Int(const_size).into());
@@ -638,12 +624,16 @@ impl<'tcx> BodyBuilder<'tcx> {
 
         // we make a new temporary which is a pointer to the array and assign `ptr`
         // to it.
-        let ty = IrTy::make_ref(IrTy::Array { ty: element_ty, length: args.len() }, self.ctx());
-        let array_ptr = self.temp_place(self.ctx().tys().create(ty));
+        let ty = IrTy::make_ref(
+            IrTy::Array { ty: element_ty, length: args.len() },
+            Mutability::Immutable,
+            RefKind::Normal,
+        );
+        let array_ptr = self.temp_place(ty);
         self.control_flow_graph.push_assign(block, array_ptr, Operand::Place(ptr).into(), span);
 
         // 2). Write data to allocation.
-        self.aggregate_into_dest(array_ptr.deref(self.ctx()), block, aggregate_kind, args, span);
+        self.aggregate_into_dest(array_ptr.deref(), block, aggregate_kind, args, span);
 
         // 3).
         //

--- a/compiler/hash-lower/src/build/matches/candidate.rs
+++ b/compiler/hash-lower/src/build/matches/candidate.rs
@@ -19,7 +19,7 @@ use hash_ir::{
     ty::{AdtId, IrTy, Mutability},
 };
 use hash_source::location::Span;
-use hash_storage::store::{statics::StoreId, CloneStore, Store};
+use hash_storage::store::statics::StoreId;
 use hash_target::size::Size;
 use hash_tir::{
     args::PatArgsId,
@@ -281,7 +281,7 @@ impl<'tcx> BodyBuilder<'tcx> {
                     } else {
                         Mutability::Immutable
                     },
-                    source: pair.place.into_place(self.ctx()),
+                    source: pair.place.into_place(),
                     name,
 
                     // @@Todo: introduce a way of specifying what the binding
@@ -302,14 +302,13 @@ impl<'tcx> BodyBuilder<'tcx> {
 
                 // get the range and bias of this range pattern from
                 // the `lo`
-                let id = self.ty_id_from_tir_ty(self.get_inferred_ty(pair.pat));
-                let range_ty = self.ctx().tys().get(id);
+                let range_ty = self.ty_id_from_tir_ty(self.get_inferred_ty(pair.pat));
 
                 // The range is the minimum value, maximum value, and the size of
                 // the item that is being compared.
                 //
                 // @@Todo: deal with big-ints
-                let (range, bias) = match range_ty {
+                let (range, bias) = match range_ty.value() {
                     IrTy::Char => {
                         (Some(('\u{0000}' as u128, '\u{10FFFF}' as u128, Size::from_bytes(4))), 0)
                     }
@@ -426,10 +425,10 @@ impl<'tcx> BodyBuilder<'tcx> {
     fn match_pat_fields(
         &mut self,
         pat_args: PatArgsId,
-        ty: AdtId,
+        adt: AdtId,
         place: PlaceBuilder,
     ) -> Vec<MatchPair> {
-        self.ctx().adts().map_fast(ty, |adt| {
+        adt.map(|adt| {
             debug_assert!(adt.flags.is_struct() || adt.flags.is_tuple());
             let variant = adt.variants.first().unwrap();
 

--- a/compiler/hash-lower/src/build/matches/candidate.rs
+++ b/compiler/hash-lower/src/build/matches/candidate.rs
@@ -354,7 +354,7 @@ impl<'tcx> BodyBuilder<'tcx> {
                 // get the type of the tuple so that we can read all of the
                 // fields
                 let ty = self.ty_id_from_tir_pat(pair.pat);
-                let adt = self.ctx().map_ty(ty, IrTy::as_adt);
+                let adt = ty.borrow().as_adt();
 
                 candidate.pairs.extend(self.match_pat_fields(data, adt, pair.place));
                 Ok(())
@@ -363,9 +363,9 @@ impl<'tcx> BodyBuilder<'tcx> {
                 let ty = self.ty_id_from_tir_pat(pair.pat);
 
                 // If the type is a boolean, then we can't simplify this pattern any further...
-                let adt = self.ctx().map_ty(ty, |ty| match ty {
+                let adt = ty.map(|ty| match ty {
                     IrTy::Bool => None,
-                    IrTy::Adt(id) => id.map(|adt| adt.flags.is_struct().then_some(*id)),
+                    IrTy::Adt(id) => (*id).borrow().flags.is_struct().then_some(*id),
                     ty => panic!("unexpected type: {ty:?}"),
                 });
 

--- a/compiler/hash-lower/src/build/matches/candidate.rs
+++ b/compiler/hash-lower/src/build/matches/candidate.rs
@@ -365,9 +365,7 @@ impl<'tcx> BodyBuilder<'tcx> {
                 // If the type is a boolean, then we can't simplify this pattern any further...
                 let adt = self.ctx().map_ty(ty, |ty| match ty {
                     IrTy::Bool => None,
-                    IrTy::Adt(id) => {
-                        self.ctx().map_adt(*id, |id, adt| adt.flags.is_struct().then_some(id))
-                    }
+                    IrTy::Adt(id) => id.map(|adt| adt.flags.is_struct().then_some(*id)),
                     ty => panic!("unexpected type: {ty:?}"),
                 });
 

--- a/compiler/hash-lower/src/build/matches/const_range.rs
+++ b/compiler/hash-lower/src/build/matches/const_range.rs
@@ -6,7 +6,7 @@ use std::cmp::Ordering;
 use hash_ast::ast;
 use hash_ir::{
     ir::{compare_constant_values, Const},
-    ty::IrTy,
+    ty::IrTyId,
 };
 use hash_tir::pats::RangePat;
 
@@ -30,12 +30,12 @@ pub(super) struct ConstRange {
 
     /// The type of the range. This is stored for convience when computing
     /// the range.
-    pub ty: IrTy,
+    pub ty: IrTyId,
 }
 
 impl ConstRange {
     /// Create a [ConstRange] from [RangePat].
-    pub fn from_range(range: &RangePat, ty: IrTy, builder: &BodyBuilder) -> Self {
+    pub fn from_range(range: &RangePat, ty: IrTyId, builder: &BodyBuilder) -> Self {
         let (lo, _) = builder.evaluate_range_lit(range.lo, ty, false);
         let (hi, _) = builder.evaluate_range_lit(range.hi, ty, true);
 

--- a/compiler/hash-lower/src/build/matches/declarations.rs
+++ b/compiler/hash-lower/src/build/matches/declarations.rs
@@ -198,7 +198,7 @@ impl<'tcx> BodyBuilder<'tcx> {
                 // we lookup the local from the current scope, and get the place of where
                 // to place this value.
                 if let Some(local) = self.lookup_local(name) {
-                    let place = Place::from_local(local, self.ctx());
+                    let place = Place::from_local(local);
 
                     unpack!(block = self.term_into_dest(place, block, term));
                     block.unit()

--- a/compiler/hash-lower/src/build/matches/mod.rs
+++ b/compiler/hash-lower/src/build/matches/mod.rs
@@ -676,8 +676,7 @@ impl<'tcx> BodyBuilder<'tcx> {
         // to avoid problems of mutation in the if-guard, and then affecting the
         // soundness of later match checks.
         for binding in bindings {
-            let value_place =
-                Place::from_local(self.lookup_local(binding.name).unwrap(), self.ctx());
+            let value_place = Place::from_local(self.lookup_local(binding.name).unwrap());
 
             // @@Todo: we might have to do some special rules for the `by-ref` case
             //         when we start to think about reference rules more concretely.
@@ -708,8 +707,7 @@ impl<'tcx> BodyBuilder<'tcx> {
 
             // Now resolve where the binding place from, and then push
             // an assign onto the binding source.
-            let value_place =
-                Place::from_local(self.lookup_local(binding.name).unwrap(), self.ctx());
+            let value_place = Place::from_local(self.lookup_local(binding.name).unwrap());
 
             self.control_flow_graph.push_assign(block, value_place, rvalue, binding.span);
         }

--- a/compiler/hash-lower/src/build/matches/mod.rs
+++ b/compiler/hash-lower/src/build/matches/mod.rs
@@ -512,7 +512,7 @@ impl<'tcx> BodyBuilder<'tcx> {
 
         // we know the exact size of the targets, so we can pre-allocate
         // the size we need
-        target_table.resize_with(test.targets(self.ctx()), Default::default);
+        target_table.resize_with(test.targets(), Default::default);
 
         let candidate_count = candidates.len();
 

--- a/compiler/hash-lower/src/build/matches/mod.rs
+++ b/compiler/hash-lower/src/build/matches/mod.rs
@@ -120,7 +120,7 @@ impl<'tcx> BodyBuilder<'tcx> {
         let place = unpack!(block = self.as_place(block, expr, Mutability::Mutable));
         let then_block = self.control_flow_graph.start_new_block();
 
-        let terminator = TerminatorKind::make_if(place.into(), then_block, else_block, self.ctx());
+        let terminator = TerminatorKind::make_if(place.into(), then_block, else_block);
         self.control_flow_graph.terminate(block, span, terminator);
 
         then_block.unit()

--- a/compiler/hash-lower/src/build/matches/optimise.rs
+++ b/compiler/hash-lower/src/build/matches/optimise.rs
@@ -9,6 +9,7 @@ use hash_ir::{
     ty::{IrTy, IrTyId},
 };
 use hash_source::location::Span;
+use hash_storage::store::statics::StoreId;
 use hash_tir::pats::{PatId, Spread};
 use hash_utils::smallvec::SmallVec;
 
@@ -64,7 +65,7 @@ impl<'tcx> BodyBuilder<'tcx> {
         rest: Option<Spread>,
         suffix: &[PatId],
     ) {
-        let (min_length, exact_size) = self.ctx().map_ty(ty, |ty| match ty {
+        let (min_length, exact_size) = ty.map(|ty| match ty {
             IrTy::Array { length: size, .. } => (*size, true),
             _ => (prefix.len() + suffix.len(), false),
         });

--- a/compiler/hash-lower/src/build/matches/test.rs
+++ b/compiler/hash-lower/src/build/matches/test.rs
@@ -11,7 +11,7 @@ use hash_ir::{
     ir::{
         BasicBlock, BinOp, Const, Operand, PlaceProjection, RValue, SwitchTargets, TerminatorKind,
     },
-    ty::{AdtId, IrTy, IrTyId, ToIrTy, VariantIdx},
+    ty::{AdtId, IrTy, IrTyId, ToIrTy, VariantIdx, COMMON_IR_TYS},
 };
 use hash_reporting::macros::panic_on_span;
 use hash_source::{
@@ -582,7 +582,7 @@ impl<'tcx> BodyBuilder<'tcx> {
 
                 // Here we want to create a switch statement that will match on all of the
                 // specified discriminants of the ADT.
-                let discriminant_ty = discriminant_ty.to_ir_ty(self.ctx());
+                let discriminant_ty = discriminant_ty.to_ir_ty();
                 let targets = SwitchTargets::new(
                     adt.map(|adt| {
                         // Map over all of the discriminants of the ADT, and filter out those that
@@ -630,7 +630,7 @@ impl<'tcx> BodyBuilder<'tcx> {
                         _ => panic!("expected boolean switch to have only two options"),
                     };
 
-                    TerminatorKind::make_if(place.into(), true_block, false_block, self.ctx())
+                    TerminatorKind::make_if(place.into(), true_block, false_block)
                 } else {
                     debug_assert_eq!(options.len() + 1, target_blocks.len());
                     let otherwise_block = target_blocks.last().copied();
@@ -730,7 +730,7 @@ impl<'tcx> BodyBuilder<'tcx> {
             TestKind::Len { len, op } => {
                 let target_blocks = make_target_blocks(self);
 
-                let usize_ty = self.ctx().common_tys.usize;
+                let usize_ty = COMMON_IR_TYS.usize;
                 let actual = self.temp_place(usize_ty);
 
                 // Assign `actual = length(place)`
@@ -777,7 +777,7 @@ impl<'tcx> BodyBuilder<'tcx> {
     ) {
         debug_assert!(op.is_comparator());
 
-        let bool_ty = self.ctx().common_tys.bool;
+        let bool_ty = COMMON_IR_TYS.bool;
         let result = self.temp_place(bool_ty);
 
         // Push an assignment with the result of the comparison, i.e. `result = op(lhs,
@@ -791,7 +791,7 @@ impl<'tcx> BodyBuilder<'tcx> {
         self.control_flow_graph.terminate(
             block,
             span,
-            TerminatorKind::make_if(result.into(), success, fail, self.ctx()),
+            TerminatorKind::make_if(result.into(), success, fail),
         );
     }
 

--- a/compiler/hash-lower/src/build/matches/test.rs
+++ b/compiler/hash-lower/src/build/matches/test.rs
@@ -208,7 +208,7 @@ impl<'tcx> BodyBuilder<'tcx> {
                         emit_const_test(value, ty_id)
                     }
                     IrTy::Adt(id) => {
-                        let (variant_count, adt) = self.ctx().map_adt(*id, |id, adt| {
+                        let (variant_count, adt) = id.map(|adt| {
                             // Structs can be simplified...
                             if adt.flags.is_struct() {
                                 panic_on_span!(
@@ -219,7 +219,7 @@ impl<'tcx> BodyBuilder<'tcx> {
                                 )
                             }
 
-                            (adt.variants.len(), id)
+                            (adt.variants.len(), *id)
                         });
 
                         Test {
@@ -312,7 +312,7 @@ impl<'tcx> BodyBuilder<'tcx> {
                 // variant patterns, bu nothing else.
                 let test_adt = self.ty_id_from_tir_ty(pat_ty);
 
-                let variant_index = self.ctx().map_ty_as_adt(test_adt, |adt, _| {
+                let variant_index = self.ctx().tys().borrow(test_adt).as_adt().map(|adt| {
                     // If this is a struct, then we don't do anything
                     // since we're expecting an enum. Although, this case shouldn't happen?
                     if adt.flags.is_struct() {

--- a/compiler/hash-lower/src/build/mod.rs
+++ b/compiler/hash-lower/src/build/mod.rs
@@ -367,8 +367,7 @@ impl<'ctx> BodyBuilder<'ctx> {
 
         // Now that we have built the inner body block, we then need to terminate
         // the current basis block with a return terminator.
-        let return_block =
-            unpack!(self.term_into_dest(Place::return_place(self.ctx()), start, body));
+        let return_block = unpack!(self.term_into_dest(Place::return_place(), start, body));
         let span = self.span_of_term(body);
 
         self.control_flow_graph.terminate(return_block, span, TerminatorKind::Return);

--- a/compiler/hash-lower/src/build/mod.rs
+++ b/compiler/hash-lower/src/build/mod.rs
@@ -301,10 +301,8 @@ impl<'ctx> BodyBuilder<'ctx> {
         // If it is a function type, then we use the return type of the
         // function as the `return_ty`, otherwise we assume the type provided
         // is the `return_ty`
-        let return_ty = self.ctx().map_ty(ty, |item_ty| match item_ty {
-            IrTy::FnDef { instance } => {
-                self.ctx().map_instance(*instance, |instance| instance.ret_ty)
-            }
+        let return_ty = ty.map(|item_ty| match item_ty {
+            IrTy::FnDef { instance } => instance.borrow().ret_ty,
             _ => ty,
         });
 

--- a/compiler/hash-lower/src/build/place.rs
+++ b/compiler/hash-lower/src/build/place.rs
@@ -5,7 +5,7 @@ use hash_ir::{
     ty::{IrTyId, Mutability, VariantIdx},
     IrCtx,
 };
-use hash_storage::store::{statics::StoreId, SequenceStore};
+use hash_storage::store::{statics::StoreId, SequenceStore, Store};
 use hash_tir::{
     access::AccessTerm,
     arrays::IndexTerm,
@@ -176,7 +176,8 @@ impl<'tcx> BodyBuilder<'tcx> {
     /// using a [ParamIndex]. This function assumes that the underlying type
     /// is a [IrTy::Adt].
     fn lookup_field_index(&mut self, ty: IrTyId, field: ParamIndex) -> usize {
-        self.ctx().map_ty_as_adt(ty, |adt, _| {
+        let adt = self.ctx().tys().borrow(ty).as_adt();
+        adt.map(|adt| {
             // @@Todo: deal with unions here.
             if adt.flags.is_struct() || adt.flags.is_tuple() {
                 // So we get the first variant of the ADT since structs, tuples always

--- a/compiler/hash-lower/src/build/place.rs
+++ b/compiler/hash-lower/src/build/place.rs
@@ -137,7 +137,7 @@ impl<'tcx> BodyBuilder<'tcx> {
                 // it.
                 let ty = self.ty_id_from_tir_term(subject);
 
-                if self.ctx().map_ty(ty, |ty| ty.is_ref()) {
+                if ty.borrow().is_ref() {
                     base_place = base_place.deref()
                 }
 

--- a/compiler/hash-lower/src/build/rvalue.rs
+++ b/compiler/hash-lower/src/build/rvalue.rs
@@ -4,7 +4,7 @@
 use hash_ir::{
     cast::CastKind,
     ir::{AssertKind, BasicBlock, BinOp, Const, ConstKind, Operand, RValue, UnaryOp},
-    ty::{IrTy, IrTyId, Mutability},
+    ty::{IrTy, IrTyId, Mutability, COMMON_IR_TYS},
 };
 use hash_source::{
     constant::{IntConstant, IntTy, InternedInt, CONSTANT_MAP},
@@ -64,7 +64,7 @@ impl<'tcx> BodyBuilder<'tcx> {
                             && ty.borrow().is_signed()
                         {
                             let min_value = self.min_value_of_ty(ty);
-                            let is_min = self.temp_place(self.ctx().common_tys.bool);
+                            let is_min = self.temp_place(COMMON_IR_TYS.bool);
 
                             self.control_flow_graph.push_assign(
                                 block,
@@ -223,7 +223,7 @@ impl<'tcx> BodyBuilder<'tcx> {
 
             if op.is_checkable() && is_integral {
                 // Create a new tuple that contains the result of the operation
-                let ty = IrTy::tuple(&[ty, self.ctx().common_tys.bool]);
+                let ty = IrTy::tuple(&[ty, COMMON_IR_TYS.bool]);
 
                 let temp = self.temp_place(ty);
                 let rvalue = RValue::CheckedBinaryOp(op, operands);
@@ -256,7 +256,7 @@ impl<'tcx> BodyBuilder<'tcx> {
                 };
 
                 // Check for division/modulo of zero...
-                let is_zero = self.temp_place(self.ctx().common_tys.bool);
+                let is_zero = self.temp_place(COMMON_IR_TYS.bool);
 
                 let const_val =
                     Const::Int(CONSTANT_MAP.create_int(IntConstant::from_uint(0, uint_ty)));
@@ -282,8 +282,8 @@ impl<'tcx> BodyBuilder<'tcx> {
                     let negative_one_val = Operand::Const(const_val.into());
                     let minimum_value = self.min_value_of_ty(ty);
 
-                    let is_negative_one = self.temp_place(self.ctx().common_tys.bool);
-                    let is_minimum_value = self.temp_place(self.ctx().common_tys.bool);
+                    let is_negative_one = self.temp_place(COMMON_IR_TYS.bool);
+                    let is_minimum_value = self.temp_place(COMMON_IR_TYS.bool);
 
                     // Push the values that have been created into the temporaries
                     self.control_flow_graph.push_assign(
@@ -304,7 +304,7 @@ impl<'tcx> BodyBuilder<'tcx> {
                     // which checks the condition `(rhs == -1) & (lhs == MIN)`, and then we
                     // emit an assert. Alternatively, this could short_circuit on the first
                     // check, but it would make control flow more complex.
-                    let is_overflow = self.temp_place(self.ctx().common_tys.bool);
+                    let is_overflow = self.temp_place(COMMON_IR_TYS.bool);
                     self.control_flow_graph.push_assign(
                         block,
                         is_overflow,

--- a/compiler/hash-lower/src/build/rvalue.rs
+++ b/compiler/hash-lower/src/build/rvalue.rs
@@ -223,7 +223,7 @@ impl<'tcx> BodyBuilder<'tcx> {
         if self.settings.lowering_settings().checked_operations {
             if op.is_checkable() && actual_ty.is_integral() {
                 // Create a new tuple that contains the result of the operation
-                let ty = IrTy::tuple(self.ctx(), &[ty, self.ctx().tys().common_tys.bool]);
+                let ty = IrTy::tuple(&[ty, self.ctx().tys().common_tys.bool]);
                 let ty_id = self.ctx().tys().create(ty);
 
                 let temp = self.temp_place(ty_id);

--- a/compiler/hash-lower/src/build/rvalue.rs
+++ b/compiler/hash-lower/src/build/rvalue.rs
@@ -65,7 +65,7 @@ impl<'tcx> BodyBuilder<'tcx> {
                             && ty.is_signed()
                         {
                             let min_value = self.min_value_of_ty(ty);
-                            let is_min = self.temp_place(self.ctx().tys().common_tys.bool);
+                            let is_min = self.temp_place(self.ctx().common_tys.bool);
 
                             self.control_flow_graph.push_assign(
                                 block,
@@ -175,7 +175,7 @@ impl<'tcx> BodyBuilder<'tcx> {
 
             // If this is a function type, we emit a ZST to represent the operand
             // of the function.
-            if self.ctx().map_ty(ty_id, |ty| matches!(ty, IrTy::FnDef { .. })) {
+            if ty_id.map(|ty| matches!(ty, IrTy::FnDef { .. })) {
                 return block.and(Operand::Const(Const::Zero(ty_id).into()));
             }
         }
@@ -223,7 +223,7 @@ impl<'tcx> BodyBuilder<'tcx> {
         if self.settings.lowering_settings().checked_operations {
             if op.is_checkable() && actual_ty.is_integral() {
                 // Create a new tuple that contains the result of the operation
-                let ty = IrTy::tuple(&[ty, self.ctx().tys().common_tys.bool]);
+                let ty = IrTy::tuple(&[ty, self.ctx().common_tys.bool]);
                 let ty_id = self.ctx().tys().create(ty);
 
                 let temp = self.temp_place(ty_id);
@@ -257,7 +257,7 @@ impl<'tcx> BodyBuilder<'tcx> {
                 };
 
                 // Check for division/modulo of zero...
-                let is_zero = self.temp_place(self.ctx().tys().common_tys.bool);
+                let is_zero = self.temp_place(self.ctx().common_tys.bool);
 
                 let const_val =
                     Const::Int(CONSTANT_MAP.create_int(IntConstant::from_uint(0, uint_ty)));
@@ -283,8 +283,8 @@ impl<'tcx> BodyBuilder<'tcx> {
                     let negative_one_val = Operand::Const(const_val.into());
                     let minimum_value = self.min_value_of_ty(actual_ty);
 
-                    let is_negative_one = self.temp_place(self.ctx().tys().common_tys.bool);
-                    let is_minimum_value = self.temp_place(self.ctx().tys().common_tys.bool);
+                    let is_negative_one = self.temp_place(self.ctx().common_tys.bool);
+                    let is_minimum_value = self.temp_place(self.ctx().common_tys.bool);
 
                     // Push the values that have been created into the temporaries
                     self.control_flow_graph.push_assign(
@@ -305,7 +305,7 @@ impl<'tcx> BodyBuilder<'tcx> {
                     // which checks the condition `(rhs == -1) & (lhs == MIN)`, and then we
                     // emit an assert. Alternatively, this could short_circuit on the first
                     // check, but it would make control flow more complex.
-                    let is_overflow = self.temp_place(self.ctx().tys().common_tys.bool);
+                    let is_overflow = self.temp_place(self.ctx().common_tys.bool);
                     self.control_flow_graph.push_assign(
                         block,
                         is_overflow,

--- a/compiler/hash-lower/src/build/temp.rs
+++ b/compiler/hash-lower/src/build/temp.rs
@@ -21,7 +21,7 @@ impl<'tcx> BodyBuilder<'tcx> {
         let local = LocalDecl::new_auxiliary(ty, mutability);
 
         let temp = self.declarations.push(local);
-        let temp_place = Place::from_local(temp, self.ctx());
+        let temp_place = Place::from_local(temp);
 
         unpack!(block = self.term_into_dest(temp_place, block, term));
         block.and(temp)
@@ -31,6 +31,6 @@ impl<'tcx> BodyBuilder<'tcx> {
     pub(crate) fn temp_place(&mut self, ty: IrTyId) -> Place {
         let decl = LocalDecl::new_auxiliary(ty, Mutability::Immutable);
 
-        Place::from_local(self.declarations.push(decl), self.ctx())
+        Place::from_local(self.declarations.push(decl))
     }
 }

--- a/compiler/hash-lower/src/build/ty.rs
+++ b/compiler/hash-lower/src/build/ty.rs
@@ -192,16 +192,16 @@ impl<'tcx> BodyBuilder<'tcx> {
     pub(crate) fn evaluate_range_lit(
         &self,
         maybe_pat: Option<LitPat>,
-        ty: IrTy,
+        ty: IrTyId,
         at_end: bool,
     ) -> (Const, u128) {
         match maybe_pat {
             Some(pat) => self.evaluate_lit_pat(pat),
-            None => match ty {
+            None => ty.map(|ty| match ty {
                 IrTy::Char if at_end => (Const::Char(std::char::MAX), std::char::MAX as u128),
                 IrTy::Char => (Const::Char(0 as char), 0),
                 ty @ (IrTy::Int(_) | IrTy::UInt(_)) => {
-                    let int_ty: IntTy = ty.into();
+                    let int_ty: IntTy = (*ty).into();
                     let ptr_size = self.target().ptr_size();
 
                     let (signed_value, value) = if at_end {
@@ -213,7 +213,7 @@ impl<'tcx> BodyBuilder<'tcx> {
                     (Const::Int(CONSTANT_MAP.create_int(signed_value.into())), value)
                 }
                 _ => unreachable!(),
-            },
+            }),
         }
     }
 }

--- a/compiler/hash-lower/src/build/utils.rs
+++ b/compiler/hash-lower/src/build/utils.rs
@@ -8,7 +8,7 @@ use hash_ir::{
         AggregateKind, AssertKind, BasicBlock, Const, Local, LocalDecl, Operand, Place, RValue,
         TerminatorKind,
     },
-    ty::{IrTyId, Mutability},
+    ty::{IrTyId, Mutability, COMMON_IR_TYS},
     IrCtx,
 };
 use hash_source::{constant::CONSTANT_MAP, location::Span};
@@ -128,8 +128,7 @@ impl<'tcx> BodyBuilder<'tcx> {
         match &self.tmp_place {
             Some(tmp) => *tmp,
             None => {
-                let local =
-                    LocalDecl::new_auxiliary(self.ctx().common_tys.unit, Mutability::Immutable);
+                let local = LocalDecl::new_auxiliary(COMMON_IR_TYS.unit, Mutability::Immutable);
                 let local_id = self.declarations.push(local);
 
                 let place = Place::from_local(local_id);

--- a/compiler/hash-lower/src/build/utils.rs
+++ b/compiler/hash-lower/src/build/utils.rs
@@ -129,10 +129,8 @@ impl<'tcx> BodyBuilder<'tcx> {
         match &self.tmp_place {
             Some(tmp) => *tmp,
             None => {
-                let local = LocalDecl::new_auxiliary(
-                    self.ctx().tys().common_tys.unit,
-                    Mutability::Immutable,
-                );
+                let local =
+                    LocalDecl::new_auxiliary(self.ctx().common_tys.unit, Mutability::Immutable);
                 let local_id = self.declarations.push(local);
 
                 let place = Place::from_local(local_id, self.ctx());

--- a/compiler/hash-lower/src/build/utils.rs
+++ b/compiler/hash-lower/src/build/utils.rs
@@ -12,7 +12,7 @@ use hash_ir::{
     IrCtx,
 };
 use hash_source::{constant::CONSTANT_MAP, location::Span};
-use hash_storage::store::SequenceStore;
+use hash_storage::store::{SequenceStore, Store};
 use hash_tir::{
     data::DataTy,
     environment::env::AccessToEnv,
@@ -114,7 +114,7 @@ impl<'tcx> BodyBuilder<'tcx> {
         ptr: Operand,
         metadata: usize,
     ) -> RValue {
-        let id = self.ctx().map_ty_as_adt(ty, |_, id| id);
+        let id = self.ctx().tys().borrow(ty).as_adt();
 
         let ptr_width = self.settings.target().ptr_size();
         let metadata =

--- a/compiler/hash-lower/src/build/utils.rs
+++ b/compiler/hash-lower/src/build/utils.rs
@@ -12,7 +12,7 @@ use hash_ir::{
     IrCtx,
 };
 use hash_source::{constant::CONSTANT_MAP, location::Span};
-use hash_storage::store::{SequenceStore, Store};
+use hash_storage::store::{statics::StoreId, SequenceStore};
 use hash_tir::{
     data::DataTy,
     environment::env::AccessToEnv,
@@ -114,13 +114,12 @@ impl<'tcx> BodyBuilder<'tcx> {
         ptr: Operand,
         metadata: usize,
     ) -> RValue {
-        let id = self.ctx().tys().borrow(ty).as_adt();
-
+        let adt = ty.borrow().as_adt();
         let ptr_width = self.settings.target().ptr_size();
         let metadata =
             Operand::Const(Const::Int(CONSTANT_MAP.create_usize_int(metadata, ptr_width)).into());
 
-        RValue::Aggregate(AggregateKind::Struct(id), vec![ptr, metadata])
+        RValue::Aggregate(AggregateKind::Struct(adt), vec![ptr, metadata])
     }
 
     /// Function to create a new [Place] that is used to ignore
@@ -133,7 +132,7 @@ impl<'tcx> BodyBuilder<'tcx> {
                     LocalDecl::new_auxiliary(self.ctx().common_tys.unit, Mutability::Immutable);
                 let local_id = self.declarations.push(local);
 
-                let place = Place::from_local(local_id, self.ctx());
+                let place = Place::from_local(local_id);
                 self.tmp_place = Some(place);
                 place
             }

--- a/compiler/hash-lower/src/ctx.rs
+++ b/compiler/hash-lower/src/ctx.rs
@@ -94,7 +94,7 @@ impl<'ir> BuilderCtx<'ir> {
     /// Get a [LayoutComputer] which can be used to compute layouts and
     /// other layout related operations.
     pub fn layout_computer(&self) -> LayoutComputer {
-        LayoutComputer::new(self.layouts, self.lcx)
+        LayoutComputer::new(self.layouts)
     }
 
     /// Compute the layout of a given [IrTyId].

--- a/compiler/hash-lower/src/lower_ty.rs
+++ b/compiler/hash-lower/src/lower_ty.rs
@@ -7,7 +7,7 @@ use hash_ir::{
     lang_items::LangItem,
     ty::{
         self, Adt, AdtField, AdtFlags, AdtId, AdtVariant, AdtVariants, Instance, IrTy, IrTyId,
-        IrTyListId, Mutability, RepresentationFlags,
+        IrTyListId, Mutability, RepresentationFlags, COMMON_IR_TYS,
     },
     TyCacheEntry,
 };
@@ -239,7 +239,7 @@ impl<'ir> BuilderCtx<'ir> {
         match ctor_defs.len() {
             // This must be the never type.
             0 => {
-                return (self.lcx.common_tys.never, false);
+                return (COMMON_IR_TYS.never, false);
             }
             1 => flags |= AdtFlags::STRUCT,
             _ => flags |= AdtFlags::ENUM,
@@ -314,7 +314,7 @@ impl<'ir> BuilderCtx<'ir> {
                 // Booleans are defined as a data type with two constructors,
                 // check here if we are dealing with a boolean.
                 if self.primitives().bool() == ty.data_def {
-                    return (self.lcx.common_tys.bool, true);
+                    return (COMMON_IR_TYS.bool, true);
                 }
 
                 self.context().enter_scope(ty.data_def.into(), || {
@@ -329,8 +329,8 @@ impl<'ir> BuilderCtx<'ir> {
                     PrimitiveCtorInfo::Numeric(NumericCtorInfo { bits, is_signed, is_float }) => {
                         if is_float {
                             match bits {
-                                NumericCtorBits::Bounded(32) => self.lcx.common_tys.f32,
-                                NumericCtorBits::Bounded(64) => self.lcx.common_tys.f64,
+                                NumericCtorBits::Bounded(32) => COMMON_IR_TYS.f32,
+                                NumericCtorBits::Bounded(64) => COMMON_IR_TYS.f64,
 
                                 // Other bits widths are not supported.
                                 _ => unreachable!(),
@@ -342,21 +342,21 @@ impl<'ir> BuilderCtx<'ir> {
 
                                     if is_signed {
                                         match size.bytes() {
-                                            1 => self.lcx.common_tys.i8,
-                                            2 => self.lcx.common_tys.i16,
-                                            4 => self.lcx.common_tys.i32,
-                                            8 => self.lcx.common_tys.i64,
-                                            16 => self.lcx.common_tys.i128,
+                                            1 => COMMON_IR_TYS.i8,
+                                            2 => COMMON_IR_TYS.i16,
+                                            4 => COMMON_IR_TYS.i32,
+                                            8 => COMMON_IR_TYS.i64,
+                                            16 => COMMON_IR_TYS.i128,
                                             _ => unreachable!(), /* Other bits widths are not
                                                                   * supported. */
                                         }
                                     } else {
                                         match size.bytes() {
-                                            1 => self.lcx.common_tys.u8,
-                                            2 => self.lcx.common_tys.u16,
-                                            4 => self.lcx.common_tys.u32,
-                                            8 => self.lcx.common_tys.u64,
-                                            16 => self.lcx.common_tys.u128,
+                                            1 => COMMON_IR_TYS.u8,
+                                            2 => COMMON_IR_TYS.u16,
+                                            4 => COMMON_IR_TYS.u32,
+                                            8 => COMMON_IR_TYS.u64,
+                                            16 => COMMON_IR_TYS.u128,
                                             _ => unreachable!(), /* Other bits widths are not
                                                                   * supported. */
                                         }
@@ -368,8 +368,8 @@ impl<'ir> BuilderCtx<'ir> {
                     }
 
                     // @@Temporary: `str` implies that it is a `&str`
-                    PrimitiveCtorInfo::Str => self.lcx.common_tys.str,
-                    PrimitiveCtorInfo::Char => self.lcx.common_tys.char,
+                    PrimitiveCtorInfo::Str => COMMON_IR_TYS.str,
+                    PrimitiveCtorInfo::Char => COMMON_IR_TYS.char,
                     PrimitiveCtorInfo::Array(ArrayCtorInfo { element_ty, length }) => {
                         // Apply the arguments as the scope of the data type.
                         self.context().enter_scope(ty.data_def.into(), || {

--- a/compiler/hash-lower/src/lower_ty.rs
+++ b/compiler/hash-lower/src/lower_ty.rs
@@ -243,7 +243,7 @@ impl<'ir> BuilderCtx<'ir> {
         match ctor_defs.len() {
             // This must be the never type.
             0 => {
-                return (self.lcx.tys().common_tys.never, false);
+                return (self.lcx.common_tys.never, false);
             }
             1 => flags |= AdtFlags::STRUCT,
             _ => flags |= AdtFlags::ENUM,
@@ -318,7 +318,7 @@ impl<'ir> BuilderCtx<'ir> {
                 // Booleans are defined as a data type with two constructors,
                 // check here if we are dealing with a boolean.
                 if self.primitives().bool() == ty.data_def {
-                    return (self.lcx.tys().common_tys.bool, true);
+                    return (self.lcx.common_tys.bool, true);
                 }
 
                 self.context().enter_scope(ty.data_def.into(), || {
@@ -333,8 +333,8 @@ impl<'ir> BuilderCtx<'ir> {
                     PrimitiveCtorInfo::Numeric(NumericCtorInfo { bits, is_signed, is_float }) => {
                         if is_float {
                             match bits {
-                                NumericCtorBits::Bounded(32) => self.lcx.tys().common_tys.f32,
-                                NumericCtorBits::Bounded(64) => self.lcx.tys().common_tys.f64,
+                                NumericCtorBits::Bounded(32) => self.lcx.common_tys.f32,
+                                NumericCtorBits::Bounded(64) => self.lcx.common_tys.f64,
 
                                 // Other bits widths are not supported.
                                 _ => unreachable!(),
@@ -346,21 +346,21 @@ impl<'ir> BuilderCtx<'ir> {
 
                                     if is_signed {
                                         match size.bytes() {
-                                            1 => self.lcx.tys().common_tys.i8,
-                                            2 => self.lcx.tys().common_tys.i16,
-                                            4 => self.lcx.tys().common_tys.i32,
-                                            8 => self.lcx.tys().common_tys.i64,
-                                            16 => self.lcx.tys().common_tys.i128,
+                                            1 => self.lcx.common_tys.i8,
+                                            2 => self.lcx.common_tys.i16,
+                                            4 => self.lcx.common_tys.i32,
+                                            8 => self.lcx.common_tys.i64,
+                                            16 => self.lcx.common_tys.i128,
                                             _ => unreachable!(), /* Other bits widths are not
                                                                   * supported. */
                                         }
                                     } else {
                                         match size.bytes() {
-                                            1 => self.lcx.tys().common_tys.u8,
-                                            2 => self.lcx.tys().common_tys.u16,
-                                            4 => self.lcx.tys().common_tys.u32,
-                                            8 => self.lcx.tys().common_tys.u64,
-                                            16 => self.lcx.tys().common_tys.u128,
+                                            1 => self.lcx.common_tys.u8,
+                                            2 => self.lcx.common_tys.u16,
+                                            4 => self.lcx.common_tys.u32,
+                                            8 => self.lcx.common_tys.u64,
+                                            16 => self.lcx.common_tys.u128,
                                             _ => unreachable!(), /* Other bits widths are not
                                                                   * supported. */
                                         }
@@ -372,8 +372,8 @@ impl<'ir> BuilderCtx<'ir> {
                     }
 
                     // @@Temporary: `str` implies that it is a `&str`
-                    PrimitiveCtorInfo::Str => self.lcx.tys().common_tys.str,
-                    PrimitiveCtorInfo::Char => self.lcx.tys().common_tys.char,
+                    PrimitiveCtorInfo::Str => self.lcx.common_tys.str,
+                    PrimitiveCtorInfo::Char => self.lcx.common_tys.char,
                     PrimitiveCtorInfo::Array(ArrayCtorInfo { element_ty, length }) => {
                         // Apply the arguments as the scope of the data type.
                         self.context().enter_scope(ty.data_def.into(), || {

--- a/compiler/hash-lower/src/optimise/cleanup_locals.rs
+++ b/compiler/hash-lower/src/optimise/cleanup_locals.rs
@@ -39,8 +39,8 @@ impl IrOptimisationPass for CleanupLocalPass {
         settings.optimisation_level >= OptimisationLevel::Debug
     }
 
-    fn optimise(&self, body: &mut Body, store: &IrCtx) {
-        let mut local_map = LocalUseMap::new(body, store);
+    fn optimise(&self, body: &mut Body, _: &IrCtx) {
+        let mut local_map = LocalUseMap::new(body);
         self.simplify_locals(body, &mut local_map);
 
         // after the locals are simplified, we need to re-map all of the
@@ -49,7 +49,7 @@ impl IrOptimisationPass for CleanupLocalPass {
 
         if local_remaps.iter().any(Option::is_none) {
             // create an updater, and then we can remap all of the places.
-            let updater = LocalUpdater::new(local_remaps, store);
+            let updater = LocalUpdater::new(local_remaps);
             updater.visit(body);
 
             body.declarations.shrink_to_fit();
@@ -68,7 +68,7 @@ impl CleanupLocalPass {
     /// see. This is done by re-visiting the statement that was removed, and
     /// decrementing the count for each [Local] that we see in that
     /// particular statement.
-    fn simplify_locals(&self, body: &mut Body, local_map: &mut LocalUseMap<'_>) {
+    fn simplify_locals(&self, body: &mut Body, local_map: &mut LocalUseMap) {
         let mut changed = true;
 
         while changed {
@@ -108,7 +108,7 @@ impl CleanupLocalPass {
 
 /// A visitor that counts how many times each [Local] is used as an
 /// [RValue] within a particular [Body].
-pub struct LocalUseMap<'ir> {
+pub struct LocalUseMap {
     /// All of the counts for each local in the specified body.
     uses: Vec<usize>,
 
@@ -124,21 +124,17 @@ pub struct LocalUseMap<'ir> {
     /// the entire CFG after each local removal, and only what is needed
     /// for scanning.
     increment: bool,
-
-    /// A reference to the [BodyDataStore] in order to access and
-    /// read values references by the [Body].
-    ctx: &'ir IrCtx,
 }
 
-impl<'ir> LocalUseMap<'ir> {
+impl LocalUseMap {
     /// Create a new [LocalUseMap] for the specified [Body].
-    pub fn new(body: &Body, ctx: &'ir IrCtx) -> Self {
+    pub fn new(body: &Body) -> Self {
         let mut counts = vec![0; body.declarations.len()];
 
         // always set to `_0` to 1 since it is the return value and
         // is always used
         counts[RETURN_PLACE.index()] = 1;
-        let mut this = Self { uses: counts, ctx, arg_count: body.arg_count, increment: true };
+        let mut this = Self { uses: counts, arg_count: body.arg_count, increment: true };
 
         // visit the body and record the counts for each local, then
         // return the
@@ -207,11 +203,7 @@ impl<'ir> LocalUseMap<'ir> {
     }
 }
 
-impl<'ir> IrVisitorMut<'ir> for LocalUseMap<'ir> {
-    fn ctx(&self) -> &'ir IrCtx {
-        self.ctx
-    }
-
+impl<'ir> IrVisitorMut<'ir> for LocalUseMap {
     /// Visit an assignment [Statement], we only visit the [RValue] part of the
     /// assignment fully, and only check the projections of the [Place] in case
     /// it is referenced within a [PlaceProjection::Index].
@@ -236,29 +228,22 @@ impl<'ir> IrVisitorMut<'ir> for LocalUseMap<'ir> {
     }
 }
 
-pub struct LocalUpdater<'ir> {
+pub struct LocalUpdater {
     /// The map of locals to remap to a new local. If the [Local] index is
     /// [None], this means that the local is dead and was removed. If the
     /// [Local] index is [Some], then the local was not removed and should
     /// be remapped to the new [Local].
     remap: IndexVec<Local, Option<Local>>,
-
-    /// Reference to body data store
-    store: &'ir IrCtx,
 }
 
-impl<'ir> LocalUpdater<'ir> {
+impl LocalUpdater {
     /// Create a new [LocalUpdater].
-    pub fn new(remap: IndexVec<Local, Option<Local>>, store: &'ir IrCtx) -> Self {
-        Self { remap, store }
+    pub fn new(remap: IndexVec<Local, Option<Local>>) -> Self {
+        Self { remap }
     }
 }
 
-impl<'ir> ModifyingIrVisitor<'ir> for LocalUpdater<'ir> {
-    fn store(&self) -> &'ir IrCtx {
-        self.store
-    }
-
+impl<'ir> ModifyingIrVisitor<'ir> for LocalUpdater {
     /// Perform a remapping of the [Local] within the [Place] to a new [Local].
     fn visit_local(&self, local: &mut Local, _: PlaceContext, _: IrRef) {
         if let Some(new_local) = self.remap[*local] {

--- a/compiler/hash-storage/src/store/mod.rs
+++ b/compiler/hash-storage/src/store/mod.rs
@@ -10,3 +10,35 @@ pub mod statics;
 
 pub use partial::*;
 pub use sequence::*;
+
+/// This macro creates a storages struct, as well as accompanying creation and
+/// access methods, for the given sequence of stores.
+#[macro_export]
+macro_rules! stores {
+    ($store_name:ident; $($name:ident: $ty:ty),* $(,)?) => {
+      #[derive(Debug)]
+      pub struct $store_name {
+          $($name: $ty),*
+      }
+
+      impl $store_name {
+          pub fn new() -> Self {
+              Self {
+                  $($name: <$ty>::new()),*
+              }
+          }
+
+          $(
+              pub fn $name(&self) -> & $ty {
+                  &self.$name
+              }
+          )*
+      }
+
+      impl Default for $store_name {
+          fn default() -> Self {
+              Self::new()
+          }
+      }
+    }
+  }

--- a/compiler/hash-tir/src/environment/stores.rs
+++ b/compiler/hash-tir/src/environment/stores.rs
@@ -1,6 +1,8 @@
 // @@Docs
 use std::sync::OnceLock;
 
+use hash_storage::stores;
+
 use super::super::{
     args::{ArgsStore, PatArgsStore},
     data::{CtorDefsStore, DataDefStore},
@@ -18,37 +20,6 @@ use crate::{
     ast_info::AstInfo, atom_info::AtomInfoStore, control::MatchCasesStore,
     directives::AppliedDirectivesStore,
 };
-
-/// This macro creates a storages struct, as well as accompanying creation and
-/// access methods, for the given sequence of stores.
-macro_rules! stores {
-  ($store_name:ident; $($name:ident: $ty:ty),* $(,)?) => {
-    #[derive(Debug)]
-    pub struct $store_name {
-        $($name: $ty),*
-    }
-
-    impl $store_name {
-        pub fn new() -> Self {
-            Self {
-                $($name: <$ty>::new()),*
-            }
-        }
-
-        $(
-            pub fn $name(&self) -> & $ty {
-                &self.$name
-            }
-        )*
-    }
-
-    impl Default for $store_name {
-        fn default() -> Self {
-            Self::new()
-        }
-    }
-  }
-}
 
 // All the stores that contain definitions for the typechecker.
 stores! {


### PR DESCRIPTION
- ir: use static store for ADTs
- ir: rename `AdtData` to `Adt`
- ir: use static stores for `IrTy`s and `Instance`s
- ir: use static store for `PlaceProjection`s
- ir: remove `tys()`, `tls()`, `adts()`, `projections()`, and `instances()`
- ir: make `CommonIrTys` a static struct, and remove `IrCtx` where possible
