### PR TITLE
spanless ast

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,6 +443,7 @@ dependencies = [
  "hash-tree-def",
  "hash-utils",
  "num-bigint",
+ "once_cell",
  "replace_with",
 ]
 
@@ -850,7 +851,6 @@ dependencies = [
  "indexmap",
  "lazy_static",
  "num-bigint",
- "parking_lot",
  "textwrap",
  "typed-builder",
  "utility-types",

--- a/compiler/hash-ast/Cargo.toml
+++ b/compiler/hash-ast/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 [dependencies]
 num-bigint = "0.4"
 replace_with = "0.1.7"
+once_cell = "1.17"
 
 hash-source = { path = "../hash-source" }
 hash-tree-def = { path = "../hash-tree-def" }

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -14,29 +14,20 @@ use hash_source::{
 };
 use hash_tree_def::define_tree;
 use hash_utils::{
-    counter,
-    index_vec::{Idx, IndexVec},
+    index_vec::{define_index_type, IndexVec},
     parking_lot::RwLock,
     smallvec::SmallVec,
 };
 use once_cell::sync::Lazy;
 use replace_with::replace_with_or_abort;
 
-counter! {
-    name: AstNodeId,
-    counter_name: AST_NODE_ID_COUNTER,
-    visibility: pub,
-    method_visibility: pub,
-}
-
-impl Idx for AstNodeId {
-    fn from_usize(idx: usize) -> Self {
-        Self::from(idx as u32)
-    }
-
-    fn index(self) -> usize {
-        self.0 as usize
-    }
+define_index_type! {
+    /// This is the unique identifier for an AST node. This is used to
+    /// map spans to nodes, and vice versa. [AstNodeId]s are unique and
+    /// they are always increasing as a new nodes are created.
+    pub struct AstNodeId = u32;
+    MAX_INDEX = i32::max_value() as usize;
+    DISABLE_MAX_INDEX_CHECK = cfg!(not(debug_assertions));
 }
 
 /// The [`SPAN_MAP`] is a global static that is used to store the span

--- a/compiler/hash-ast/src/lib.rs
+++ b/compiler/hash-ast/src/lib.rs
@@ -1,6 +1,6 @@
 //! Hash Compiler AST library file
 
-#![feature(box_into_inner, iter_intersperse, let_chains)]
+#![feature(box_into_inner, iter_intersperse, let_chains, lazy_cell)]
 
 pub mod ast;
 pub mod node_map;

--- a/compiler/hash-parser/src/lib.rs
+++ b/compiler/hash-parser/src/lib.rs
@@ -10,10 +10,7 @@ mod source;
 use std::{env, path::PathBuf};
 
 use crossbeam_channel::{unbounded, Sender};
-use hash_ast::{
-    ast::{self, AstUtils},
-    node_map::ModuleEntry,
-};
+use hash_ast::{ast, node_map::ModuleEntry};
 use hash_lexer::Lexer;
 use hash_pipeline::{
     interface::{CompilerInterface, CompilerStage},
@@ -63,9 +60,6 @@ impl<Ctx: ParserCtxQuery> CompilerStage<Ctx> for Parser {
     ) -> hash_pipeline::interface::CompilerResult<()> {
         let ParserCtx { workspace, pool } = &mut ctx.data();
         let current_dir = env::current_dir().map_err(|err| vec![err.into()])?;
-
-        // Initialise the map if it hasn't been initialised yet.
-        AstUtils::span_map();
 
         let mut collected_diagnostics = Vec::new();
         let (sender, receiver) = unbounded::<ParserAction>();

--- a/compiler/hash-parser/src/lib.rs
+++ b/compiler/hash-parser/src/lib.rs
@@ -11,7 +11,7 @@ use std::{env, path::PathBuf};
 
 use crossbeam_channel::{unbounded, Sender};
 use hash_ast::{
-    ast::{self},
+    ast::{self, AstUtils},
     node_map::ModuleEntry,
 };
 use hash_lexer::Lexer;
@@ -63,6 +63,9 @@ impl<Ctx: ParserCtxQuery> CompilerStage<Ctx> for Parser {
     ) -> hash_pipeline::interface::CompilerResult<()> {
         let ParserCtx { workspace, pool } = &mut ctx.data();
         let current_dir = env::current_dir().map_err(|err| vec![err.into()])?;
+
+        // Initialise the map if it hasn't been initialised yet.
+        AstUtils::span_map();
 
         let mut collected_diagnostics = Vec::new();
         let (sender, receiver) = unbounded::<ParserAction>();

--- a/compiler/hash-tir/Cargo.toml
+++ b/compiler/hash-tir/Cargo.toml
@@ -13,7 +13,6 @@ textwrap = "0.16"
 utility-types = "0.0.2"
 typed-builder = "0.11"
 lazy_static = "1.4"
-parking_lot = "0.12"
 
 hash-ast = { path = "../hash-ast" }
 hash-source = { path = "../hash-source" }

--- a/compiler/hash-tir/src/ast_info.rs
+++ b/compiler/hash-tir/src/ast_info.rs
@@ -2,7 +2,7 @@ use std::hash::Hash;
 
 use bimap::BiMap;
 use hash_ast::ast::AstNodeId;
-use parking_lot::RwLock;
+use hash_utils::parking_lot::RwLock;
 
 use crate::{
     args::ArgId,

--- a/compiler/hash-tir/src/locations.rs
+++ b/compiler/hash-tir/src/locations.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use hash_source::location::{SourceLocation, Span};
 use hash_storage::store::SequenceStoreKey;
-use parking_lot::RwLock;
+use hash_utils::parking_lot::RwLock;
 
 use super::{
     args::{ArgId, ArgsId, PatArgId, PatArgsId},

--- a/compiler/hash-tir/src/problems.rs
+++ b/compiler/hash-tir/src/problems.rs
@@ -1,4 +1,4 @@
-use parking_lot::RwLock;
+use hash_utils::parking_lot::RwLock;
 
 use crate::context::Context;
 

--- a/compiler/hash-tir/src/scopes.rs
+++ b/compiler/hash-tir/src/scopes.rs
@@ -9,7 +9,7 @@ use hash_storage::{
     static_single_store,
     store::{statics::StoreId, Store, TrivialSequenceStoreKey},
 };
-use parking_lot::{MappedRwLockReadGuard, MappedRwLockWriteGuard};
+use hash_utils::parking_lot::{MappedRwLockReadGuard, MappedRwLockWriteGuard};
 use textwrap::indent;
 use utility_types::omit;
 

--- a/compiler/hash-tree-def/src/emit.rs
+++ b/compiler/hash-tree-def/src/emit.rs
@@ -560,7 +560,7 @@ fn emit_walk_node_field(
                 if nodes_mut {
                     Ok(Some(quote! {
                         visitor.#visit_child_function_name(
-                            super::#node_ref_name::new(#field_path, span, id)
+                            super::#node_ref_name::new(#field_path, id)
                         )?
                     }))
                 } else {
@@ -629,7 +629,7 @@ fn emit_walker_enum_function(
         nodes_mut,
         self_mut,
         quote! {
-           let (span, id) = (node.span(), node.id());
+           let id = node.id();
            Ok(match #ref_or_mut *node {
                #(#cases),*
            })
@@ -676,7 +676,7 @@ fn emit_walker_struct_function(
         nodes_mut,
         self_mut,
         quote! {
-            let (span, id) = (node.span(), node.id());
+            let id = node.id();
             Ok(#node_name {
                 #(#walk_fields),*
             })

--- a/compiler/hash-utils/src/lib.rs
+++ b/compiler/hash-utils/src/lib.rs
@@ -27,5 +27,6 @@ pub use fxhash;
 pub use index_vec;
 pub use itertools;
 pub use log;
+pub use parking_lot;
 pub use smallvec;
 pub use thin_vec;


### PR DESCRIPTION
- ast: Make AST spanless, and store `Span`s within `SPAN_MAP`
- ast: Use `RwLock` and `once_cell:sync::Lazy` for SpanMap
