### PR TITLE
core: Use `SourceLocation` (new name `Span`) over `Span` (new name `ByteRange`) to refer to locations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,7 +730,6 @@ dependencies = [
 name = "hash-semantics"
 version = "0.1.0"
 dependencies = [
- "bimap",
  "bitflags 2.0.0-rc.1",
  "dashmap",
  "derive_more",
@@ -841,7 +840,6 @@ dependencies = [
 name = "hash-tir"
 version = "0.1.0"
 dependencies = [
- "bimap",
  "derive_more",
  "hash-ast",
  "hash-source",
@@ -879,7 +877,6 @@ dependencies = [
 name = "hash-typecheck"
 version = "0.1.0"
 dependencies = [
- "bimap",
  "dashmap",
  "derive_more",
  "hash-ast",

--- a/compiler/hash-ast-desugaring/src/desugaring.rs
+++ b/compiler/hash-ast-desugaring/src/desugaring.rs
@@ -10,7 +10,7 @@ use hash_ast::{
     ast_nodes,
 };
 use hash_reporting::macros::panic_on_span;
-use hash_source::location::Span;
+use hash_source::location::SourceLocation;
 
 use crate::visitor::AstDesugaring;
 
@@ -42,12 +42,12 @@ impl<'s> AstDesugaring<'s> {
     ///
     /// So essentially the for-loop becomes a simple loop with a match block on
     /// the given iterator since for-loops only support iterators.
-    pub(crate) fn desugar_for_loop_block(&self, node: Block, parent_span: Span) -> Block {
+    pub(crate) fn desugar_for_loop_block(&self, node: Block, parent_span: SourceLocation) -> Block {
         // Since this function expects it to be a for-loop block, we match it and unwrap
         let block = match node {
             Block::For(body) => body,
             block => panic_on_span!(
-                self.source_location(parent_span),
+                parent_span,
                 self.source_map,
                 "lowering: expected for-loop, got {}",
                 block.as_str()
@@ -163,12 +163,16 @@ impl<'s> AstDesugaring<'s> {
     /// executing is treated like a matchable pattern, and then matched on
     /// whether if it is true or not. If it is true, the body block is
     /// executed, otherwise the loop breaks.
-    pub(crate) fn desugar_while_loop_block(&self, node: Block, parent_span: Span) -> Block {
+    pub(crate) fn desugar_while_loop_block(
+        &self,
+        node: Block,
+        parent_span: SourceLocation,
+    ) -> Block {
         // Since this function expects it to be a for-loop block, we match it and unwrap
         let block = match node {
             Block::While(body) => body,
             block => panic_on_span!(
-                self.source_location(parent_span),
+                parent_span,
                 self.source_map,
                 "lowering: expected while-block, got {}",
                 block.as_str()
@@ -330,12 +334,12 @@ impl<'s> AstDesugaring<'s> {
     /// complicate things with pattern exhaustiveness because then there
     /// would be no base case branch, thus the exhaustiveness checking would
     /// also need to know about the omitted else branch.
-    pub(crate) fn desugar_if_block(&self, node: Block, parent_span: Span) -> Block {
+    pub(crate) fn desugar_if_block(&self, node: Block, parent_span: SourceLocation) -> Block {
         // Since this function expects it to be a for-loop block, we match it and unwrap
         let block = match node {
             Block::If(body) => body,
             block => panic_on_span!(
-                self.source_location(parent_span),
+                parent_span,
                 self.source_map,
                 "lowering: expected if-block, got {}",
                 block.as_str()

--- a/compiler/hash-ast-desugaring/src/desugaring.rs
+++ b/compiler/hash-ast-desugaring/src/desugaring.rs
@@ -75,7 +75,7 @@ impl<'s> AstDesugaring<'s> {
             Pat::Constructor(ConstructorPat {
                 subject: make_binding_pat("Some"),
                 spread: None,
-                fields: ast_nodes![AstNode::new(TuplePatEntry { name: None, pat }, pat_span)],
+                fields: ast_nodes![AstNode::new(TuplePatEntry { name: None, pat }, pat_span); pat_span],
             }),
             pat_span,
         );
@@ -96,14 +96,14 @@ impl<'s> AstDesugaring<'s> {
                         Pat::Constructor(ConstructorPat {
                             subject: make_binding_pat("None"),
                             spread: None,
-                            fields: ast_nodes![],
+                            fields: ast_nodes![; pat_span],
                         },),
                         pat_span
                     ),
                     expr: AstNode::new(Expr::Break(BreakStatement {}), body_span),
                 },
                 pat_span
-            ),
+            ); parent_span
         ];
 
         // Here want to transform the for-loop into just a loop block
@@ -121,7 +121,7 @@ impl<'s> AstDesugaring<'s> {
                             args: ast_nodes![AstNode::new(
                                 ConstructorCallArg { name: None, value: iterator },
                                 iter_span
-                            )],
+                            ); iter_span],
                         }),
                         body_span,
                     ),
@@ -215,7 +215,8 @@ impl<'s> AstDesugaring<'s> {
                                 expr: AstNode::new(Expr::Break(BreakStatement {}), condition_span)
                             },
                             condition_span
-                        ),
+                        );
+                        parent_span
                     ],
                     origin: MatchOrigin::While,
                 }),
@@ -380,7 +381,7 @@ impl<'s> AstDesugaring<'s> {
                         Expr::Block(BlockExpr {
                             data: AstNode::new(
                                 Block::Body(BodyBlock {
-                                    statements: AstNodes::empty(),
+                                    statements: AstNodes::empty(parent_span),
                                     expr: None,
                                 }),
                                 parent_span,

--- a/compiler/hash-ast-desugaring/src/desugaring.rs
+++ b/compiler/hash-ast-desugaring/src/desugaring.rs
@@ -10,7 +10,7 @@ use hash_ast::{
     ast_nodes,
 };
 use hash_reporting::macros::panic_on_span;
-use hash_source::location::SourceLocation;
+use hash_source::location::Span;
 
 use crate::visitor::AstDesugaring;
 
@@ -42,7 +42,7 @@ impl<'s> AstDesugaring<'s> {
     ///
     /// So essentially the for-loop becomes a simple loop with a match block on
     /// the given iterator since for-loops only support iterators.
-    pub(crate) fn desugar_for_loop_block(&self, node: Block, parent_span: SourceLocation) -> Block {
+    pub(crate) fn desugar_for_loop_block(&self, node: Block, parent_span: Span) -> Block {
         // Since this function expects it to be a for-loop block, we match it and unwrap
         let block = match node {
             Block::For(body) => body,
@@ -163,11 +163,7 @@ impl<'s> AstDesugaring<'s> {
     /// executing is treated like a matchable pattern, and then matched on
     /// whether if it is true or not. If it is true, the body block is
     /// executed, otherwise the loop breaks.
-    pub(crate) fn desugar_while_loop_block(
-        &self,
-        node: Block,
-        parent_span: SourceLocation,
-    ) -> Block {
+    pub(crate) fn desugar_while_loop_block(&self, node: Block, parent_span: Span) -> Block {
         // Since this function expects it to be a for-loop block, we match it and unwrap
         let block = match node {
             Block::While(body) => body,
@@ -334,7 +330,7 @@ impl<'s> AstDesugaring<'s> {
     /// complicate things with pattern exhaustiveness because then there
     /// would be no base case branch, thus the exhaustiveness checking would
     /// also need to know about the omitted else branch.
-    pub(crate) fn desugar_if_block(&self, node: Block, parent_span: SourceLocation) -> Block {
+    pub(crate) fn desugar_if_block(&self, node: Block, parent_span: Span) -> Block {
         // Since this function expects it to be a for-loop block, we match it and unwrap
         let block = match node {
             Block::If(body) => body,

--- a/compiler/hash-ast-desugaring/src/lib.rs
+++ b/compiler/hash-ast-desugaring/src/lib.rs
@@ -75,7 +75,7 @@ impl<Ctx: AstDesugaringCtxQuery> CompilerStage<Ctx> for AstDesugaringPass {
             // De-sugar the target if it isn't already de-sugared
             if !source_stage_info.get(entry_point).is_desugared() && entry_point.is_interactive() {
                 let source = node_map.get_interactive_block_mut(entry_point.into());
-                let mut desugarer = AstDesugaring::new(source_map, entry_point);
+                let mut desugarer = AstDesugaring::new(source_map);
 
                 desugarer.visit_body_block(source.node_ref_mut()).unwrap();
             }
@@ -101,7 +101,7 @@ impl<Ctx: AstDesugaringCtxQuery> CompilerStage<Ctx> for AstDesugaringPass {
                 // investigating this in the future.
                 for expr in module.node_mut().contents.iter_mut() {
                     scope.spawn(move |_| {
-                        let mut desugarer = AstDesugaring::new(source_map, source_id);
+                        let mut desugarer = AstDesugaring::new(source_map);
                         desugarer.visit_expr(expr.ast_ref_mut()).unwrap()
                     })
                 }

--- a/compiler/hash-ast-desugaring/src/visitor.rs
+++ b/compiler/hash-ast-desugaring/src/visitor.rs
@@ -5,27 +5,18 @@ use hash_ast::{
     ast_visitor_mut_default_impl,
     visitor::{walk_mut, AstVisitorMut},
 };
-use hash_source::{
-    location::{SourceLocation, Span},
-    SourceId, SourceMap,
-};
+use hash_source::SourceMap;
 
 #[derive(Debug)]
 pub struct AstDesugaring<'s> {
     pub(crate) source_map: &'s SourceMap,
-    source_id: SourceId,
 }
 
 impl<'s> AstDesugaring<'s> {
     /// Create a new [AstDesugaring]. Contains the [SourceMap] and the
     /// current id of the source in reference.
-    pub fn new(source_map: &'s SourceMap, source_id: SourceId) -> Self {
-        Self { source_map, source_id }
-    }
-
-    /// Create a [SourceLocation] from a [Span]
-    pub(crate) fn source_location(&self, span: Span) -> SourceLocation {
-        SourceLocation { span, id: self.source_id }
+    pub fn new(source_map: &'s SourceMap) -> Self {
+        Self { source_map }
     }
 }
 

--- a/compiler/hash-ast-expand/src/lib.rs
+++ b/compiler/hash-ast-expand/src/lib.rs
@@ -64,7 +64,7 @@ impl<Ctx: AstExpansionCtxQuery> CompilerStage<Ctx> for AstExpansionPass {
 
         // De-sugar the target if it isn't already de-sugared
         if source_info.is_expanded() && entry_point.is_interactive() {
-            let mut expander = AstExpander::new(source_map, entry_point, settings, stdout.clone());
+            let mut expander = AstExpander::new(source_map, settings, stdout.clone());
             let source = node_map.get_interactive_block(entry_point.into());
 
             expander.visit_body_block(source.node_ref()).unwrap();
@@ -79,7 +79,7 @@ impl<Ctx: AstExpansionCtxQuery> CompilerStage<Ctx> for AstExpansionPass {
                 continue;
             }
 
-            let mut expander = AstExpander::new(source_map, source_id, settings, stdout.clone());
+            let mut expander = AstExpander::new(source_map, settings, stdout.clone());
             expander.visit_module(module.node_ref()).unwrap();
         }
 

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -31,6 +31,18 @@ define_index_type! {
     DISABLE_MAX_INDEX_CHECK = cfg!(not(debug_assertions));
 }
 
+impl AstNodeId {
+    /// Get the [Span] of this [AstNodeId].
+    pub fn span(&self) -> Span {
+        SpanMap::span_of(*self)
+    }
+
+    /// Get the [SourceId] of this [AstNodeId].
+    pub fn source(&self) -> SourceId {
+        SpanMap::source_of(*self)
+    }
+}
+
 /// The [`SPAN_MAP`] is a global static that is used to store the span
 /// of each AST node. This is used to avoid storing the [Span] on the
 /// [`AstNode<T>`] itself in order for other data structures to be able

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -10,7 +10,7 @@ use std::{
 use hash_source::{
     constant::{FloatTy, IntTy, InternedFloat, InternedInt, InternedStr, SIntTy},
     identifier::Identifier,
-    location::{SourceLocation, Span},
+    location::{ByteRange, SourceLocation},
     SourceId,
 };
 use hash_tree_def::define_tree;
@@ -112,7 +112,7 @@ impl<T> AstNode<T> {
     }
 
     /// Get the [ByteRange] of this [AstNode].
-    pub fn byte_range(&self) -> Span {
+    pub fn byte_range(&self) -> ByteRange {
         self.span().span
     }
 
@@ -137,7 +137,7 @@ impl<T> AstNode<T> {
     }
 
     /// Create an [AstNodeRef] by providing a body and copying over the
-    /// [Span] and [AstNodeId] that belong to this [AstNode].
+    /// [AstNodeId] that belong to this [AstNode].
     pub fn with_body<'u, U>(&self, body: &'u U) -> AstNodeRef<'u, U> {
         AstNodeRef { body, id: self.id }
     }
@@ -172,7 +172,7 @@ impl<'t, T> AstNodeRef<'t, T> {
         self.body
     }
 
-    /// Utility function to copy over the [Span] and [AstNodeId] from
+    /// Utility function to copy over the [AstNodeId] from
     /// another [AstNodeRef] with a provided body.
     pub fn with_body<'u, U>(&self, body: &'u U) -> AstNodeRef<'u, U> {
         AstNodeRef { body, id: self.id }

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -11,6 +11,7 @@ use hash_source::{
     constant::{FloatTy, IntTy, InternedFloat, InternedInt, InternedStr, SIntTy},
     identifier::Identifier,
     location::{SourceLocation, Span},
+    SourceId,
 };
 use hash_tree_def::define_tree;
 use hash_utils::{
@@ -46,6 +47,11 @@ impl SpanMap {
     /// Get the span of a node by [AstNodeId].
     pub fn span_of(id: AstNodeId) -> SourceLocation {
         SPAN_MAP.read()[id]
+    }
+
+    /// Get the [SourceId] of a node by [AstNodeId].
+    pub fn source_of(id: AstNodeId) -> SourceId {
+        SpanMap::span_of(id).id
     }
 
     /// Get a mutable reference to the [`SPAN_MAP`]. This is only

--- a/compiler/hash-codegen-llvm/src/translation/debug_info.rs
+++ b/compiler/hash-codegen-llvm/src/translation/debug_info.rs
@@ -5,7 +5,7 @@ use hash_codegen::{
     abi::FnAbi,
     traits::debug::{DebugInfoBuilderMethods, VariableKind},
 };
-use hash_source::{identifier::Identifier, location::SourceLocation};
+use hash_source::{identifier::Identifier, location::Span};
 
 use super::LLVMBuilder;
 
@@ -24,7 +24,7 @@ impl<'b, 'm> DebugInfoBuilderMethods for LLVMBuilder<'_, 'b, 'm> {
         _ty: hash_ir::ty::IrTyId,
         _scope: Self::DebugInfoScope,
         _kind: VariableKind,
-        _span: SourceLocation,
+        _span: Span,
     ) -> Self::DebugInfoVariable {
         unimplemented!()
     }
@@ -32,7 +32,7 @@ impl<'b, 'm> DebugInfoBuilderMethods for LLVMBuilder<'_, 'b, 'm> {
     fn create_debug_info_location(
         &self,
         _scope: Self::DebugInfoScope,
-        _span: SourceLocation,
+        _span: Span,
     ) -> Self::DebugInfoLocation {
         unimplemented!()
     }

--- a/compiler/hash-codegen/src/traits/debug.rs
+++ b/compiler/hash-codegen/src/traits/debug.rs
@@ -6,7 +6,7 @@
 
 use hash_abi::FnAbi;
 use hash_ir::ty::IrTyId;
-use hash_source::{identifier::Identifier, location::SourceLocation};
+use hash_source::{identifier::Identifier, location::Span};
 
 use super::BackendTypes;
 
@@ -41,7 +41,7 @@ pub trait DebugInfoBuilderMethods: BackendTypes {
         ty: IrTyId,
         scope: Self::DebugInfoScope,
         kind: VariableKind,
-        span: SourceLocation,
+        span: Span,
     ) -> Self::DebugInfoVariable;
 
     /// Create a new [`BackendTypes::DebugInfoLocation`] which represents a
@@ -50,7 +50,7 @@ pub trait DebugInfoBuilderMethods: BackendTypes {
     fn create_debug_info_location(
         &self,
         scope: Self::DebugInfoScope,
-        span: SourceLocation,
+        span: Span,
     ) -> Self::DebugInfoLocation;
 
     /// Finish the process of generating debug information for a particular

--- a/compiler/hash-exhaustiveness/src/diagnostics.rs
+++ b/compiler/hash-exhaustiveness/src/diagnostics.rs
@@ -4,7 +4,7 @@
 use hash_ast::ast::{MatchOrigin, RangeEnd};
 use hash_error_codes::error_codes::HashErrorCode;
 use hash_reporting::{diagnostic::DiagnosticCellStore, reporter::Reporter};
-use hash_source::location::SourceLocation;
+use hash_source::location::Span;
 use hash_tir::{environment::env::Env, lits::LitPat, pats::PatId, utils::common::CommonUtils};
 use hash_utils::{
     itertools::Itertools,
@@ -47,7 +47,7 @@ pub enum ExhaustivenessError {
     /// When a match block is non-exhaustive
     NonExhaustiveMatch {
         /// The term of the subject expression.
-        location: SourceLocation,
+        location: Span,
 
         /// Generated patterns that are not covered by match arms
         uncovered_pats: Vec<PatId>,
@@ -136,7 +136,7 @@ pub enum ExhaustivenessWarning {
         pat: PatId,
 
         /// The location of the match subject that is being checked.
-        location: SourceLocation,
+        location: Span,
     },
 
     // Exhaustiveness checking has found this pattern to

--- a/compiler/hash-exhaustiveness/src/lib.rs
+++ b/compiler/hash-exhaustiveness/src/lib.rs
@@ -67,7 +67,7 @@ use diagnostics::{ExhaustivenessDiagnostics, ExhaustivenessError, Exhaustiveness
 use hash_ast::ast::MatchOrigin;
 use hash_intrinsics::primitives::{AccessToPrimitives, DefinedPrimitives};
 use hash_reporting::diagnostic::Diagnostics;
-use hash_source::location::SourceLocation;
+use hash_source::location::Span;
 use hash_storage::store::CloneStore;
 use hash_tir::{
     environment::env::{AccessToEnv, Env},
@@ -101,7 +101,7 @@ impl PatCtx {
 pub struct ExhaustivenessChecker<'tc> {
     /// The span of the subject that is being checked for exhaustiveness
     /// or usefulness.
-    subject_span: SourceLocation,
+    subject_span: Span,
 
     /// A reference to the TC env in order to lookup various TIR items and have
     /// access to TC utilities.
@@ -138,11 +138,7 @@ impl<'tc> AccessToPrimitives for ExhaustivenessChecker<'tc> {
 
 impl<'tc> ExhaustivenessChecker<'tc> {
     /// Create a new checker.
-    pub fn new(
-        subject_span: SourceLocation,
-        tcx: &'tc Env<'tc>,
-        primitives: &'tc DefinedPrimitives,
-    ) -> Self {
+    pub fn new(subject_span: Span, tcx: &'tc Env<'tc>, primitives: &'tc DefinedPrimitives) -> Self {
         Self {
             subject_span,
             tcx,

--- a/compiler/hash-ir/src/ir.rs
+++ b/compiler/hash-ir/src/ir.rs
@@ -1524,7 +1524,6 @@ mod tests {
     }
 }
 
-
 #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
 mod size_asserts {
     use hash_utils::assert::static_assert_size;

--- a/compiler/hash-ir/src/ir.rs
+++ b/compiler/hash-ir/src/ir.rs
@@ -1523,3 +1523,15 @@ mod tests {
         assert_eq!(format!("{}", place), "(*(*(*_0)))");
     }
 }
+
+
+#[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
+mod size_asserts {
+    use hash_utils::assert::static_assert_size;
+
+    use super::*;
+
+    static_assert_size!(Statement, 64);
+    static_assert_size!(Terminator, 104);
+    static_assert_size!(RValue, 40);
+}

--- a/compiler/hash-ir/src/ir.rs
+++ b/compiler/hash-ir/src/ir.rs
@@ -840,7 +840,7 @@ pub struct Statement {
     /// The location of the statement. This is mostly used for error reporting
     /// or generating debug information at later stages of lowering
     /// beyond the IR.
-    pub span: AstNodeId,
+    pub origin: AstNodeId,
 }
 
 /// The kind of assert terminator that it is.
@@ -916,7 +916,7 @@ pub struct Terminator {
     /// The source location of the terminator. This is mostly used for error
     /// reporting or generating debug information at later stages of
     /// lowering beyond the IR.
-    pub span: AstNodeId,
+    pub origin: AstNodeId,
 }
 
 pub type Successors<'a> = impl Iterator<Item = BasicBlock> + 'a;
@@ -1294,7 +1294,7 @@ pub struct Body {
     pub arg_count: usize,
 
     /// The location of the function
-    span: AstNodeId,
+    origin: AstNodeId,
 
     /// Whether the IR Body that is generated should be printed
     /// when the generation process is finalised.
@@ -1309,7 +1309,7 @@ impl Body {
         declarations: IndexVec<Local, LocalDecl>,
         info: BodyInfo,
         arg_count: usize,
-        span: AstNodeId,
+        origin: AstNodeId,
     ) -> Self {
         Self {
             needed_constants: vec![],
@@ -1317,7 +1317,7 @@ impl Body {
             info,
             declarations,
             arg_count,
-            span,
+            origin,
             dump: false,
         }
     }
@@ -1372,12 +1372,12 @@ impl Body {
 
     /// Get the [Span] of the [Body].
     pub(crate) fn span(&self) -> Span {
-        self.span.span()
+        self.origin.span()
     }
 
     /// Get the [SourceId] of the [Body].
     pub(crate) fn source(&self) -> SourceId {
-        self.span.source()
+        self.origin.source()
     }
 }
 

--- a/compiler/hash-ir/src/ir.rs
+++ b/compiler/hash-ir/src/ir.rs
@@ -12,7 +12,7 @@ use hash_intrinsics::intrinsics;
 use hash_source::{
     constant::{IntConstant, InternedFloat, InternedInt, InternedStr, CONSTANT_MAP},
     identifier::Identifier,
-    location::SourceLocation,
+    location::Span,
     SourceId,
 };
 use hash_storage::{
@@ -1371,7 +1371,7 @@ impl Body {
     }
 
     /// Get the [Span] of the [Body].
-    pub(crate) fn span(&self) -> SourceLocation {
+    pub(crate) fn span(&self) -> Span {
         self.span.span()
     }
 

--- a/compiler/hash-ir/src/write/graphviz.rs
+++ b/compiler/hash-ir/src/write/graphviz.rs
@@ -282,7 +282,7 @@ pub fn dump_ir_bodies(
 
     for (id, body) in bodies.iter().enumerate() {
         // Skip the prelude if we're in quiet mode
-        if prelude_is_quiet && body.source_id.is_prelude() {
+        if prelude_is_quiet && body.source().is_prelude() {
             continue;
         }
 

--- a/compiler/hash-ir/src/write/pretty.rs
+++ b/compiler/hash-ir/src/write/pretty.rs
@@ -164,7 +164,7 @@ pub fn dump_ir_bodies(
 ) -> std::io::Result<()> {
     for (index, body) in bodies.iter().enumerate() {
         // Skip the prelude if we're in quiet mode
-        if prelude_is_quiet && body.source_id.is_prelude() {
+        if prelude_is_quiet && body.source().is_prelude() {
             continue;
         }
 
@@ -184,7 +184,7 @@ pub fn dump_ir_bodies(
             "IR dump for {} `{}` defined at {}\n{}",
             body.info().source(),
             body.info().name(),
-            source_map.fmt_location(body.location()),
+            source_map.fmt_location(body.span()),
             IrBodyWriter::new(body)
         )?;
     }

--- a/compiler/hash-lexer/src/error.rs
+++ b/compiler/hash-lexer/src/error.rs
@@ -7,7 +7,7 @@ use hash_reporting::{
     report::{Report, ReportElement, ReportNote, ReportNoteKind},
     reporter::{Reporter, Reports},
 };
-use hash_source::{identifier::Identifier, location::SourceLocation};
+use hash_source::{identifier::Identifier, location::Span};
 use hash_token::{delimiter::Delimiter, TokenKind};
 
 use crate::Lexer;
@@ -80,7 +80,7 @@ pub type LexerResult<T> = Result<T, LexerError>;
 
 /// A [LexerError] represents a encountered error during tokenisation, which
 /// includes an optional message with the error, the [LexerErrorKind] which
-/// classifies the error, and a [SourceLocation] that represents where the
+/// classifies the error, and a [Span] that represents where the
 /// tokenisation error occurred.
 #[derive(Debug)]
 pub struct LexerError {
@@ -92,7 +92,7 @@ pub struct LexerError {
 
     /// The location of the error, this includes the span and the id of the
     /// source.
-    pub(crate) location: SourceLocation,
+    pub(crate) location: Span,
 }
 
 /// A [LexerErrorKind] represents the kind of [LexerError] which gives

--- a/compiler/hash-lexer/src/lib.rs
+++ b/compiler/hash-lexer/src/lib.rs
@@ -8,7 +8,7 @@ use hash_reporting::diagnostic::AccessToDiagnosticsMut;
 use hash_source::{
     constant::{IntConstant, IntConstantValue, IntTy, SIntTy, UIntTy, CONSTANT_MAP},
     identifier::{Identifier, IDENTS},
-    location::{SourceLocation, Span},
+    location::{ByteRange, SourceLocation},
     SourceId,
 };
 use hash_target::size::Size;
@@ -92,7 +92,7 @@ impl<'a> Lexer<'a> {
         &mut self,
         message: Option<String>,
         kind: LexerErrorKind,
-        span: Span,
+        span: ByteRange,
     ) -> TokenKind {
         self.diagnostics.has_fatal_error.set(true);
         self.emit_error(message, kind, span)
@@ -105,7 +105,7 @@ impl<'a> Lexer<'a> {
         &mut self,
         message: Option<String>,
         kind: LexerErrorKind,
-        span: Span,
+        span: ByteRange,
     ) -> TokenKind {
         self.add_error(LexerError {
             message,
@@ -123,7 +123,7 @@ impl<'a> Lexer<'a> {
         &self,
         message: Option<String>,
         kind: LexerErrorKind,
-        span: Span,
+        span: ByteRange,
     ) -> Result<T, LexerError> {
         Err(LexerError { message, kind, location: SourceLocation { span, id: self.source_id } })
     }
@@ -223,7 +223,10 @@ impl<'a> Lexer<'a> {
 
                         // @@Hack: since we already compare if the first item is a slash, we'll just
                         // return here the slash and advance it by one.
-                        return Some(Token::new(TokenKind::Slash, Span::new(offset, offset + 1)));
+                        return Some(Token::new(
+                            TokenKind::Slash,
+                            ByteRange::new(offset, offset + 1),
+                        ));
                     }
                 },
                 _ => break,
@@ -306,7 +309,7 @@ impl<'a> Lexer<'a> {
             return None;
         }
 
-        let location = Span::new(offset, self.len_consumed());
+        let location = ByteRange::new(offset, self.len_consumed());
         Some(Token::new(token_kind, location))
     }
 
@@ -352,7 +355,7 @@ impl<'a> Lexer<'a> {
             _ => self.emit_error(
                 None,
                 LexerErrorKind::Unclosed(delimiter),
-                Span::new(start, start + 1),
+                ByteRange::new(start, start + 1),
             ),
         }
     }
@@ -492,7 +495,7 @@ impl<'a> Lexer<'a> {
                 self.emit_error(
                     None,
                     LexerErrorKind::InvalidLitSuffix(NumericLitKind::Integer, suffix),
-                    Span::new(self.offset.get(), self.offset.get()),
+                    ByteRange::new(self.offset.get(), self.offset.get()),
                 );
 
                 IntTy::Int(SIntTy::I32)
@@ -504,7 +507,7 @@ impl<'a> Lexer<'a> {
             self.emit_error(
                 None,
                 LexerErrorKind::MalformedNumericalLit,
-                Span::new(start_pos, self.offset.get()),
+                ByteRange::new(start_pos, self.offset.get()),
             );
 
             // It doesn't matter what we return here since we will terminate on the
@@ -563,7 +566,7 @@ impl<'a> Lexer<'a> {
                     return self.emit_error(
                         None,
                         LexerErrorKind::MissingDigits,
-                        Span::new(start, self.offset.get()),
+                        ByteRange::new(start, self.offset.get()),
                     );
                 }
 
@@ -578,7 +581,7 @@ impl<'a> Lexer<'a> {
                     return self.emit_error(
                         None,
                         LexerErrorKind::UnsupportedFloatBaseLiteral(radix.into()),
-                        Span::new(start, self.offset.get()),
+                        ByteRange::new(start, self.offset.get()),
                     );
                 } else {
                     return self.create_int_const(chars.as_str(), radix, suffix, start);
@@ -625,7 +628,7 @@ impl<'a> Lexer<'a> {
                         Err(err) => self.emit_error(
                             Some(format!("{err}.")),
                             LexerErrorKind::MalformedNumericalLit,
-                            Span::new(start, self.offset.get()),
+                            ByteRange::new(start, self.offset.get()),
                         ),
                         Ok(parsed) => {
                             // Create interned float constant
@@ -651,7 +654,7 @@ impl<'a> Lexer<'a> {
             Err(err) => self.emit_error(
                 Some(format!("{err}.")),
                 LexerErrorKind::MalformedNumericalLit,
-                Span::new(start, self.offset.get()),
+                ByteRange::new(start, self.offset.get()),
             ),
             Ok(value) => {
                 match self.eat_exponent(start) {
@@ -672,7 +675,7 @@ impl<'a> Lexer<'a> {
                                 self.emit_error(
                                     None,
                                     LexerErrorKind::InvalidLitSuffix(NumericLitKind::Float, suffix_ident),
-                                    Span::new(start, self.offset.get()),
+                                    ByteRange::new(start, self.offset.get()),
                                 );
                             }
 
@@ -713,7 +716,7 @@ impl<'a> Lexer<'a> {
             return self.error(
                 None,
                 LexerErrorKind::MissingExponentDigits,
-                Span::new(start, self.offset.get()),
+                ByteRange::new(start, self.offset.get()),
             );
         }
 
@@ -721,7 +724,7 @@ impl<'a> Lexer<'a> {
             Err(_) => self.error(
                 Some("Invalid float exponent.".to_string()),
                 LexerErrorKind::MalformedNumericalLit,
-                Span::new(start, self.offset.get() + 1),
+                ByteRange::new(start, self.offset.get() + 1),
             ),
             Ok(num) if negated => Ok(-num),
             Ok(num) => Ok(num),
@@ -756,7 +759,7 @@ impl<'a> Lexer<'a> {
                     return self.error(
                         Some("Expected `{` after a `\\u` escape sequence".to_string()),
                         LexerErrorKind::BadEscapeSequence,
-                        Span::new(start, self.offset.get()),
+                        ByteRange::new(start, self.offset.get()),
                     );
                 }
 
@@ -769,7 +772,7 @@ impl<'a> Lexer<'a> {
                     return self.error(
                         Some("expected `}` after a escape sequence".to_string()),
                         LexerErrorKind::BadEscapeSequence,
-                        Span::new(self.offset.get(), self.offset.get() + 1),
+                        ByteRange::new(self.offset.get(), self.offset.get() + 1),
                     );
                 }
                 self.skip(); // Eat the '}' ending part of the scape sequence
@@ -778,7 +781,7 @@ impl<'a> Lexer<'a> {
                     return self.error(
                         Some("Unicode escape literal must be at most 6 hex digits".to_string()),
                         LexerErrorKind::BadEscapeSequence,
-                        Span::new(start, self.offset.get()),
+                        ByteRange::new(start, self.offset.get()),
                     );
                 }
 
@@ -791,7 +794,7 @@ impl<'a> Lexer<'a> {
                                 .to_string(),
                         ),
                         LexerErrorKind::BadEscapeSequence,
-                        Span::new(start, self.offset.get()),
+                        ByteRange::new(start, self.offset.get()),
                     );
                 }
 
@@ -807,12 +810,12 @@ impl<'a> Lexer<'a> {
                         EOF_CHAR => self.error(
                             Some("ASCII escape code too short".to_string()),
                             LexerErrorKind::BadEscapeSequence,
-                            Span::new(start, self.offset.get()),
+                            ByteRange::new(start, self.offset.get()),
                         ),
                         c => self.error(
                             Some("ASCII escape code must only contain hex digits".to_string()),
                             LexerErrorKind::Unexpected(c),
-                            Span::new(start, self.offset.get()),
+                            ByteRange::new(start, self.offset.get()),
                         ),
                     })
                     .collect();
@@ -836,7 +839,7 @@ impl<'a> Lexer<'a> {
             ch => self.error(
                 Some(format!("unknown escape sequence `{ch}`")),
                 LexerErrorKind::BadEscapeSequence,
-                Span::new(start, start + 1),
+                ByteRange::new(start, start + 1),
             ),
         }
     }
@@ -878,14 +881,14 @@ impl<'a> Lexer<'a> {
                             return self.emit_error(
                                 Some("unclosed character literal".to_string()),
                                 LexerErrorKind::Expected(TokenKind::SingleQuote),
-                                Span::new(offset, offset + 1),
+                                ByteRange::new(offset, offset + 1),
                             );
                         }
 
                         return self.emit_error(
                             Some("character literal can only contain one codepoint".to_string()),
                             LexerErrorKind::BadEscapeSequence,
-                            Span::new(start, offset),
+                            ByteRange::new(start, offset),
                         );
                     }
 
@@ -922,7 +925,7 @@ impl<'a> Lexer<'a> {
         self.emit_error(
             None,
             LexerErrorKind::InvalidCharacterLit(lit),
-            Span::new(start, self.offset.get()),
+            ByteRange::new(start, self.offset.get()),
         )
     }
 
@@ -964,7 +967,7 @@ impl<'a> Lexer<'a> {
             return self.emit_fatal_error(
                 None,
                 LexerErrorKind::UnclosedStringLit,
-                Span::new(start, self.offset.get()),
+                ByteRange::new(start, self.offset.get()),
             );
         }
 

--- a/compiler/hash-lexer/src/lib.rs
+++ b/compiler/hash-lexer/src/lib.rs
@@ -8,7 +8,7 @@ use hash_reporting::diagnostic::AccessToDiagnosticsMut;
 use hash_source::{
     constant::{IntConstant, IntConstantValue, IntTy, SIntTy, UIntTy, CONSTANT_MAP},
     identifier::{Identifier, IDENTS},
-    location::{ByteRange, SourceLocation},
+    location::{ByteRange, Span},
     SourceId,
 };
 use hash_target::size::Size;
@@ -107,11 +107,7 @@ impl<'a> Lexer<'a> {
         kind: LexerErrorKind,
         span: ByteRange,
     ) -> TokenKind {
-        self.add_error(LexerError {
-            message,
-            kind,
-            location: SourceLocation { span, id: self.source_id },
-        });
+        self.add_error(LexerError { message, kind, location: Span { span, id: self.source_id } });
 
         TokenKind::Err
     }
@@ -125,7 +121,7 @@ impl<'a> Lexer<'a> {
         kind: LexerErrorKind,
         span: ByteRange,
     ) -> Result<T, LexerError> {
-        Err(LexerError { message, kind, location: SourceLocation { span, id: self.source_id } })
+        Err(LexerError { message, kind, location: Span { span, id: self.source_id } })
     }
 
     /// Returns a reference to the stored token trees for the current job

--- a/compiler/hash-lower/src/build/constant.rs
+++ b/compiler/hash-lower/src/build/constant.rs
@@ -25,11 +25,11 @@ impl<'tcx> BodyBuilder<'tcx> {
     }
 
     /// Lower a constant expression, i.e. a literal value.
-    pub(crate) fn lower_constant_expr(&mut self, term: &Term, span: AstNodeId) -> ConstKind {
+    pub(crate) fn lower_constant_expr(&mut self, term: &Term, origin: AstNodeId) -> ConstKind {
         match term {
             Term::Lit(lit) => self.as_constant(lit),
             _ => panic_on_span!(
-                span.span(),
+                origin.span(),
                 self.source_map(),
                 "cannot lower non-literal expression into constant"
             ),

--- a/compiler/hash-lower/src/build/constant.rs
+++ b/compiler/hash-lower/src/build/constant.rs
@@ -4,12 +4,10 @@
 
 use std::ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Rem, Shl, Shr, Sub};
 
+use hash_ast::ast::AstNodeId;
 use hash_ir::ir::{self, BinOp, Const, ConstKind};
 use hash_reporting::macros::panic_on_span;
-use hash_source::{
-    constant::{FloatConstant, FloatConstantValue, IntConstant, CONSTANT_MAP},
-    location::Span,
-};
+use hash_source::constant::{FloatConstant, FloatConstantValue, IntConstant, CONSTANT_MAP};
 use hash_tir::{environment::env::AccessToEnv, lits::Lit, terms::Term};
 
 use super::BodyBuilder;
@@ -27,11 +25,11 @@ impl<'tcx> BodyBuilder<'tcx> {
     }
 
     /// Lower a constant expression, i.e. a literal value.
-    pub(crate) fn lower_constant_expr(&mut self, term: &Term, span: Span) -> ConstKind {
+    pub(crate) fn lower_constant_expr(&mut self, term: &Term, span: AstNodeId) -> ConstKind {
         match term {
             Term::Lit(lit) => self.as_constant(lit),
             _ => panic_on_span!(
-                span.into_location(self.source_id),
+                span.span(),
                 self.source_map(),
                 "cannot lower non-literal expression into constant"
             ),

--- a/compiler/hash-lower/src/build/matches/candidate.rs
+++ b/compiler/hash-lower/src/build/matches/candidate.rs
@@ -46,7 +46,7 @@ use crate::build::{place::PlaceBuilder, BodyBuilder};
 pub(super) struct Candidate {
     /// The span of the `match` arm, for-error reporting
     /// functionality.
-    pub span: AstNodeId,
+    pub origin: AstNodeId,
 
     /// Whether or not the candidate arm hsa an associated guard,
     pub has_guard: bool,
@@ -92,9 +92,14 @@ pub(super) type Candidates<'tcx> = (MatchCase, Candidate);
 
 impl Candidate {
     /// Create a new [Candidate].
-    pub(super) fn new(span: AstNodeId, pat: PatId, place: &PlaceBuilder, has_guard: bool) -> Self {
+    pub(super) fn new(
+        origin: AstNodeId,
+        pat: PatId,
+        place: &PlaceBuilder,
+        has_guard: bool,
+    ) -> Self {
         Self {
-            span,
+            origin,
             has_guard,
             otherwise_block: None,
             pre_binding_block: None,
@@ -145,7 +150,7 @@ pub(super) fn traverse_candidate<C, T, I>(
 #[derive(Debug, Clone)]
 pub(super) struct Binding {
     /// The span of the binding.
-    pub span: AstNodeId,
+    pub origin: AstNodeId,
 
     /// The source of the binding, where the value is coming from.
     pub source: Place,
@@ -274,7 +279,7 @@ impl<'tcx> BodyBuilder<'tcx> {
                 }
 
                 candidate.bindings.push(Binding {
-                    span,
+                    origin: span,
                     mutability: if is_mutable {
                         Mutability::Mutable
                     } else {
@@ -465,7 +470,7 @@ impl<'tcx> BodyBuilder<'tcx> {
             .copied()
             .map(|pat| {
                 let mut sub_candidate = Candidate::new(
-                    candidate.span,
+                    candidate.origin,
                     pat,
                     subject,
                     candidate.has_guard || pat.borrow().is_or(),

--- a/compiler/hash-lower/src/build/matches/candidate.rs
+++ b/compiler/hash-lower/src/build/matches/candidate.rs
@@ -13,12 +13,11 @@
 
 use std::{borrow::Borrow, mem};
 
-use hash_ast::ast;
+use hash_ast::ast::{self, AstNodeId};
 use hash_ir::{
     ir::{BasicBlock, Place, PlaceProjection},
     ty::{AdtId, IrTy, Mutability},
 };
-use hash_source::location::Span;
 use hash_storage::store::statics::StoreId;
 use hash_target::size::Size;
 use hash_tir::{
@@ -47,7 +46,7 @@ use crate::build::{place::PlaceBuilder, BodyBuilder};
 pub(super) struct Candidate {
     /// The span of the `match` arm, for-error reporting
     /// functionality.
-    pub span: Span,
+    pub span: AstNodeId,
 
     /// Whether or not the candidate arm hsa an associated guard,
     pub has_guard: bool,
@@ -93,7 +92,7 @@ pub(super) type Candidates<'tcx> = (MatchCase, Candidate);
 
 impl Candidate {
     /// Create a new [Candidate].
-    pub(super) fn new(span: Span, pat: PatId, place: &PlaceBuilder, has_guard: bool) -> Self {
+    pub(super) fn new(span: AstNodeId, pat: PatId, place: &PlaceBuilder, has_guard: bool) -> Self {
         Self {
             span,
             has_guard,
@@ -146,7 +145,7 @@ pub(super) fn traverse_candidate<C, T, I>(
 #[derive(Debug, Clone)]
 pub(super) struct Binding {
     /// The span of the binding.
-    pub span: Span,
+    pub span: AstNodeId,
 
     /// The source of the binding, where the value is coming from.
     pub source: Place,

--- a/compiler/hash-lower/src/build/matches/declarations.rs
+++ b/compiler/hash-lower/src/build/matches/declarations.rs
@@ -1,12 +1,12 @@
 //! This deals with lowering declarations,assigning them to a [Local],
 //! and later resolving references to the locals with the current [Builder].
 
+use hash_ast::ast::AstNodeId;
 use hash_ir::{
     ir::{BasicBlock, Local, LocalDecl, Place},
     ty::{IrTyId, Mutability},
 };
 use hash_reporting::macros::panic_on_span;
-use hash_source::location::Span;
 use hash_storage::store::{statics::StoreId, TrivialSequenceStoreKey};
 use hash_tir::{
     arrays::ArrayPat,
@@ -46,7 +46,7 @@ impl<'tcx> BodyBuilder<'tcx> {
         &mut self,
         mut block: BasicBlock,
         decl: &DeclTerm,
-        decl_span: Span,
+        decl_span: AstNodeId,
     ) -> BlockAnd<()> {
         if let Some(value) = &decl.value {
             // First, we declare all of the bindings that are present
@@ -57,7 +57,7 @@ impl<'tcx> BodyBuilder<'tcx> {
             unpack!(block = self.tir_term_into_pat(block, decl.bind_pat, *value));
         } else {
             panic_on_span!(
-                decl_span.into_location(self.source_id),
+                decl_span.span(),
                 self.source_map(),
                 "expected initialisation value, declaration are expected to have values (for now)."
             );
@@ -83,7 +83,7 @@ impl<'tcx> BodyBuilder<'tcx> {
     fn visit_primary_pattern_bindings(
         &mut self,
         pat: PatId,
-        f: &mut impl FnMut(&mut Self, Mutability, Symbol, Span, IrTyId),
+        f: &mut impl FnMut(&mut Self, Mutability, Symbol, AstNodeId, IrTyId),
     ) {
         let span = self.span_of_pat(pat);
 

--- a/compiler/hash-lower/src/build/matches/declarations.rs
+++ b/compiler/hash-lower/src/build/matches/declarations.rs
@@ -46,7 +46,7 @@ impl<'tcx> BodyBuilder<'tcx> {
         &mut self,
         mut block: BasicBlock,
         decl: &DeclTerm,
-        decl_span: AstNodeId,
+        decl_origin: AstNodeId,
     ) -> BlockAnd<()> {
         if let Some(value) = &decl.value {
             // First, we declare all of the bindings that are present
@@ -57,7 +57,7 @@ impl<'tcx> BodyBuilder<'tcx> {
             unpack!(block = self.tir_term_into_pat(block, decl.bind_pat, *value));
         } else {
             panic_on_span!(
-                decl_span.span(),
+                decl_origin.span(),
                 self.source_map(),
                 "expected initialisation value, declaration are expected to have values (for now)."
             );

--- a/compiler/hash-lower/src/build/matches/mod.rs
+++ b/compiler/hash-lower/src/build/matches/mod.rs
@@ -10,12 +10,11 @@ mod test;
 
 use std::mem;
 
-use hash_ast::ast;
+use hash_ast::ast::{self, AstNodeId};
 use hash_ir::{
     ir::{self, BasicBlock, LogicalBinOp, Place, RValue, TerminatorKind},
     ty::{Mutability, RefKind},
 };
-use hash_source::location::Span;
 use hash_storage::store::statics::StoreId;
 use hash_tir::{
     context::{Context, ScopeKind},
@@ -44,7 +43,7 @@ impl<'tcx> BodyBuilder<'tcx> {
         &mut self,
         destination: Place,
         mut block: BasicBlock,
-        span: Span,
+        span: AstNodeId,
         subject: TermId,
         arms: MatchCasesId,
         origin: ast::MatchOrigin,
@@ -137,8 +136,8 @@ impl<'tcx> BodyBuilder<'tcx> {
     fn lower_match_tree(
         &mut self,
         block: BasicBlock,
-        subject_span: Span,
-        span: Span,
+        subject_span: AstNodeId,
+        span: AstNodeId,
         candidates: &mut [&mut Candidate],
     ) {
         // This is the basic block that is derived for using when the
@@ -178,7 +177,7 @@ impl<'tcx> BodyBuilder<'tcx> {
     fn lower_match_arms(
         &mut self,
         destination: Place,
-        subject_span: Span,
+        subject_span: AstNodeId,
         arm_candidates: Vec<Candidates<'tcx>>,
     ) -> BlockAnd<()> {
         // Lower all of the arms...
@@ -221,7 +220,7 @@ impl<'tcx> BodyBuilder<'tcx> {
     /// This is the main **entry point** of the match-lowering algorithm.
     fn match_candidates(
         &mut self,
-        span: Span,
+        span: AstNodeId,
         block: BasicBlock,
         otherwise: &mut Option<BasicBlock>,
         candidates: &mut [&mut Candidate],
@@ -257,7 +256,7 @@ impl<'tcx> BodyBuilder<'tcx> {
 
     fn match_simplified_candidates(
         &mut self,
-        span: Span,
+        span: AstNodeId,
         start_block: BasicBlock,
         otherwise_block: &mut Option<BasicBlock>,
         candidates: &mut [&mut Candidate],
@@ -369,7 +368,7 @@ impl<'tcx> BodyBuilder<'tcx> {
     /// if not then we start building tests for candidates.
     fn test_candidates_with_or(
         &mut self,
-        span: Span,
+        span: AstNodeId,
         candidates: &mut [&mut Candidate],
         block: BasicBlock,
         otherwise_block: &mut Option<BasicBlock>,
@@ -471,7 +470,7 @@ impl<'tcx> BodyBuilder<'tcx> {
     /// approach, we essentially generate an `if-else-if` chain.
     fn test_candidates(
         &mut self,
-        span: Span,
+        span: AstNodeId,
         mut candidates: &mut [&mut Candidate],
         block: BasicBlock,
         otherwise: &mut Option<BasicBlock>,
@@ -579,7 +578,7 @@ impl<'tcx> BodyBuilder<'tcx> {
 
     /// This function is responsible for putting all of the declared bindings
     /// into scope.
-    fn bind_pat(&mut self, span: Span, pat: PatId, candidate: Candidate) -> BasicBlock {
+    fn bind_pat(&mut self, span: AstNodeId, pat: PatId, candidate: Candidate) -> BasicBlock {
         let guard = match pat.value() {
             Pat::If(IfPat { condition, .. }) => Some(condition),
             _ => None,
@@ -627,7 +626,7 @@ impl<'tcx> BodyBuilder<'tcx> {
         candidate: Candidate,
         guard: Option<TermId>,
         parent_bindings: &[Vec<Binding>],
-        span: Span,
+        span: AstNodeId,
     ) -> BasicBlock {
         let block = candidate.pre_binding_block.unwrap();
 

--- a/compiler/hash-lower/src/build/matches/optimise.rs
+++ b/compiler/hash-lower/src/build/matches/optimise.rs
@@ -4,11 +4,11 @@
 
 use std::mem;
 
+use hash_ast::ast::AstNodeId;
 use hash_ir::{
     ir::PlaceProjection,
     ty::{IrTy, IrTyId},
 };
-use hash_source::location::Span;
 use hash_storage::store::statics::StoreId;
 use hash_tir::pats::{PatId, Spread};
 use hash_utils::smallvec::SmallVec;
@@ -19,7 +19,7 @@ use crate::build::{place::PlaceBuilder, BodyBuilder};
 impl<'tcx> BodyBuilder<'tcx> {
     /// Attempt to optimise the sub-candidates of a provided [Candidate]. This
     /// only performs a trivial merge, so we avoid generating exponential
-    pub(super) fn merge_sub_candidates(&mut self, candidate: &mut Candidate, span: Span) {
+    pub(super) fn merge_sub_candidates(&mut self, candidate: &mut Candidate, span: AstNodeId) {
         if candidate.sub_candidates.is_empty() {
             return;
         }

--- a/compiler/hash-lower/src/build/matches/optimise.rs
+++ b/compiler/hash-lower/src/build/matches/optimise.rs
@@ -19,7 +19,7 @@ use crate::build::{place::PlaceBuilder, BodyBuilder};
 impl<'tcx> BodyBuilder<'tcx> {
     /// Attempt to optimise the sub-candidates of a provided [Candidate]. This
     /// only performs a trivial merge, so we avoid generating exponential
-    pub(super) fn merge_sub_candidates(&mut self, candidate: &mut Candidate, span: AstNodeId) {
+    pub(super) fn merge_sub_candidates(&mut self, candidate: &mut Candidate, origin: AstNodeId) {
         if candidate.sub_candidates.is_empty() {
             return;
         }
@@ -31,7 +31,7 @@ impl<'tcx> BodyBuilder<'tcx> {
         //
         // @@Todo: don't give up so easily here.
         for sub_candidate in &mut candidate.sub_candidates {
-            self.merge_sub_candidates(sub_candidate, span);
+            self.merge_sub_candidates(sub_candidate, origin);
 
             can_merge &=
                 sub_candidate.sub_candidates.is_empty() && sub_candidate.bindings.is_empty();
@@ -44,7 +44,7 @@ impl<'tcx> BodyBuilder<'tcx> {
             // candidate `pre_binding` block.
             for sub_candidate in mem::take(&mut candidate.sub_candidates) {
                 let or_block = sub_candidate.pre_binding_block.unwrap();
-                self.control_flow_graph.goto(or_block, any_matches, span)
+                self.control_flow_graph.goto(or_block, any_matches, origin)
             }
 
             candidate.pre_binding_block = Some(any_matches);

--- a/compiler/hash-lower/src/build/mod.rs
+++ b/compiler/hash-lower/src/build/mod.rs
@@ -24,10 +24,7 @@ use hash_ir::{
     ty::{IrTy, Mutability},
 };
 use hash_pipeline::settings::CompilerSettings;
-use hash_source::{
-    identifier::{Identifier, IDENTS},
-    SourceId,
-};
+use hash_source::identifier::{Identifier, IDENTS};
 use hash_storage::store::{statics::StoreId, FxHashMap, PartialCloneStore, SequenceStoreKey};
 use hash_tir::{
     context::{Context, ScopeKind},
@@ -155,9 +152,6 @@ pub(crate) struct BodyBuilder<'tcx> {
     /// The item that is being lowered.
     item: BuildItem,
 
-    /// The originating module of where this item is defined.
-    source_id: SourceId,
-
     /// Number of arguments that will be used in the function, for constant
     /// expressions, this will be zero.
     arg_count: usize,
@@ -218,7 +212,6 @@ impl<'ctx> BodyBuilder<'ctx> {
     pub(crate) fn new(
         name: Identifier,
         item: BuildItem,
-        source_id: SourceId,
         tcx: BuilderCtx<'ctx>,
         settings: &'ctx CompilerSettings,
     ) -> Self {
@@ -238,7 +231,6 @@ impl<'ctx> BodyBuilder<'ctx> {
             ctx: tcx,
             info: BodyInfo::new(name, source),
             arg_count,
-            source_id,
             control_flow_graph: ControlFlowGraph::new(),
             declarations: IndexVec::new(),
             _needed_constants: Vec::new(),
@@ -279,7 +271,6 @@ impl<'ctx> BodyBuilder<'ctx> {
             self.info,
             self.arg_count,
             span,
-            self.source_id,
         );
 
         // If the body needs to be dumped, then we mark it as such.

--- a/compiler/hash-lower/src/build/rvalue.rs
+++ b/compiler/hash-lower/src/build/rvalue.rs
@@ -199,7 +199,7 @@ impl<'tcx> BodyBuilder<'tcx> {
         &mut self,
         mut block: BasicBlock,
         ty: IrTyId,
-        span: AstNodeId,
+        origin: AstNodeId,
         op: BinOp,
         lhs: Operand,
         rhs: Operand,
@@ -230,14 +230,14 @@ impl<'tcx> BodyBuilder<'tcx> {
                 let overflow = temp.field(1);
 
                 // Push an assignment to the tuple on the operation
-                self.control_flow_graph.push_assign(block, temp, rvalue, span);
+                self.control_flow_graph.push_assign(block, temp, rvalue, origin);
 
                 block = self.assert(
                     block,
                     Operand::Place(overflow),
                     false,
                     AssertKind::Overflow { op, lhs, rhs },
-                    span,
+                    origin,
                 );
 
                 return block.and(result.into());
@@ -264,10 +264,10 @@ impl<'tcx> BodyBuilder<'tcx> {
                     block,
                     is_zero,
                     RValue::BinaryOp(BinOp::Eq, Box::new((rhs, zero_val))),
-                    span,
+                    origin,
                 );
 
-                block = self.assert(block, Operand::Place(is_zero), false, assert_kind, span);
+                block = self.assert(block, Operand::Place(is_zero), false, assert_kind, origin);
 
                 // In the case of signed integers, if the RHS value is `-1`, and the LHS
                 // is the MIN value, this will result in a division overflow, we need to
@@ -288,14 +288,14 @@ impl<'tcx> BodyBuilder<'tcx> {
                         block,
                         is_negative_one,
                         RValue::BinaryOp(BinOp::Eq, Box::new((rhs, negative_one_val))),
-                        span,
+                        origin,
                     );
 
                     self.control_flow_graph.push_assign(
                         block,
                         is_minimum_value,
                         RValue::BinaryOp(BinOp::Eq, Box::new((lhs, minimum_value))),
-                        span,
+                        origin,
                     );
 
                     // To simplify the generated control flow, we perform a bit_and operation
@@ -310,7 +310,7 @@ impl<'tcx> BodyBuilder<'tcx> {
                             BinOp::BitAnd,
                             Box::new((is_negative_one.into(), is_minimum_value.into())),
                         ),
-                        span,
+                        origin,
                     );
 
                     // Now finally, emit the assert
@@ -319,7 +319,7 @@ impl<'tcx> BodyBuilder<'tcx> {
                         Operand::Place(is_overflow),
                         false,
                         AssertKind::Overflow { op, lhs, rhs },
-                        span,
+                        origin,
                     );
                 }
             }

--- a/compiler/hash-lower/src/build/rvalue.rs
+++ b/compiler/hash-lower/src/build/rvalue.rs
@@ -1,15 +1,13 @@
 //! Module that contains logic for handling and creating [RValue]s from
 //! [Term]s.
 
+use hash_ast::ast::AstNodeId;
 use hash_ir::{
     cast::CastKind,
     ir::{AssertKind, BasicBlock, BinOp, Const, ConstKind, Operand, RValue, UnaryOp},
     ty::{IrTy, IrTyId, Mutability, COMMON_IR_TYS},
 };
-use hash_source::{
-    constant::{IntConstant, IntTy, InternedInt, CONSTANT_MAP},
-    location::Span,
-};
+use hash_source::constant::{IntConstant, IntTy, InternedInt, CONSTANT_MAP};
 use hash_storage::store::statics::StoreId;
 use hash_tir::terms::{Term, TermId};
 
@@ -201,7 +199,7 @@ impl<'tcx> BodyBuilder<'tcx> {
         &mut self,
         mut block: BasicBlock,
         ty: IrTyId,
-        span: Span,
+        span: AstNodeId,
         op: BinOp,
         lhs: Operand,
         rhs: Operand,

--- a/compiler/hash-lower/src/build/utils.rs
+++ b/compiler/hash-lower/src/build/utils.rs
@@ -38,7 +38,7 @@ impl<'tcx> BodyBuilder<'tcx> {
     pub(crate) fn span_of_pat(&self, id: PatId) -> AstNodeId {
         self.stores().ast_info().pats().get_node_by_data(id).unwrap_or_else(|| {
             log::debug!("expected pattern `{}` to have a location", id);
-            AstNodeId(0)
+            AstNodeId::new(0)
         })
     }
 
@@ -46,7 +46,7 @@ impl<'tcx> BodyBuilder<'tcx> {
     pub(crate) fn span_of_def(&self, id: FnDefId) -> AstNodeId {
         self.stores().ast_info().fn_defs().get_node_by_data(id).unwrap_or_else(|| {
             log::debug!("expected function definition `{}` to have a location", id);
-            AstNodeId(0)
+            AstNodeId::new(0)
         })
     }
 
@@ -54,7 +54,7 @@ impl<'tcx> BodyBuilder<'tcx> {
     pub(crate) fn span_of_term(&self, id: TermId) -> AstNodeId {
         self.stores().ast_info().terms().get_node_by_data(id).unwrap_or_else(|| {
             log::debug!("expected term `{:?}` to have a location", id);
-            AstNodeId(0)
+            AstNodeId::new(0)
         })
     }
 
@@ -143,13 +143,13 @@ impl<'tcx> BodyBuilder<'tcx> {
         condition: Operand,
         expected: bool,
         kind: AssertKind,
-        span: AstNodeId,
+        origin: AstNodeId,
     ) -> BasicBlock {
         let success_block = self.control_flow_graph.start_new_block();
 
         self.control_flow_graph.terminate(
             block,
-            span,
+            origin,
             TerminatorKind::Assert { condition, expected, kind, target: success_block },
         );
 

--- a/compiler/hash-lower/src/build/utils.rs
+++ b/compiler/hash-lower/src/build/utils.rs
@@ -34,7 +34,7 @@ impl<'tcx> BodyBuilder<'tcx> {
         self.ctx.lcx
     }
 
-    /// Get the [Span] of a given [PatId].
+    /// Get the interned span of a given [PatId].
     pub(crate) fn span_of_pat(&self, id: PatId) -> AstNodeId {
         self.stores().ast_info().pats().get_node_by_data(id).unwrap_or_else(|| {
             log::debug!("expected pattern `{}` to have a location", id);
@@ -42,7 +42,7 @@ impl<'tcx> BodyBuilder<'tcx> {
         })
     }
 
-    /// Get the [Span] of a [FnDefId].
+    /// Get the interned span of a [FnDefId].
     pub(crate) fn span_of_def(&self, id: FnDefId) -> AstNodeId {
         self.stores().ast_info().fn_defs().get_node_by_data(id).unwrap_or_else(|| {
             log::debug!("expected function definition `{}` to have a location", id);
@@ -50,7 +50,7 @@ impl<'tcx> BodyBuilder<'tcx> {
         })
     }
 
-    /// Get the [Span] of a given [TermId].
+    /// Get the interned span of a given [TermId].
     pub(crate) fn span_of_term(&self, id: TermId) -> AstNodeId {
         self.stores().ast_info().terms().get_node_by_data(id).unwrap_or_else(|| {
             log::debug!("expected term `{:?}` to have a location", id);

--- a/compiler/hash-lower/src/cfg.rs
+++ b/compiler/hash-lower/src/cfg.rs
@@ -53,16 +53,16 @@ impl ControlFlowGraph {
 
     /// Create a [BasicBlock] that is terminated by a [TerminatorKind::Return]
     /// and has no other present statements.
-    pub(crate) fn make_return_block(&mut self, span: AstNodeId) -> BasicBlock {
+    pub(crate) fn make_return_block(&mut self, origin: AstNodeId) -> BasicBlock {
         let block = self.start_new_block();
         self.block_data_mut(block).terminator =
-            Some(Terminator { kind: TerminatorKind::Return, span });
+            Some(Terminator { kind: TerminatorKind::Return, origin });
         block
     }
 
     /// Function to terminate a particular [BasicBlock] provided that it has not
     /// been already terminated.
-    pub(crate) fn terminate(&mut self, block: BasicBlock, span: AstNodeId, kind: TerminatorKind) {
+    pub(crate) fn terminate(&mut self, block: BasicBlock, origin: AstNodeId, kind: TerminatorKind) {
         debug_assert!(
             self.block_data(block).terminator.is_none(),
             "terminate: block `{:?}` already has a terminator `{:?}` set",
@@ -70,7 +70,7 @@ impl ControlFlowGraph {
             self.block_data(block).terminator.as_ref().unwrap()
         );
 
-        self.block_data_mut(block).terminator = Some(Terminator { span, kind });
+        self.block_data_mut(block).terminator = Some(Terminator { origin, kind });
     }
 
     /// Check whether a block has been terminated or not.
@@ -89,13 +89,13 @@ impl ControlFlowGraph {
         block: BasicBlock,
         place: Place,
         value: RValue,
-        span: AstNodeId,
+        origin: AstNodeId,
     ) {
-        self.push(block, Statement { kind: StatementKind::Assign(place, value), span });
+        self.push(block, Statement { kind: StatementKind::Assign(place, value), origin });
     }
 
     /// Terminate a [BasicBlock] by adding a [TerminatorKind::Goto]
-    pub(crate) fn goto(&mut self, source: BasicBlock, target: BasicBlock, span: AstNodeId) {
-        self.terminate(source, span, TerminatorKind::Goto(target));
+    pub(crate) fn goto(&mut self, source: BasicBlock, target: BasicBlock, origin: AstNodeId) {
+        self.terminate(source, origin, TerminatorKind::Goto(target));
     }
 }

--- a/compiler/hash-lower/src/cfg.rs
+++ b/compiler/hash-lower/src/cfg.rs
@@ -3,10 +3,10 @@
 
 use std::fmt;
 
+use hash_ast::ast::AstNodeId;
 use hash_ir::ir::{
     BasicBlock, BasicBlockData, Place, RValue, Statement, StatementKind, Terminator, TerminatorKind,
 };
-use hash_source::location::Span;
 use hash_utils::index_vec::IndexVec;
 
 pub struct ControlFlowGraph {
@@ -53,16 +53,16 @@ impl ControlFlowGraph {
 
     /// Create a [BasicBlock] that is terminated by a [TerminatorKind::Return]
     /// and has no other present statements.
-    pub(crate) fn make_return_block(&mut self) -> BasicBlock {
+    pub(crate) fn make_return_block(&mut self, span: AstNodeId) -> BasicBlock {
         let block = self.start_new_block();
         self.block_data_mut(block).terminator =
-            Some(Terminator { kind: TerminatorKind::Return, span: Span::default() });
+            Some(Terminator { kind: TerminatorKind::Return, span });
         block
     }
 
     /// Function to terminate a particular [BasicBlock] provided that it has not
     /// been already terminated.
-    pub(crate) fn terminate(&mut self, block: BasicBlock, span: Span, kind: TerminatorKind) {
+    pub(crate) fn terminate(&mut self, block: BasicBlock, span: AstNodeId, kind: TerminatorKind) {
         debug_assert!(
             self.block_data(block).terminator.is_none(),
             "terminate: block `{:?}` already has a terminator `{:?}` set",
@@ -89,13 +89,13 @@ impl ControlFlowGraph {
         block: BasicBlock,
         place: Place,
         value: RValue,
-        span: Span,
+        span: AstNodeId,
     ) {
         self.push(block, Statement { kind: StatementKind::Assign(place, value), span });
     }
 
     /// Terminate a [BasicBlock] by adding a [TerminatorKind::Goto]
-    pub(crate) fn goto(&mut self, source: BasicBlock, target: BasicBlock, span: Span) {
+    pub(crate) fn goto(&mut self, source: BasicBlock, target: BasicBlock, span: AstNodeId) {
         self.terminate(source, span, TerminatorKind::Goto(target));
     }
 }

--- a/compiler/hash-lower/src/lib.rs
+++ b/compiler/hash-lower/src/lib.rs
@@ -34,7 +34,7 @@ use hash_pipeline::{
     workspace::{SourceStageInfo, Workspace},
 };
 use hash_semantics::SemanticStorage;
-use hash_source::{identifier::IDENTS, location::SourceLocation, SourceId};
+use hash_source::{identifier::IDENTS, SourceId};
 use hash_storage::store::{
     statics::{SequenceStoreValue, StoreId},
     PartialStore,
@@ -44,7 +44,6 @@ use hash_tir::{
     data::DataTy,
     directives::DirectiveTarget,
     environment::{env::Env, source_info::CurrentSourceInfo, stores::tir_stores},
-    utils::common::CommonUtils,
 };
 use hash_utils::{
     stream_writeln,
@@ -153,13 +152,7 @@ impl<Ctx: LoweringCtxQuery> CompilerStage<Ctx> for IrGen {
             for func in items.iter() {
                 let name = func.borrow().name.ident();
 
-                // Get the source of the symbol therefore that way
-                // we can get the source id of the function.
-                let Some(SourceLocation { id, .. }) = env.get_location(func) else {
-                    panic!("function `{name}` has no defined source location");
-                };
-
-                let mut builder = BodyBuilder::new(name, (*func).into(), id, ctx, settings);
+                let mut builder = BodyBuilder::new(name, (*func).into(), ctx, settings);
                 builder.build();
 
                 let body = builder.finish();

--- a/compiler/hash-parser/src/diagnostics/error.rs
+++ b/compiler/hash-parser/src/diagnostics/error.rs
@@ -6,7 +6,7 @@ use hash_reporting::{
     report::{ReportElement, ReportNote, ReportNoteKind},
     reporter::{Reporter, Reports},
 };
-use hash_source::{identifier::Identifier, location::SourceLocation};
+use hash_source::{identifier::Identifier, location::Span};
 use hash_token::{TokenKind, TokenKindVector};
 use hash_utils::printing::SequenceDisplay;
 
@@ -22,7 +22,7 @@ pub struct ParseError {
     /// The kind of the error.
     kind: ParseErrorKind,
     /// Location of where the error references
-    location: SourceLocation,
+    location: Span,
     /// An optional vector of tokens that are expected to circumvent the error.
     expected: Option<TokenKindVector>,
     /// An optional token in question that was received byt shouldn't of been

--- a/compiler/hash-parser/src/diagnostics/mod.rs
+++ b/compiler/hash-parser/src/diagnostics/mod.rs
@@ -9,18 +9,12 @@ use hash_reporting::{
     reporter::Reports,
 };
 
-use self::{
-    error::ParseError,
-    warning::{ParseWarning, ParseWarningWrapper},
-};
+use self::{error::ParseError, warning::ParseWarning};
 use crate::parser::AstGen;
 
 impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
     pub(super) fn into_reports(mut self) -> Reports {
-        let current_source_id = self.resolver.current_source_id();
-        self.diagnostics().into_reports(Reports::from, |warn| {
-            Reports::from(ParseWarningWrapper(warn, current_source_id))
-        })
+        self.diagnostics().into_reports(Reports::from, Reports::from)
     }
 }
 

--- a/compiler/hash-parser/src/diagnostics/warning.rs
+++ b/compiler/hash-parser/src/diagnostics/warning.rs
@@ -5,7 +5,7 @@ use std::fmt::Display;
 use derive_more::Constructor;
 use hash_ast::ast::Expr;
 use hash_reporting::reporter::{Reporter, Reports};
-use hash_source::location::SourceLocation;
+use hash_source::location::Span;
 use hash_utils::pluralise;
 
 use crate::parser::DefinitionKind;
@@ -18,7 +18,7 @@ pub struct ParseWarning {
     kind: WarningKind,
 
     /// The highlighter span of the where the warning applies to.
-    span: SourceLocation,
+    span: Span,
 }
 
 /// When warnings describe that a subject could be being applied

--- a/compiler/hash-parser/src/diagnostics/warning.rs
+++ b/compiler/hash-parser/src/diagnostics/warning.rs
@@ -5,10 +5,7 @@ use std::fmt::Display;
 use derive_more::Constructor;
 use hash_ast::ast::Expr;
 use hash_reporting::reporter::{Reporter, Reports};
-use hash_source::{
-    location::{SourceLocation, Span},
-    SourceId,
-};
+use hash_source::location::SourceLocation;
 use hash_utils::pluralise;
 
 use crate::parser::DefinitionKind;
@@ -19,8 +16,9 @@ pub struct ParseWarning {
     /// The kind of warning that is generated, stores relevant information
     /// about the warning.
     kind: WarningKind,
+
     /// The highlighter span of the where the warning applies to.
-    location: Span,
+    span: SourceLocation,
 }
 
 /// When warnings describe that a subject could be being applied
@@ -75,10 +73,8 @@ pub enum WarningKind {
     UselessTyParams { def_kind: DefinitionKind },
 }
 
-pub(crate) struct ParseWarningWrapper(pub ParseWarning, pub SourceId);
-
-impl From<ParseWarningWrapper> for Reports {
-    fn from(ParseWarningWrapper(warning, id): ParseWarningWrapper) -> Self {
+impl From<ParseWarning> for Reports {
+    fn from(warning: ParseWarning) -> Self {
         let mut span_label = "".to_string();
 
         let message = match warning.kind {
@@ -108,10 +104,7 @@ impl From<ParseWarningWrapper> for Reports {
         };
 
         let mut reporter = Reporter::new();
-        reporter
-            .warning()
-            .title(message)
-            .add_labelled_span(SourceLocation { span: warning.location, id }, span_label);
+        reporter.warning().title(message).add_labelled_span(warning.span, span_label);
 
         reporter.into_reports()
     }

--- a/compiler/hash-parser/src/import_resolver.rs
+++ b/compiler/hash-parser/src/import_resolver.rs
@@ -32,7 +32,7 @@ impl<'p> ImportResolver<'p> {
     }
 
     /// Get the [SourceId] associated with the current [ImportResolver]
-    pub(crate) fn current_source_id(&self) -> SourceId {
+    pub(crate) fn source(&self) -> SourceId {
         self.source_id
     }
 

--- a/compiler/hash-parser/src/parser/block.rs
+++ b/compiler/hash-parser/src/parser/block.rs
@@ -16,7 +16,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         let block = gen.parse_body_block_inner();
         self.diagnostics.merge_diagnostics(gen.diagnostics);
 
-        Ok(self.node_with_span(Block::Body(block), self.current_location()))
+        Ok(self.node_with_span(Block::Body(block), self.current_pos()))
     }
 
     /// Helper function to simply parse a body block without wrapping it in
@@ -28,7 +28,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         let block = gen.parse_body_block_inner();
         self.merge_diagnostics(gen.diagnostics);
 
-        Ok(self.node_with_span(block, self.current_location()))
+        Ok(self.node_with_span(block, self.current_pos()))
     }
 
     /// Parse a body block that uses itself as the inner generator. This
@@ -36,7 +36,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
     /// next token is a brace tree.
     pub(crate) fn parse_body_block_inner(&mut self) -> BodyBlock {
         // Append the initial statement if there is one.
-        let start = self.current_location();
+        let start = self.current_pos();
         let mut block = BodyBlock { statements: AstNodes::empty(self.span()), expr: None };
 
         // Just return an empty block if we don't get anything
@@ -47,7 +47,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         // firstly check if the first token signals a beginning of a statement, we can
         // tell this by checking for keywords that must begin a statement...
         while self.has_token() {
-            let next_location = self.current_location();
+            let next_location = self.current_pos();
 
             let (semi, expr) = match self.parse_top_level_expr() {
                 Ok(Some(res)) => res,
@@ -64,7 +64,8 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
             } else {
                 // update the `statements` span to reflect the true span of the statements
                 // that were parsed
-                block.statements.set_span(start.join(next_location));
+                let span = self.make_span(start.join(next_location));
+                block.statements.set_span(span);
                 block.expr = Some(expr)
             }
         }
@@ -76,7 +77,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
     pub(crate) fn parse_for_loop(&mut self) -> ParseResult<AstNode<Block>> {
         debug_assert!(self.current_token().has_kind(TokenKind::Keyword(Keyword::For)));
 
-        let start = self.current_location();
+        let start = self.current_pos();
 
         // now we parse the singular pattern that begins at the for-loop
         let pattern = self.parse_singular_pat()?;
@@ -96,7 +97,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
     pub(crate) fn parse_while_loop(&mut self) -> ParseResult<AstNode<Block>> {
         debug_assert!(self.current_token().has_kind(TokenKind::Keyword(Keyword::While)));
 
-        let start = self.current_location();
+        let start = self.current_pos();
 
         let condition = self.parse_expr_with_precedence(0)?;
         let while_body = self.parse_block()?;
@@ -108,7 +109,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
     /// Parse a match case. A match case involves handling the pattern and the
     /// expression branch.
     pub(crate) fn parse_match_case(&mut self) -> ParseResult<AstNode<MatchCase>> {
-        let start = self.current_location();
+        let start = self.current_pos();
         let pattern = self.parse_pat()?;
 
         self.parse_arrow()?;
@@ -122,7 +123,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
     pub(crate) fn parse_match_block(&mut self) -> ParseResult<AstNode<Block>> {
         debug_assert!(self.current_token().has_kind(TokenKind::Keyword(Keyword::Match)));
 
-        let start = self.current_location();
+        let start = self.current_pos();
         let subject = self.parse_expr_with_precedence(0)?;
 
         let mut gen = self.parse_delim_tree(Delimiter::Brace, None)?;
@@ -140,14 +141,14 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
     pub(crate) fn parse_if_block(&mut self) -> ParseResult<AstNode<Block>> {
         debug_assert!(matches!(self.current_token().kind, TokenKind::Keyword(Keyword::If)));
 
-        let start = self.current_location();
+        let start = self.current_pos();
 
         let mut clauses = vec![];
         let mut otherwise_clause = None;
-        let mut if_span = self.current_location();
+        let mut if_span = self.current_pos();
 
         while self.has_token() {
-            if_span = self.current_location();
+            if_span = self.current_pos();
             let condition = self.parse_expr_with_precedence(0)?;
             let body = self.parse_block()?;
 
@@ -179,7 +180,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
 
         Ok(self.node_with_joined_span(
             Block::If(IfBlock {
-                clauses: AstNodes::new(clauses, start.join(if_span)),
+                clauses: self.nodes_with_span(clauses, start.join(if_span)),
                 otherwise: otherwise_clause,
             }),
             start,

--- a/compiler/hash-parser/src/parser/definitions.rs
+++ b/compiler/hash-parser/src/parser/definitions.rs
@@ -58,7 +58,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         let name = self.parse_name()?;
         let name_span = name.span();
 
-        let mut fields = AstNodes::empty();
+        let mut fields = AstNodes::empty(name_span);
 
         if matches!(self.peek(), Some(token) if token.is_paren_tree()) {
             let mut gen = self.parse_delim_tree(Delimiter::Paren, None)?;
@@ -66,6 +66,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
                 |g| g.parse_nominal_def_param(ParamOrigin::EnumVariant),
                 |g| g.parse_token(TokenKind::Comma),
             );
+            fields.set_span(gen.span());
             self.consume_gen(gen);
         }
 
@@ -226,7 +227,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
                 self.skip_token();
                 self.parse_ty_params(def_kind)
             }
-            _ => Ok(AstNodes::new(vec![], None)),
+            _ => Ok(AstNodes::empty(self.current_location())),
         }
     }
 
@@ -234,7 +235,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
     /// definitions, and trait definitions.
     fn parse_ty_params(&mut self, def_kind: DefinitionKind) -> ParseResult<AstNodes<Param>> {
         let start_span = self.current_location();
-        let mut params = AstNodes::empty();
+        let mut params = AstNodes::empty(start_span);
 
         // Flag denoting that we were able to parse the ending `>` within the function
         // def arg
@@ -284,7 +285,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         if params.is_empty() {
             self.add_warning(ParseWarning::new(
                 WarningKind::UselessTyParams { def_kind },
-                params.span().unwrap(),
+                params.span(),
             ))
         }
 

--- a/compiler/hash-parser/src/parser/expr.rs
+++ b/compiler/hash-parser/src/parser/expr.rs
@@ -521,10 +521,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         let subject_span = subject.span();
 
         Ok(self.node_with_joined_span(
-            Expr::ConstructorCall(ConstructorCallExpr {
-                subject,
-                args: AstNodes::new(args, Some(span)),
-            }),
+            Expr::ConstructorCall(ConstructorCallExpr { subject, args: AstNodes::new(args, span) }),
             subject_span,
         ))
     }
@@ -894,7 +891,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
             let tuple = gen.node_with_joined_span(
                 Expr::Lit(LitExpr {
                     data: gen.node_with_joined_span(
-                        Lit::Tuple(TupleLit { elements: ast_nodes![] }),
+                        Lit::Tuple(TupleLit { elements: AstNodes::empty(start) }),
                         start,
                     ),
                 }),
@@ -932,7 +929,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
             return Ok(expr);
         }
 
-        let mut elements = ast_nodes![entry];
+        let mut elements = ast_nodes![entry; gen.span()];
 
         loop {
             match gen.peek() {
@@ -1037,7 +1034,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
             }
         }
 
-        let span = gen.parent_span;
+        let span = gen.span();
         self.consume_gen(gen);
 
         Ok(AstNodes::new(exprs, span))

--- a/compiler/hash-parser/src/parser/expr.rs
+++ b/compiler/hash-parser/src/parser/expr.rs
@@ -2,7 +2,7 @@
 //! logic that transforms tokens into an AST.
 use hash_ast::{ast::*, ast_nodes};
 use hash_reporting::diagnostic::AccessToDiagnosticsMut;
-use hash_source::{constant::CONSTANT_MAP, location::Span};
+use hash_source::{constant::CONSTANT_MAP, location::ByteRange};
 use hash_token::{delimiter::Delimiter, keyword::Keyword, Token, TokenKind, TokenKindVector};
 use hash_utils::smallvec::smallvec;
 
@@ -476,7 +476,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         &mut self,
         subject: AstNode<Expr>,
         tree: &'stream [Token],
-        span: Span,
+        span: ByteRange,
     ) -> ParseResult<AstNode<Expr>> {
         let mut gen = self.from_stream(tree, span);
         let mut args = vec![];
@@ -535,7 +535,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         &mut self,
         subject: AstNode<Expr>,
         tree: &'stream [Token],
-        span: Span,
+        span: ByteRange,
     ) -> ParseResult<AstNode<Expr>> {
         let mut gen = self.from_stream(tree, span);
         let start = gen.current_pos();
@@ -881,7 +881,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
     pub(crate) fn parse_expr_or_tuple(
         &mut self,
         tree: &'stream [Token],
-        span: Span,
+        span: ByteRange,
     ) -> ParseResult<AstNode<Expr>> {
         let mut gen = self.from_stream(tree, span);
         let start = self.current_pos();

--- a/compiler/hash-parser/src/parser/lit.rs
+++ b/compiler/hash-parser/src/parser/lit.rs
@@ -169,7 +169,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         span: Span,
     ) -> ParseResult<AstNode<Expr>> {
         let mut gen = self.from_stream(tree, span);
-        let mut elements = AstNodes::empty();
+        let mut elements = AstNodes::empty(span);
 
         while gen.has_token() {
             let expr = gen.parse_expr_with_precedence(0)?;

--- a/compiler/hash-parser/src/parser/lit.rs
+++ b/compiler/hash-parser/src/parser/lit.rs
@@ -87,7 +87,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
     /// this will just parse the entry as a single expression rather than a
     /// tuple entry with an associated name and type.
     pub(crate) fn parse_tuple_lit_entry(&mut self) -> ParseResult<AstNode<TupleLitEntry>> {
-        let start = self.next_location();
+        let start = self.next_pos();
         let offset = self.offset();
 
         // Determine if this might have a tuple field name and optional type
@@ -131,7 +131,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
                             ParseErrorKind::ExpectedValueAfterTyAnnotation,
                             Some(TokenKindVector::singleton(TokenKind::Eq)),
                             None,
-                            Some(self.next_location()),
+                            Some(self.next_pos()),
                         )
                     })?;
 
@@ -169,7 +169,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         span: Span,
     ) -> ParseResult<AstNode<Expr>> {
         let mut gen = self.from_stream(tree, span);
-        let mut elements = AstNodes::empty(span);
+        let mut elements = self.nodes_with_joined_span(vec![], span);
 
         while gen.has_token() {
             let expr = gen.parse_expr_with_precedence(0)?;

--- a/compiler/hash-parser/src/parser/lit.rs
+++ b/compiler/hash-parser/src/parser/lit.rs
@@ -1,7 +1,7 @@
 //! Hash Compiler AST generation sources. This file contains the sources to the
 //! logic that transforms tokens into an AST.
 use hash_ast::ast::*;
-use hash_source::{constant::CONSTANT_MAP, location::Span};
+use hash_source::{constant::CONSTANT_MAP, location::ByteRange};
 use hash_token::{keyword::Keyword, Token, TokenKind, TokenKindVector};
 
 use super::AstGen;
@@ -166,7 +166,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
     pub(crate) fn parse_array_lit(
         &self,
         tree: &'stream [Token],
-        span: Span,
+        span: ByteRange,
     ) -> ParseResult<AstNode<Expr>> {
         let mut gen = self.from_stream(tree, span);
         let mut elements = self.nodes_with_joined_span(vec![], span);

--- a/compiler/hash-parser/src/parser/mod.rs
+++ b/compiler/hash-parser/src/parser/mod.rs
@@ -15,7 +15,7 @@ use std::{cell::Cell, fmt::Display};
 
 use hash_ast::ast::*;
 use hash_reporting::diagnostic::{AccessToDiagnosticsMut, DiagnosticStore};
-use hash_source::location::{ByteRange, SourceLocation};
+use hash_source::location::{ByteRange, Span};
 use hash_token::{
     delimiter::{Delimiter, DelimiterVariant},
     Token, TokenKind, TokenKindVector,
@@ -173,14 +173,14 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
 
     /// Get the [Span] of the current generator, this asserts that a parent
     /// [Span] is present.
-    pub(crate) fn span(&self) -> SourceLocation {
-        SourceLocation { span: self.parent_span.unwrap(), id: self.resolver.source() }
+    pub(crate) fn span(&self) -> Span {
+        Span { span: self.parent_span.unwrap(), id: self.resolver.source() }
     }
 
-    /// Function to create a [SourceLocation] from a [ByteRange] by using the
+    /// Function to create a [Span] from a [ByteRange] by using the
     /// provided resolver
-    pub(crate) fn make_span(&self, span: ByteRange) -> SourceLocation {
-        SourceLocation { span, id: self.resolver.source() }
+    pub(crate) fn make_span(&self, span: ByteRange) -> Span {
+        Span { span, id: self.resolver.source() }
     }
 
     /// Get the current offset of where the stream is at.

--- a/compiler/hash-parser/src/parser/mod.rs
+++ b/compiler/hash-parser/src/parser/mod.rs
@@ -171,6 +171,12 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         }
     }
 
+    /// Get the [Span] of the current generator, this asserts that a parent
+    /// [Span] is present.
+    pub(crate) fn span(&self) -> Span {
+        self.parent_span.unwrap()
+    }
+
     /// Function to create a [SourceLocation] from a [Span] by using the
     /// provided resolver
     pub(crate) fn source_location(&self, span: &Span) -> SourceLocation {
@@ -459,7 +465,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
             }
         }
 
-        AstNodes::new(args, Some(start.join(self.current_location())))
+        AstNodes::new(args, start.join(self.current_location()))
     }
 
     /// This function behaves identically to [parse_separated_fn] except that it
@@ -528,7 +534,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
             }
         }
 
-        AstNodes::new(args, Some(start.join(self.current_location())))
+        AstNodes::new(args, start.join(self.current_location()))
     }
 
     /// Function to parse the next [Token] with the specified [TokenKind].
@@ -608,7 +614,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         }
 
         let span = start.join(self.current_location());
-        self.node_with_span(Module { contents: AstNodes::new(contents, Some(span)) }, span)
+        self.node_with_span(Module { contents: AstNodes::new(contents, span) }, span)
     }
 
     /// This function is used to exclusively parse a interactive block which

--- a/compiler/hash-parser/src/parser/name.rs
+++ b/compiler/hash-parser/src/parser/name.rs
@@ -26,7 +26,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
                 err,
                 None,
                 None,
-                token.map(|tok| tok.span).unwrap_or_else(|| self.next_location()),
+                token.map(|tok| tok.span).unwrap_or_else(|| self.next_pos()),
             ),
         }
     }
@@ -44,7 +44,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
                 err,
                 None,
                 None,
-                token.map(|tok| tok.span).unwrap_or_else(|| self.next_location()),
+                token.map(|tok| tok.span).unwrap_or_else(|| self.next_pos()),
             ),
         }
     }

--- a/compiler/hash-parser/src/parser/operator.rs
+++ b/compiler/hash-parser/src/parser/operator.rs
@@ -88,7 +88,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
                 ParseErrorKind::ExpectedArrow,
                 None,
                 None,
-                self.next_location(),
+                self.next_pos(),
             )?;
         }
 
@@ -97,7 +97,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
                 ParseErrorKind::ExpectedArrow,
                 None,
                 None,
-                self.next_location(),
+                self.next_pos(),
             )?;
         }
 

--- a/compiler/hash-parser/src/parser/pat.rs
+++ b/compiler/hash-parser/src/parser/pat.rs
@@ -1,6 +1,6 @@
 //! Hash Compiler AST generation sources. This file contains the sources to the
 //! logic that transforms tokens into an AST.
-use hash_ast::{ast::*, ast_nodes, origin::PatOrigin};
+use hash_ast::{ast::*, origin::PatOrigin};
 use hash_reporting::diagnostic::AccessToDiagnosticsMut;
 use hash_source::{identifier::IDENTS, location::Span};
 use hash_token::{delimiter::Delimiter, keyword::Keyword, Token, TokenKind};
@@ -22,7 +22,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
 
         // Parse the first pattern, but throw away the location information since that
         // will be computed at the end anyway...
-        let mut variants = ast_nodes![];
+        let mut variants = AstNodes::empty(start);
 
         while self.has_token() {
             let pat = self.parse_pat_with_if()?;
@@ -321,7 +321,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         }
         self.consume_gen(gen);
 
-        Ok(ModulePat { fields: AstNodes::new(fields, Some(span)) })
+        Ok(ModulePat { fields: AstNodes::new(fields, span) })
     }
 
     /// Parse a [`Pat::Array`] pattern from the token vector. An array pattern
@@ -373,7 +373,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         if let Some(token) = tree.get(0) {
             if token.has_kind(TokenKind::Comma) {
                 return Ok(self.node_with_span(
-                    Pat::Tuple(TuplePat { fields: AstNodes::empty(), spread: None }),
+                    Pat::Tuple(TuplePat { fields: AstNodes::empty(parent_span), spread: None }),
                     parent_span,
                 ));
             }

--- a/compiler/hash-parser/src/parser/pat.rs
+++ b/compiler/hash-parser/src/parser/pat.rs
@@ -2,7 +2,7 @@
 //! logic that transforms tokens into an AST.
 use hash_ast::{ast::*, origin::PatOrigin};
 use hash_reporting::diagnostic::AccessToDiagnosticsMut;
-use hash_source::{identifier::IDENTS, location::Span};
+use hash_source::{identifier::IDENTS, location::ByteRange};
 use hash_token::{delimiter::Delimiter, keyword::Keyword, Token, TokenKind};
 
 use super::AstGen;
@@ -303,7 +303,11 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
 
     /// Parse a [ModulePat] which is comprised of a collection of
     /// [ModulePatEntry]s that are comma separated within a brace tree.
-    fn parse_module_pat(&mut self, tree: &'stream [Token], span: Span) -> ParseResult<ModulePat> {
+    fn parse_module_pat(
+        &mut self,
+        tree: &'stream [Token],
+        span: ByteRange,
+    ) -> ParseResult<ModulePat> {
         let mut gen = self.from_stream(tree, span);
         let mut fields = vec![];
 
@@ -333,7 +337,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
     pub(crate) fn parse_array_pat(
         &mut self,
         tree: &'stream [Token],
-        parent_span: Span,
+        parent_span: ByteRange,
     ) -> ParseResult<AstNode<Pat>> {
         let mut gen = self.from_stream(tree, parent_span);
 
@@ -369,7 +373,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
     pub(crate) fn parse_tuple_pat(
         &mut self,
         tree: &'stream [Token],
-        parent_span: Span,
+        parent_span: ByteRange,
     ) -> ParseResult<AstNode<Pat>> {
         // check here if the tree length is 1, and the first token is the comma to check
         // if it is an empty tuple pattern...

--- a/compiler/hash-parser/src/parser/ty.rs
+++ b/compiler/hash-parser/src/parser/ty.rs
@@ -190,7 +190,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
                     }, span);
 
                     Ty::Fn(FnTy {
-                        params: ast_nodes![ty_arg],
+                        params: ast_nodes![ty_arg; span],
                         return_ty,
                     })
                 }
@@ -270,8 +270,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         }
 
         // Update the location of the type bound to reflect the '<' and '>' tokens...
-        // type_args.set_span(start.join(self.current_location()));
-        Ok(AstNodes::new(ty_args, Some(start.join(self.current_location()))))
+        Ok(AstNodes::new(ty_args, start.join(self.current_location())))
     }
 
     /// Parses a [Ty::Fn] which involves a parenthesis token tree with some
@@ -279,10 +278,8 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
     /// [Ty] that is preceded by an `thin-arrow` (->) after the
     /// parentheses. e.g. `(i32) -> str`
     fn parse_fn_or_tuple_ty(&mut self) -> ParseResult<Ty> {
-        let mut params = AstNodes::empty();
-
         let mut gen = self.parse_delim_tree(Delimiter::Paren, None)?;
-        params.span = gen.parent_span;
+        let mut params = AstNodes::empty(gen.span());
 
         match gen.peek() {
             // Handle special case where there is only one comma and no following items...
@@ -406,6 +403,6 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         self.parse_thin_arrow()?;
         let return_ty = self.parse_ty()?;
 
-        Ok(Ty::TyFn(TyFn { params: AstNodes::new(args, Some(arg_span)), return_ty }))
+        Ok(Ty::TyFn(TyFn { params: AstNodes::new(args, arg_span), return_ty }))
     }
 }

--- a/compiler/hash-reporting/src/render.rs
+++ b/compiler/hash-reporting/src/render.rs
@@ -14,7 +14,7 @@ use std::{
 };
 
 use hash_source::{
-    location::{RowCol, RowColSpan, SourceLocation},
+    location::{RowCol, RowColRange, SourceLocation},
     SourceMap,
 };
 use hash_utils::highlight::{highlight, Colour, Modifier};
@@ -70,7 +70,7 @@ impl ReportCodeBlock {
             Some(info) => info,
             None => {
                 let SourceLocation { span, id } = self.source_location;
-                let source = sources.line_ranges_by_id(id);
+                let source = sources.line_ranges(id);
 
                 // Compute offset rows and columns from the provided span
                 let start @ RowCol { row: start_row, .. } = source.get_row_col(span.start());
@@ -88,7 +88,7 @@ impl ReportCodeBlock {
                     .chars()
                     .count();
 
-                let span = RowColSpan::new(start, end);
+                let span = RowColRange::new(start, end);
                 let info = ReportCodeBlockInfo { indent_width, span };
 
                 self.info.replace(Some(info));

--- a/compiler/hash-reporting/src/render.rs
+++ b/compiler/hash-reporting/src/render.rs
@@ -14,7 +14,7 @@ use std::{
 };
 
 use hash_source::{
-    location::{RowCol, RowColRange, SourceLocation},
+    location::{RowCol, RowColRange, Span},
     SourceMap,
 };
 use hash_utils::highlight::{highlight, Colour, Modifier};
@@ -69,7 +69,7 @@ impl ReportCodeBlock {
         match self.info.get() {
             Some(info) => info,
             None => {
-                let SourceLocation { span, id } = self.source_location;
+                let Span { span, id } = self.source_location;
                 let source = sources.line_ranges(id);
 
                 // Compute offset rows and columns from the provided span
@@ -342,7 +342,7 @@ impl ReportCodeBlock {
     }
 
     /// Function to render the [ReportCodeBlock] using the provided
-    /// [SourceLocation], message and [ReportKind].
+    /// [Span], message and [ReportKind].
     pub(crate) fn render(
         &self,
         f: &mut fmt::Formatter,

--- a/compiler/hash-reporting/src/report.rs
+++ b/compiler/hash-reporting/src/report.rs
@@ -2,7 +2,7 @@
 use std::{cell::Cell, fmt};
 
 use hash_error_codes::error_codes::HashErrorCode;
-use hash_source::location::{RowColRange, SourceLocation};
+use hash_source::location::{RowColRange, Span};
 use hash_utils::highlight::{highlight, Colour, Modifier};
 
 /// A data type representing a comment/message on a specific span in a code
@@ -117,14 +117,14 @@ impl ReportNote {
 /// optional [ReportCodeBlockInfo] which adds a message pointed to a code item.
 #[derive(Debug, Clone)]
 pub struct ReportCodeBlock {
-    pub source_location: SourceLocation,
+    pub source_location: Span,
     pub code_message: String,
     pub(crate) info: Cell<Option<ReportCodeBlockInfo>>,
 }
 
 impl ReportCodeBlock {
-    /// Create a new [ReportCodeBlock] from a [SourceLocation] and a message.
-    pub fn new(source_location: SourceLocation, code_message: impl ToString) -> Self {
+    /// Create a new [ReportCodeBlock] from a [Span] and a message.
+    pub fn new(source_location: Span, code_message: impl ToString) -> Self {
         Self { source_location, code_message: code_message.to_string(), info: Cell::new(None) }
     }
 }
@@ -223,16 +223,12 @@ impl Report {
     }
 
     /// Add a code block at the given location to the [Report].
-    pub fn add_span(&mut self, location: SourceLocation) -> &mut Self {
+    pub fn add_span(&mut self, location: Span) -> &mut Self {
         self.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(location, "")))
     }
 
     /// Add a labelled code block at the given location to the [Report].
-    pub fn add_labelled_span(
-        &mut self,
-        location: SourceLocation,
-        message: impl ToString,
-    ) -> &mut Self {
+    pub fn add_labelled_span(&mut self, location: Span, message: impl ToString) -> &mut Self {
         self.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
             location,
             message.to_string(),

--- a/compiler/hash-reporting/src/report.rs
+++ b/compiler/hash-reporting/src/report.rs
@@ -2,7 +2,7 @@
 use std::{cell::Cell, fmt};
 
 use hash_error_codes::error_codes::HashErrorCode;
-use hash_source::location::{RowColSpan, SourceLocation};
+use hash_source::location::{RowColRange, SourceLocation};
 use hash_utils::highlight::{highlight, Colour, Modifier};
 
 /// A data type representing a comment/message on a specific span in a code
@@ -13,7 +13,7 @@ pub struct ReportCodeBlockInfo {
     pub indent_width: usize,
 
     /// The span of the code block but using row and column indices.
-    pub span: RowColSpan,
+    pub span: RowColRange,
 }
 
 /// Enumeration describing the kind of [Report]; either being a warning, info or

--- a/compiler/hash-semantics/Cargo.toml
+++ b/compiler/hash-semantics/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["The Hash Language authors"]
 edition = "2021"
 
 [dependencies]
-bimap = "0.6"
 dashmap = "5.1"
 derive_more = "0.99"
 num-bigint = "0.4"

--- a/compiler/hash-semantics/src/diagnostics/error.rs
+++ b/compiler/hash-semantics/src/diagnostics/error.rs
@@ -5,7 +5,7 @@ use hash_reporting::{
     self,
     reporter::{Reporter, Reports},
 };
-use hash_source::location::SourceLocation;
+use hash_source::location::Span;
 use hash_tir::{
     environment::env::AccessToEnv, symbols::Symbol, terms::TermId, utils::common::CommonUtils,
 };
@@ -29,49 +29,49 @@ pub enum SemanticError {
     NeedMoreTypeAnnotationsToInfer { term: TermId },
 
     /// Traits are not yet supported.
-    TraitsNotSupported { trait_location: SourceLocation },
+    TraitsNotSupported { trait_location: Span },
 
     /// Merge declarations are not yet supported.
-    MergeDeclarationsNotSupported { merge_location: SourceLocation },
+    MergeDeclarationsNotSupported { merge_location: Span },
 
     /// Module patterns are not yet supported.
-    ModulePatternsNotSupported { location: SourceLocation },
+    ModulePatternsNotSupported { location: Span },
 
     /// Some specified symbol was not found.
-    SymbolNotFound { symbol: Symbol, location: SourceLocation, looking_in: ContextKind },
+    SymbolNotFound { symbol: Symbol, location: Span, looking_in: ContextKind },
 
     /// Cannot use a module in a value position.
-    CannotUseModuleInValuePosition { location: SourceLocation },
+    CannotUseModuleInValuePosition { location: Span },
 
     /// Cannot use a module in a type position.
-    CannotUseModuleInTypePosition { location: SourceLocation },
+    CannotUseModuleInTypePosition { location: Span },
 
     /// Cannot use a module in a pattern position.
-    CannotUseModuleInPatternPosition { location: SourceLocation },
+    CannotUseModuleInPatternPosition { location: Span },
 
     /// Cannot use a data type in a value position.
-    CannotUseDataTypeInValuePosition { location: SourceLocation },
+    CannotUseDataTypeInValuePosition { location: Span },
 
     /// Cannot use a data type in a pattern position.
-    CannotUseDataTypeInPatternPosition { location: SourceLocation },
+    CannotUseDataTypeInPatternPosition { location: Span },
 
     /// Cannot use a constructor in a type position.
-    CannotUseConstructorInTypePosition { location: SourceLocation },
+    CannotUseConstructorInTypePosition { location: Span },
 
     /// Cannot use a function in type position.
-    CannotUseFunctionInTypePosition { location: SourceLocation },
+    CannotUseFunctionInTypePosition { location: Span },
 
     /// Cannot use a function in a pattern position.
-    CannotUseFunctionInPatternPosition { location: SourceLocation },
+    CannotUseFunctionInPatternPosition { location: Span },
 
     /// Cannot use a non-constant item in constant position.
-    CannotUseNonConstantItem { location: SourceLocation },
+    CannotUseNonConstantItem { location: Span },
 
     /// Cannot use the subject as a namespace.
-    InvalidNamespaceSubject { location: SourceLocation },
+    InvalidNamespaceSubject { location: Span },
 
     /// Cannot use arguments here.
-    UnexpectedArguments { location: SourceLocation },
+    UnexpectedArguments { location: Span },
 
     /// Type error, forwarded from the typechecker.
     TypeError { error: TcError },
@@ -80,10 +80,10 @@ pub enum SemanticError {
     ExhaustivenessError { error: ExhaustivenessError },
 
     /// Type error, forwarded from the typechecker.
-    EnumTypeAnnotationMustBeOfDefiningType { location: SourceLocation },
+    EnumTypeAnnotationMustBeOfDefiningType { location: Span },
 
     /// Given data definition is not a singleton.
-    DataDefIsNotSingleton { location: SourceLocation },
+    DataDefIsNotSingleton { location: Span },
 
     /// An entry point was not found in the entry module.
     EntryPointNotFound,

--- a/compiler/hash-semantics/src/passes/ast_utils.rs
+++ b/compiler/hash-semantics/src/passes/ast_utils.rs
@@ -2,7 +2,6 @@ use hash_ast::{
     ast::{self, AstNodeRef, BodyBlock, Module, OwnsAstNode},
     node_map::SourceRef,
 };
-use hash_source::location::{SourceLocation, Span};
 use hash_tir::symbols::{sym, Symbol};
 
 use crate::{diagnostics::error::SemanticResult, environment::sem_env::AccessToSemEnv};
@@ -40,17 +39,6 @@ pub trait AstPass: AccessToSemEnv {
 }
 
 pub trait AstUtils: AccessToSemEnv {
-    /// Create a [SourceLocation] from a [Span].
-    fn source_location(&self, span: Span) -> SourceLocation {
-        SourceLocation { span, id: self.current_source_info().source_id() }
-    }
-
-    /// Create a [SourceLocation] at the given [hash_ast::ast::AstNode].
-    fn node_location<N>(&self, node: AstNodeRef<N>) -> SourceLocation {
-        let node_span = node.span();
-        self.source_location(node_span)
-    }
-
     /// Create a [`Symbol`] for the given [`ast::Name`], or a fresh symbol if no
     /// name is provided.
     fn new_symbol_from_ast_name(&self, name: Option<&ast::AstNode<ast::Name>>) -> Symbol {

--- a/compiler/hash-semantics/src/passes/discovery/defs.rs
+++ b/compiler/hash-semantics/src/passes/discovery/defs.rs
@@ -19,7 +19,7 @@ use hash_utils::{
     state::LightState,
 };
 
-use super::{super::ast_utils::AstUtils, DiscoveryPass};
+use super::DiscoveryPass;
 use crate::ops::common::CommonOps;
 
 /// An item that is discovered: either a definition or a function type.
@@ -331,11 +331,7 @@ impl<'tc> DiscoveryPass<'tc> {
             Some(ast::Expr::Block(block)) => block.data.id(),
             Some(_) => node.value.as_ref().unwrap().id(),
             _ => {
-                panic_on_span!(
-                    self.node_location(node),
-                    self.source_map(),
-                    "Found declaration without value"
-                )
+                panic_on_span!(node.span(), self.source_map(), "Found declaration without value")
             }
         };
 
@@ -448,7 +444,7 @@ impl<'tc> DiscoveryPass<'tc> {
             ast::Pat::Module(_) => {
                 // This should have been handled pre-tc semantics
                 panic_on_span!(
-                    self.node_location(node),
+                    node.span(),
                     self.source_map(),
                     "Found module pattern in stack definition"
                 )
@@ -482,11 +478,7 @@ impl<'tc> DiscoveryPass<'tc> {
                 // @@Invariant: Here we assume that each branch of the or pattern has the same
                 // members This should have already been checked at pre-tc semantics.
                 Some(pat) => self.add_stack_members_in_pat_to_buf(pat.ast_ref(), buf),
-                None => panic_on_span!(
-                    self.node_location(node),
-                    self.source_map(),
-                    "Found empty or pattern"
-                ),
+                None => panic_on_span!(node.span(), self.source_map(), "Found empty or pattern"),
             },
             ast::Pat::If(if_pat) => self.add_stack_members_in_pat_to_buf(if_pat.pat.ast_ref(), buf),
             ast::Pat::Wild(_) => buf.push((
@@ -551,8 +543,6 @@ impl<'tc> DiscoveryPass<'tc> {
         def_id: DefId,
         originating_node: AstNodeRef<U>,
     ) {
-        self.stores()
-            .location()
-            .add_location_to_target(def_id, self.node_location(originating_node));
+        self.stores().location().add_location_to_target(def_id, originating_node.span());
     }
 }

--- a/compiler/hash-semantics/src/passes/discovery/params.rs
+++ b/compiler/hash-semantics/src/passes/discovery/params.rs
@@ -7,7 +7,7 @@ use hash_tir::{
 };
 
 use super::DiscoveryPass;
-use crate::{ops::common::CommonOps, passes::ast_utils::AstUtils};
+use crate::ops::common::CommonOps;
 
 impl<'tc> DiscoveryPass<'tc> {
     /// Create a parameter list from the given AST generic parameter list, where
@@ -27,9 +27,7 @@ impl<'tc> DiscoveryPass<'tc> {
                 })
                 .map(|index| index.into_symbol()),
         );
-        self.stores()
-            .location()
-            .add_locations_to_targets(params_id, |i| Some(self.source_location(params[i].span())));
+        self.stores().location().add_locations_to_targets(params_id, |i| Some(params[i].span()));
 
         for (i, param) in params.iter().enumerate() {
             self.ast_info().params().insert(param.id(), ParamId(params_id, i));

--- a/compiler/hash-semantics/src/passes/discovery/visitor.rs
+++ b/compiler/hash-semantics/src/passes/discovery/visitor.rs
@@ -19,7 +19,7 @@ use hash_tir::{
 };
 use hash_utils::itertools::Itertools;
 
-use super::{super::ast_utils::AstUtils, defs::ItemId, DiscoveryPass};
+use super::{defs::ItemId, DiscoveryPass};
 use crate::{
     diagnostics::error::SemanticError, environment::sem_env::AccessToSemEnv,
     passes::ast_utils::AstPass,
@@ -70,14 +70,14 @@ impl<'tc> ast::AstVisitor for DiscoveryPass<'tc> {
                         Some(name) => self.add_declaration_node_to_mod_def(name, node, mod_def_id),
                         None => {
                             return Err(SemanticError::ModulePatternsNotSupported {
-                                location: self.node_location(node),
+                                location: node.span(),
                             })
                         }
                     }
                 }
                 DefId::Data(_) => {
                     panic_on_span!(
-                        self.node_location(node),
+                        node.span(),
                         self.source_map(),
                         "found declaration in data definition scope, which should have been handled earlier"
                     )
@@ -102,7 +102,7 @@ impl<'tc> ast::AstVisitor for DiscoveryPass<'tc> {
                 }
                 DefId::Fn(_) => {
                     panic_on_span!(
-                        self.node_location(node),
+                        node.span(),
                         self.source_map(),
                         "found declaration in function scope, which should instead be in a stack scope"
                     )
@@ -110,14 +110,14 @@ impl<'tc> ast::AstVisitor for DiscoveryPass<'tc> {
             },
             Some(ItemId::Ty(_)) => {
                 panic_on_span!(
-                        self.node_location(node),
+                        node.span(),
                         self.source_map(),
                         "found declaration in function type scope, which should instead be in a stack scope"
                     )
             }
             None => {
                 panic_on_span!(
-                    self.node_location(node),
+                    node.span(),
                     self.source_map(),
                     "found declaration before any scopes"
                 )
@@ -375,9 +375,8 @@ impl<'tc> ast::AstVisitor for DiscoveryPass<'tc> {
         node: ast::AstNodeRef<ast::TraitDef>,
     ) -> Result<Self::TraitDefRet, Self::Error> {
         // Traits are not yet supported
-        self.diagnostics().add_error(SemanticError::TraitsNotSupported {
-            trait_location: self.node_location(node),
-        });
+        self.diagnostics()
+            .add_error(SemanticError::TraitsNotSupported { trait_location: node.span() });
         Ok(())
     }
 

--- a/compiler/hash-semantics/src/passes/resolution/defs.rs
+++ b/compiler/hash-semantics/src/passes/resolution/defs.rs
@@ -22,7 +22,7 @@ use crate::{
     diagnostics::error::{SemanticError, SemanticResult},
     environment::sem_env::AccessToSemEnv,
     ops::common::CommonOps,
-    passes::ast_utils::{AstPass, AstUtils},
+    passes::ast_utils::AstPass,
 };
 
 impl<'tc> ResolutionPass<'tc> {
@@ -148,7 +148,8 @@ impl<'tc> ResolutionPass<'tc> {
                                             _ => {
                                                 self.diagnostics().add_error(
                                                     SemanticError::EnumTypeAnnotationMustBeOfDefiningType {
-                                                       location: self.node_location(variant_ty.ast_ref())}
+                                                       location: variant_ty.span()
+                                                    }
                                                 );
                                             }
                                         }

--- a/compiler/hash-semantics/src/passes/resolution/exprs.rs
+++ b/compiler/hash-semantics/src/passes/resolution/exprs.rs
@@ -13,7 +13,7 @@ use hash_intrinsics::{
     utils::PrimitiveUtils,
 };
 use hash_reporting::macros::panic_on_span;
-use hash_source::{identifier::IDENTS, location::Span};
+use hash_source::{identifier::IDENTS, location::SourceLocation};
 use hash_storage::store::{
     PartialCloneStore, PartialStore, SequenceStore, SequenceStoreKey, Store,
     TrivialSequenceStoreKey,
@@ -53,7 +53,7 @@ use crate::{
     diagnostics::error::{SemanticError, SemanticResult},
     environment::sem_env::AccessToSemEnv,
     ops::common::CommonOps,
-    passes::ast_utils::{AstPass, AstUtils},
+    passes::ast_utils::AstPass,
 };
 
 /// This block converts AST nodes of different kinds into [`AstPath`]s, in order
@@ -210,7 +210,7 @@ impl<'tc> ResolutionPass<'tc> {
         };
 
         self.ast_info().terms().insert(node.id(), term_id);
-        self.stores().location().add_location_to_target(term_id, self.node_location(node));
+        self.stores().location().add_location_to_target(term_id, node.span());
         Ok(term_id)
     }
 
@@ -240,9 +240,7 @@ impl<'tc> ResolutionPass<'tc> {
                 ast::PropertyKind::NamedField(name) => {
                     let mut root =
                         self.expr_as_ast_path(node.body.subject.ast_ref())?.ok_or_else(|| {
-                            SemanticError::InvalidNamespaceSubject {
-                                location: self.node_location(node),
-                            }
+                            SemanticError::InvalidNamespaceSubject { location: node.span() }
                         })?;
                     root.push(AstPathComponent {
                         name: *name,
@@ -255,7 +253,7 @@ impl<'tc> ResolutionPass<'tc> {
                 ast::PropertyKind::NumericField(_) => {
                     // Should have been caught at semantics
                     panic_on_span!(
-                        self.node_location(node),
+                        node.span(),
                         self.source_map(),
                         "Namespace followed by numeric field found"
                     )
@@ -315,7 +313,7 @@ impl<'tc> ResolutionPass<'tc> {
     pub(super) fn make_term_from_resolved_ast_path(
         &self,
         path: &ResolvedAstPathComponent,
-        original_node_span: Span,
+        original_node_span: SourceLocation,
     ) -> SemanticResult<TermId> {
         match path {
             ResolvedAstPathComponent::NonTerminal(non_terminal) => {
@@ -330,7 +328,7 @@ impl<'tc> ResolutionPass<'tc> {
                     NonTerminalResolvedPathComponent::Mod(_) => {
                         // Modules are not allowed in value positions
                         Err(SemanticError::CannotUseModuleInValuePosition {
-                            location: self.source_location(original_node_span),
+                            location: original_node_span,
                         })
                     }
                 }
@@ -342,7 +340,7 @@ impl<'tc> ResolutionPass<'tc> {
                 }
                 TerminalResolvedPathComponent::CtorPat(_) => {
                     panic_on_span!(
-                        self.source_location(original_node_span),
+                        original_node_span,
                         self.source_map(),
                         "found CtorPat in value ast path"
                     )
@@ -754,7 +752,7 @@ impl<'tc> ResolutionPass<'tc> {
             })
             .unwrap_or_else(|| {
                 panic_on_span!(
-                    self.node_location(node),
+                    node.span(),
                     self.source_map(),
                     "Found non-stack body block in make_term_from_ast_body_block"
                 )
@@ -797,7 +795,7 @@ impl<'tc> ResolutionPass<'tc> {
             // Others done during de-sugaring:
             ast::Block::For(_) | ast::Block::While(_) | ast::Block::If(_) => {
                 panic_on_span!(
-                    self.node_location(node),
+                    node.span(),
                     self.source_map(),
                     "Found non-desugared block in make_term_from_ast_block_expr"
                 )

--- a/compiler/hash-semantics/src/passes/resolution/exprs.rs
+++ b/compiler/hash-semantics/src/passes/resolution/exprs.rs
@@ -13,7 +13,7 @@ use hash_intrinsics::{
     utils::PrimitiveUtils,
 };
 use hash_reporting::macros::panic_on_span;
-use hash_source::{identifier::IDENTS, location::SourceLocation};
+use hash_source::{identifier::IDENTS, location::Span};
 use hash_storage::store::{
     PartialCloneStore, PartialStore, SequenceStore, SequenceStoreKey, Store,
     TrivialSequenceStoreKey,
@@ -313,7 +313,7 @@ impl<'tc> ResolutionPass<'tc> {
     pub(super) fn make_term_from_resolved_ast_path(
         &self,
         path: &ResolvedAstPathComponent,
-        original_node_span: SourceLocation,
+        original_node_span: Span,
     ) -> SemanticResult<TermId> {
         match path {
             ResolvedAstPathComponent::NonTerminal(non_terminal) => {

--- a/compiler/hash-semantics/src/passes/resolution/params.rs
+++ b/compiler/hash-semantics/src/passes/resolution/params.rs
@@ -1,7 +1,7 @@
 //! Resolution of AST parameters and arguments to terms.
 
 use hash_ast::ast::{self, AstNodeRef};
-use hash_source::location::SourceLocation;
+use hash_source::location::Span;
 use hash_storage::store::{statics::SequenceStoreValue, SequenceStore, SequenceStoreKey};
 use hash_tir::{
     args::{ArgsId, PatArgsId},
@@ -39,7 +39,7 @@ pub enum AstArgGroup<'a> {
 
 impl AstArgGroup<'_> {
     /// Get the span of this argument group.
-    pub fn span(&self) -> SourceLocation {
+    pub fn span(&self) -> Span {
         match self {
             AstArgGroup::ExplicitArgs(args) => args.span(),
             AstArgGroup::ImplicitArgs(args) => args.span(),
@@ -282,7 +282,7 @@ impl<'tc> ResolutionPass<'tc> {
         &self,
         subject: TermId,
         args: &[AstArgGroup],
-        original_span: SourceLocation,
+        original_span: Span,
     ) -> SemanticResult<FnCallTerm> {
         debug_assert!(!args.is_empty());
         let mut current_subject = subject;

--- a/compiler/hash-semantics/src/passes/resolution/params.rs
+++ b/compiler/hash-semantics/src/passes/resolution/params.rs
@@ -40,14 +40,13 @@ pub enum AstArgGroup<'a> {
 
 impl AstArgGroup<'_> {
     /// Get the span of this argument group.
-    pub fn span(&self) -> Option<Span> {
+    pub fn span(&self) -> Span {
         match self {
             AstArgGroup::ExplicitArgs(args) => args.span(),
             AstArgGroup::ImplicitArgs(args) => args.span(),
-            AstArgGroup::ExplicitPatArgs(args, spread) => args
-                .span()
-                .and_then(|args_span| Some(args_span.join(spread.as_ref()?.span())))
-                .or_else(|| Some(spread.as_ref()?.span())),
+            AstArgGroup::ExplicitPatArgs(args, spread) => spread
+                .as_ref()
+                .map_or_else(|| args.span(), |spread| args.span().join(spread.span())),
             AstArgGroup::TupleArgs(args) => args.span(),
         }
     }

--- a/compiler/hash-semantics/src/passes/resolution/params.rs
+++ b/compiler/hash-semantics/src/passes/resolution/params.rs
@@ -1,7 +1,7 @@
 //! Resolution of AST parameters and arguments to terms.
 
 use hash_ast::ast::{self, AstNodeRef};
-use hash_source::location::Span;
+use hash_source::location::SourceLocation;
 use hash_storage::store::{statics::SequenceStoreValue, SequenceStore, SequenceStoreKey};
 use hash_tir::{
     args::{ArgsId, PatArgsId},
@@ -18,7 +18,6 @@ use super::ResolutionPass;
 use crate::{
     diagnostics::error::{SemanticError, SemanticResult},
     ops::common::CommonOps,
-    passes::ast_utils::AstUtils,
 };
 
 /// An argument group in the AST.
@@ -40,7 +39,7 @@ pub enum AstArgGroup<'a> {
 
 impl AstArgGroup<'_> {
     /// Get the span of this argument group.
-    pub fn span(&self) -> Span {
+    pub fn span(&self) -> SourceLocation {
         match self {
             AstArgGroup::ExplicitArgs(args) => args.span(),
             AstArgGroup::ImplicitArgs(args) => args.span(),
@@ -283,7 +282,7 @@ impl<'tc> ResolutionPass<'tc> {
         &self,
         subject: TermId,
         args: &[AstArgGroup],
-        original_span: Span,
+        original_span: SourceLocation,
     ) -> SemanticResult<FnCallTerm> {
         debug_assert!(!args.is_empty());
         let mut current_subject = subject;
@@ -304,7 +303,7 @@ impl<'tc> ResolutionPass<'tc> {
                     // Here we are trying to call a function with pattern arguments.
                     // This is not allowed.
                     return Err(SemanticError::CannotUseFunctionInPatternPosition {
-                        location: self.source_location(original_span),
+                        location: original_span,
                     });
                 }
             }

--- a/compiler/hash-semantics/src/passes/resolution/paths.rs
+++ b/compiler/hash-semantics/src/passes/resolution/paths.rs
@@ -22,7 +22,7 @@
 use std::fmt;
 
 use hash_ast::ast;
-use hash_source::{identifier::Identifier, location::SourceLocation};
+use hash_source::{identifier::Identifier, location::Span};
 use hash_storage::store::TrivialKeySequenceStore;
 use hash_tir::{
     args::ArgsId,
@@ -52,7 +52,7 @@ use crate::diagnostics::error::{SemanticError, SemanticResult};
 #[derive(Clone, Debug)]
 pub struct AstPathComponent<'a> {
     pub name: Identifier,
-    pub name_span: SourceLocation,
+    pub name_span: Span,
     pub args: Vec<AstArgGroup<'a>>,
     pub node_id: ast::AstNodeId,
 }
@@ -64,7 +64,7 @@ pub type AstPath<'a> = Vec<AstPathComponent<'a>>;
 
 impl AstPathComponent<'_> {
     /// Get the span of this path component.
-    pub fn span(&self) -> SourceLocation {
+    pub fn span(&self) -> Span {
         let span = self.name_span;
         if let Some(last_arg) = self.args.last() {
             span.join(last_arg.span())
@@ -141,8 +141,8 @@ impl<'tc> ResolutionPass<'tc> {
     fn resolve_ast_name(
         &self,
         name: Identifier,
-        name_span: SourceLocation,
-        starting_from: Option<(NonTerminalResolvedPathComponent, SourceLocation)>,
+        name_span: Span,
+        starting_from: Option<(NonTerminalResolvedPathComponent, Span)>,
     ) -> SemanticResult<(Symbol, BindingKind)> {
         match starting_from {
             Some((member_value, _span)) => match member_value {
@@ -181,7 +181,7 @@ impl<'tc> ResolutionPass<'tc> {
     fn resolve_ast_path_component(
         &self,
         component: &AstPathComponent<'_>,
-        starting_from: Option<(NonTerminalResolvedPathComponent, SourceLocation)>,
+        starting_from: Option<(NonTerminalResolvedPathComponent, Span)>,
     ) -> SemanticResult<ResolvedAstPathComponent> {
         let (_binding, binding_kind) =
             self.resolve_ast_name(component.name, component.name_span, starting_from)?;

--- a/compiler/hash-semantics/src/passes/resolution/paths.rs
+++ b/compiler/hash-semantics/src/passes/resolution/paths.rs
@@ -69,8 +69,8 @@ impl AstPathComponent<'_> {
     /// Get the span of this path component.
     pub fn span(&self) -> Span {
         let span = self.name_span;
-        if let Some(last_arg) = self.args.last() && let Some(arg_span) = last_arg.span() {
-            span.join(arg_span)
+        if let Some(last_arg) = self.args.last() {
+            span.join(last_arg.span())
         } else {
             span
         }
@@ -221,9 +221,8 @@ impl<'tc> ResolutionPass<'tc> {
                                 }
                                 [first, second, _rest @ ..] => {
                                     return Err(SemanticError::UnexpectedArguments {
-                                        location: self.source_location(
-                                            first.span().unwrap().join(second.span().unwrap()),
-                                        ),
+                                        location: self
+                                            .source_location(first.span().join(second.span())),
                                     });
                                 }
                             };
@@ -299,7 +298,7 @@ impl<'tc> ResolutionPass<'tc> {
                     [arg_group] => self.make_args_from_ast_arg_group(arg_group)?,
                     [_first, second, _rest @ ..] => {
                         return Err(SemanticError::UnexpectedArguments {
-                            location: self.source_location(second.span().unwrap()),
+                            location: self.source_location(second.span()),
                         });
                     }
                 };

--- a/compiler/hash-semantics/src/passes/resolution/pats.rs
+++ b/compiler/hash-semantics/src/passes/resolution/pats.rs
@@ -9,7 +9,7 @@ use std::iter::empty;
 use hash_ast::ast::{self, AstNodeRef};
 use hash_intrinsics::utils::PrimitiveUtils;
 use hash_reporting::macros::panic_on_span;
-use hash_source::location::SourceLocation;
+use hash_source::location::Span;
 use hash_storage::store::{SequenceStore, SequenceStoreKey};
 use hash_tir::{
     args::{PatArgData, PatArgsId, PatOrCapture},
@@ -181,7 +181,7 @@ impl ResolutionPass<'_> {
     fn make_pat_from_resolved_ast_path(
         &self,
         path: &ResolvedAstPathComponent,
-        original_node_span: SourceLocation,
+        original_node_span: Span,
     ) -> SemanticResult<PatId> {
         match path {
             ResolvedAstPathComponent::NonTerminal(non_terminal) => match non_terminal {

--- a/compiler/hash-semantics/src/passes/resolution/scoping.rs
+++ b/compiler/hash-semantics/src/passes/resolution/scoping.rs
@@ -2,7 +2,7 @@
 use std::{collections::HashMap, fmt};
 
 use hash_ast::ast;
-use hash_source::{identifier::Identifier, location::Span};
+use hash_source::{identifier::Identifier, location::SourceLocation};
 use hash_storage::store::{
     CloneStore, SequenceStore, SequenceStoreKey, Store, TrivialKeySequenceStore,
 };
@@ -26,7 +26,6 @@ use crate::{
     diagnostics::error::{SemanticError, SemanticResult},
     environment::sem_env::{AccessToSemEnv, SemEnv},
     ops::common::CommonOps,
-    passes::ast_utils::AstUtils,
 };
 
 /// The kind of context we are in.
@@ -145,16 +144,13 @@ impl<'tc> Scoping<'tc> {
     pub(super) fn lookup_symbol_by_name_or_error(
         &self,
         name: impl Into<Identifier>,
-        span: Span,
+        span: SourceLocation,
         looking_in: ContextKind,
     ) -> SemanticResult<(Symbol, BindingKind)> {
         let name = name.into();
-        let symbol =
-            self.lookup_symbol_by_name(name).ok_or_else(|| SemanticError::SymbolNotFound {
-                symbol: sym(name),
-                location: self.source_location(span),
-                looking_in,
-            })?;
+        let symbol = self.lookup_symbol_by_name(name).ok_or_else(|| {
+            SemanticError::SymbolNotFound { symbol: sym(name), location: span, looking_in }
+        })?;
 
         // @@Todo: Ensure that we are in the correct context for the binding.
         // if self.context().get_current_scope_kind().is_constant() {

--- a/compiler/hash-semantics/src/passes/resolution/scoping.rs
+++ b/compiler/hash-semantics/src/passes/resolution/scoping.rs
@@ -2,7 +2,7 @@
 use std::{collections::HashMap, fmt};
 
 use hash_ast::ast;
-use hash_source::{identifier::Identifier, location::SourceLocation};
+use hash_source::{identifier::Identifier, location::Span};
 use hash_storage::store::{
     CloneStore, SequenceStore, SequenceStoreKey, Store, TrivialKeySequenceStore,
 };
@@ -144,7 +144,7 @@ impl<'tc> Scoping<'tc> {
     pub(super) fn lookup_symbol_by_name_or_error(
         &self,
         name: impl Into<Identifier>,
-        span: SourceLocation,
+        span: Span,
         looking_in: ContextKind,
     ) -> SemanticResult<(Symbol, BindingKind)> {
         let name = name.into();

--- a/compiler/hash-semantics/src/passes/resolution/tys.rs
+++ b/compiler/hash-semantics/src/passes/resolution/tys.rs
@@ -9,7 +9,7 @@ use std::iter::once;
 use hash_ast::ast::{self, AstNodeRef};
 use hash_intrinsics::primitives::AccessToPrimitives;
 use hash_reporting::macros::panic_on_span;
-use hash_source::{identifier::IDENTS, location::SourceLocation};
+use hash_source::{identifier::IDENTS, location::Span};
 use hash_tir::{
     args::{ArgData, ArgsId},
     data::DataTy,
@@ -111,7 +111,7 @@ impl<'tc> ResolutionPass<'tc> {
     fn make_ty_from_resolved_ast_path(
         &self,
         path: &ResolvedAstPathComponent,
-        original_node_span: SourceLocation,
+        original_node_span: Span,
     ) -> SemanticResult<TyId> {
         match path {
             ResolvedAstPathComponent::NonTerminal(non_terminal) => match non_terminal {

--- a/compiler/hash-semantics/src/passes/resolution/tys.rs
+++ b/compiler/hash-semantics/src/passes/resolution/tys.rs
@@ -9,7 +9,7 @@ use std::iter::once;
 use hash_ast::ast::{self, AstNodeRef};
 use hash_intrinsics::primitives::AccessToPrimitives;
 use hash_reporting::macros::panic_on_span;
-use hash_source::{identifier::IDENTS, location::Span};
+use hash_source::{identifier::IDENTS, location::SourceLocation};
 use hash_tir::{
     args::{ArgData, ArgsId},
     data::DataTy,
@@ -33,7 +33,6 @@ use super::{
 use crate::{
     diagnostics::error::{SemanticError, SemanticResult},
     ops::common::CommonOps,
-    passes::ast_utils::AstUtils,
 };
 
 impl<'tc> ResolutionPass<'tc> {
@@ -78,9 +77,9 @@ impl<'tc> ResolutionPass<'tc> {
         &self,
         node: AstNodeRef<'a, ast::AccessTy>,
     ) -> SemanticResult<AstPath<'a>> {
-        let mut root = self.ty_as_ast_path(node.body.subject.ast_ref())?.ok_or_else(|| {
-            SemanticError::InvalidNamespaceSubject { location: self.node_location(node) }
-        })?;
+        let mut root = self
+            .ty_as_ast_path(node.body.subject.ast_ref())?
+            .ok_or_else(|| SemanticError::InvalidNamespaceSubject { location: node.span() })?;
 
         root.push(AstPathComponent {
             name: node.body.property.ident,
@@ -112,7 +111,7 @@ impl<'tc> ResolutionPass<'tc> {
     fn make_ty_from_resolved_ast_path(
         &self,
         path: &ResolvedAstPathComponent,
-        original_node_span: Span,
+        original_node_span: SourceLocation,
     ) -> SemanticResult<TyId> {
         match path {
             ResolvedAstPathComponent::NonTerminal(non_terminal) => match non_terminal {
@@ -124,7 +123,7 @@ impl<'tc> ResolutionPass<'tc> {
                 NonTerminalResolvedPathComponent::Mod(_) => {
                     // Modules are not allowed in type positions
                     Err(SemanticError::CannotUseModuleInTypePosition {
-                        location: self.source_location(original_node_span),
+                        location: original_node_span,
                     })
                 }
             },
@@ -134,7 +133,7 @@ impl<'tc> ResolutionPass<'tc> {
                 }
                 TerminalResolvedPathComponent::CtorPat(_) => {
                     panic_on_span!(
-                        self.source_location(original_node_span),
+                        original_node_span,
                         self.source_map(),
                         "found CtorPat in type ast path"
                     )
@@ -385,16 +384,12 @@ impl<'tc> ResolutionPass<'tc> {
                 self.new_ty(expr)
             }
             ast::Ty::Union(_) => {
-                panic_on_span!(
-                    self.node_location(node),
-                    self.source_map(),
-                    "Found union type after discovery"
-                )
+                panic_on_span!(node.span(), self.source_map(), "Found union type after discovery")
             }
         };
 
         self.ast_info().tys().insert(node.id(), ty_id);
-        self.stores().location().add_location_to_target(ty_id, self.node_location(node));
+        self.stores().location().add_location_to_target(ty_id, node.span());
         Ok(ty_id)
     }
 }

--- a/compiler/hash-source/src/lib.rs
+++ b/compiler/hash-source/src/lib.rs
@@ -19,7 +19,7 @@ use hash_utils::{
     path::adjust_canonicalisation,
     range_map::RangeMap,
 };
-use location::{RowCol, RowColRange, SourceLocation, Span};
+use location::{ByteRange, RowCol, RowColRange, SourceLocation};
 use once_cell::sync::OnceCell;
 
 /// Used to check what kind of [SourceId] is being
@@ -201,8 +201,8 @@ impl LineRanges {
         RowCol { row: line, column: index - offset }
     }
 
-    /// Returns the line and column of the given [Span]
-    pub fn row_cols(&self, range: Span) -> RowColRange {
+    /// Returns the line and column of the given [ByteRange]
+    pub fn row_cols(&self, range: ByteRange) -> RowColRange {
         let start = self.get_row_col(range.start());
         let end = self.get_row_col(range.end());
 

--- a/compiler/hash-source/src/lib.rs
+++ b/compiler/hash-source/src/lib.rs
@@ -19,7 +19,7 @@ use hash_utils::{
     path::adjust_canonicalisation,
     range_map::RangeMap,
 };
-use location::{ByteRange, RowCol, RowColRange, SourceLocation};
+use location::{ByteRange, RowCol, RowColRange, Span};
 use once_cell::sync::OnceCell;
 
 /// Used to check what kind of [SourceId] is being
@@ -452,16 +452,16 @@ impl SourceMap {
         SourceId::new_interactive(id)
     }
 
-    /// Function to get a friendly representation of the [SourceLocation] in
+    /// Function to get a friendly representation of the [Span] in
     /// terms of row and column positions.
-    pub fn get_row_col_for(&self, location: SourceLocation) -> RowColRange {
+    pub fn get_row_col_for(&self, location: Span) -> RowColRange {
         self.line_ranges(location.id).row_cols(location.span)
     }
 
-    /// Convert a [SourceLocation] in terms of the filename, row and column.
+    /// Convert a [Span] in terms of the filename, row and column.
     ///
     /// @@cleanup: move this out of here.
-    pub fn fmt_location(&self, location: SourceLocation) -> String {
+    pub fn fmt_location(&self, location: Span) -> String {
         let name = self.canonicalised_path_by_id(location.id);
         let span = self.get_row_col_for(location);
 

--- a/compiler/hash-source/src/location.rs
+++ b/compiler/hash-source/src/location.rs
@@ -104,9 +104,19 @@ impl SourceLocation {
     ///
     /// *Note*: the `id` of both [SourceLocation]s must be the same.
     pub fn join(self, other: Self) -> Self {
-        assert!(self.id == other.id);
+        debug_assert!(self.id == other.id);
 
         Self { id: self.id, span: self.span.join(other.span) }
+    }
+
+    /// Get the length of the [Span].
+    pub fn len(&self) -> usize {
+        self.span.len()
+    }
+
+    /// Check if the [Span] is empty.
+    pub fn is_empty(&self) -> bool {
+        self.span.is_empty()
     }
 }
 

--- a/compiler/hash-source/src/location.rs
+++ b/compiler/hash-source/src/location.rs
@@ -137,25 +137,25 @@ impl Display for RowCol {
     }
 }
 
-/// [RowColSpan] is a data structure that is equivalent to [Span] but uses rows
-/// and columns to denote offsets within the source file. [RowColSpan] is only
+/// [RowColRange] is a data structure that is equivalent to [Span] but uses rows
+/// and columns to denote offsets within the source file. [RowColRange] is only
 /// re-used when specific line numbers need to be reported, this shouldn't be
 /// used for general purpose storage of positions of source items.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
-pub struct RowColSpan {
-    /// The starting position of the [RowColSpan].
+pub struct RowColRange {
+    /// The starting position of the [RowColRange].
     pub start: RowCol,
-    /// The end position of the [RowColSpan].
+    /// The end position of the [RowColRange].
     pub end: RowCol,
 }
 
-impl RowColSpan {
-    /// Create a new [RowColSpan] from a `start` and `end`.
+impl RowColRange {
+    /// Create a new [RowColRange] from a `start` and `end`.
     pub fn new(start: RowCol, end: RowCol) -> Self {
         Self { start, end }
     }
 
-    /// Get the associated rows with the start and end of the [RowColSpan].
+    /// Get the associated rows with the start and end of the [RowColRange].
     pub fn rows(&self) -> (usize, usize) {
         (self.start.row, self.end.row)
     }
@@ -165,7 +165,7 @@ impl RowColSpan {
     }
 }
 
-impl Display for RowColSpan {
+impl Display for RowColRange {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if self.start == self.end {
             write!(f, "{}", self.start)

--- a/compiler/hash-source/src/location.rs
+++ b/compiler/hash-source/src/location.rs
@@ -8,25 +8,26 @@ use derive_more::Constructor;
 
 use crate::SourceId;
 
-/// [Span] represents a location of a range of tokens within the source.
+/// [ByteRange] represents a location of a range of tokens within the source.
 ///
 /// The first element of the tuple represents the starting byte offset and the
 /// second element represents the ending byte offset.
 #[derive(Debug, Eq, Hash, Clone, Copy, PartialEq)]
-pub struct Span(u32, u32);
+pub struct ByteRange(u32, u32);
 
-impl Span {
-    /// Create a [Span] by providing a start and end byte position.
+impl ByteRange {
+    /// Create a [ByteRange] by providing a start and end byte position.
     pub const fn new(start: usize, end: usize) -> Self {
         debug_assert!(end >= start, "invalid span. start > end");
-        Span(start as u32, end as u32)
+        ByteRange(start as u32, end as u32)
     }
 
-    /// This function is used to join a [Span] to another [Span]. The assumption
-    /// is made that the left hand-side [Span] ends before the start of the
-    /// right hand side [Span]. If that is the case, then a new location is
-    /// created with start position of the `self`, and the end position of the
-    /// `other`. If that is not the case, the `self` span is returned.
+    /// This function is used to join a [ByteRange] to another [ByteRange]ange].
+    /// The assumption is made that the left hand-side [ByteRange] ends before
+    /// the start of the right hand side [ByteRange]. If that is the case, then
+    /// a new location is created with start position of the `self`, and the
+    /// end position of the `other`. If that is not the case, the `self`
+    /// span is returned.
     ///
     /// In essence, if this was the source stream:
     /// ```text
@@ -40,61 +41,63 @@ impl Span {
     #[must_use]
     pub fn join(&self, other: Self) -> Self {
         if self.end() <= other.start() {
-            return Span::new(self.start(), other.end());
+            return ByteRange::new(self.start(), other.end());
         }
 
         *self
     }
 
-    /// Get the start of the [Span].
+    /// Get the start of the [ByteRange].
     pub fn start(&self) -> usize {
         self.0.try_into().unwrap()
     }
 
-    /// Get the end of the [Span].
+    /// Get the end of the [ByteRange].
     pub fn end(&self) -> usize {
         self.1.try_into().unwrap()
     }
 
-    /// Compute the actual size of the [Span] by subtracting the end from start.
+    /// Compute the actual size of the [ByteRange] by subtracting the end
+    /// from start.
     pub fn len(&self) -> usize {
         self.end() - self.start()
     }
 
-    /// Check if the [Span] is empty.
+    /// Check if the [ByteRange] is empty.
     pub fn is_empty(&self) -> bool {
         self.start() == self.end()
     }
 
-    /// Convert the [Span] into a [SourceLocation].
+    /// Convert the [ByteRange] into a [SourceLocation].
     pub fn into_location(self, source_id: SourceId) -> SourceLocation {
         SourceLocation::new(self, source_id)
     }
 }
 
-impl Default for Span {
+impl Default for ByteRange {
     fn default() -> Self {
         Self::new(0, 0)
     }
 }
 
-impl fmt::Display for Span {
+impl fmt::Display for ByteRange {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}:{}", self.0, self.1)
     }
 }
 
 /// A [SourceLocation] describes the location of something that is relative to
-/// a module that is within the workspace and that has an associated [Span].
+/// a module that is within the workspace and that has an associated
+/// [ByteRange].
 ///
 /// [SourceLocation]s are only used when printing reports within the
 /// `hash_reporting` crate. Ideally, data structures that need to store
-/// locations of various items should use [Span] and then convert into
+/// locations of various items should use [ByteRange] and then convert into
 /// [SourceLocation]s.
 #[derive(Debug, Clone, Copy, Constructor, PartialEq, Eq, Hash)]
 pub struct SourceLocation {
-    /// The associated [Span] with the [SourceLocation].
-    pub span: Span,
+    /// The associated [ByteRange] with the [SourceLocation].
+    pub span: ByteRange,
     /// The id of the source that the span is referencing.
     pub id: SourceId,
 }
@@ -137,10 +140,10 @@ impl Display for RowCol {
     }
 }
 
-/// [RowColRange] is a data structure that is equivalent to [Span] but uses rows
-/// and columns to denote offsets within the source file. [RowColRange] is only
-/// re-used when specific line numbers need to be reported, this shouldn't be
-/// used for general purpose storage of positions of source items.
+/// [RowColRange] is a data structure that is equivalent to [ByteRange] but uses
+/// rows and columns to denote offsets within the source file. [RowColRange] is
+/// only re-used when specific line numbers need to be reported, this shouldn't
+/// be used for general purpose storage of positions of source items.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct RowColRange {
     /// The starting position of the [RowColRange].

--- a/compiler/hash-source/src/location.rs
+++ b/compiler/hash-source/src/location.rs
@@ -68,9 +68,9 @@ impl ByteRange {
         self.start() == self.end()
     }
 
-    /// Convert the [ByteRange] into a [SourceLocation].
-    pub fn into_location(self, source_id: SourceId) -> SourceLocation {
-        SourceLocation::new(self, source_id)
+    /// Convert the [ByteRange] into a [Span].
+    pub fn into_location(self, source_id: SourceId) -> Span {
+        Span::new(self, source_id)
     }
 }
 
@@ -86,26 +86,26 @@ impl fmt::Display for ByteRange {
     }
 }
 
-/// A [SourceLocation] describes the location of something that is relative to
+/// A [Span] describes the location of something that is relative to
 /// a module that is within the workspace and that has an associated
 /// [ByteRange].
 ///
-/// [SourceLocation]s are only used when printing reports within the
+/// [Span]s are only used when printing reports within the
 /// `hash_reporting` crate. Ideally, data structures that need to store
 /// locations of various items should use [ByteRange] and then convert into
-/// [SourceLocation]s.
+/// [Span]s.
 #[derive(Debug, Clone, Copy, Constructor, PartialEq, Eq, Hash)]
-pub struct SourceLocation {
-    /// The associated [ByteRange] with the [SourceLocation].
+pub struct Span {
+    /// The associated [ByteRange] with the [Span].
     pub span: ByteRange,
     /// The id of the source that the span is referencing.
     pub id: SourceId,
 }
 
-impl SourceLocation {
-    /// Join the span of a [SourceLocation] with another [SourceLocation].
+impl Span {
+    /// Join the span of a [Span] with another [Span].
     ///
-    /// *Note*: the `id` of both [SourceLocation]s must be the same.
+    /// *Note*: the `id` of both [Span]s must be the same.
     pub fn join(self, other: Self) -> Self {
         debug_assert!(self.id == other.id);
 

--- a/compiler/hash-tir/Cargo.toml
+++ b/compiler/hash-tir/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["The Hash Language authors"]
 edition = "2021"
 
 [dependencies]
-bimap = "0.6"
 derive_more = "0.99"
 indexmap = "1.9"
 num-bigint = "0.4"

--- a/compiler/hash-tir/src/ast_info.rs
+++ b/compiler/hash-tir/src/ast_info.rs
@@ -1,7 +1,7 @@
-use std::hash::Hash;
+use std::{collections::HashMap, fmt::Debug, hash::Hash};
 
-use bimap::BiMap;
 use hash_ast::ast::AstNodeId;
+use hash_storage::store::FxHashMap;
 use hash_utils::parking_lot::RwLock;
 
 use crate::{
@@ -17,15 +17,54 @@ use crate::{
     tys::TyId,
 };
 
-/// A partial mapping from AST nodes to `T` and back.
-#[derive(Debug)]
-pub struct AstMap<T: Hash + Eq> {
-    data: RwLock<BiMap<AstNodeId, T>>,
+/// This is used to store the relations between [AstNodeId]s and their
+/// respective [`T`]. There is no assumption that the relation is uniquely
+/// biderctional, e.g. multiple function definitions may point to one
+/// [AstNodeId], i.e. mono-morphization.
+#[derive(Debug, Default)]
+struct AstMapInner<T: Hash + Eq + Copy> {
+    left: FxHashMap<AstNodeId, T>,
+    right: HashMap<T, AstNodeId>,
 }
 
-impl<T: Hash + Eq> AstMap<T> {
+impl<T: Hash + Eq + Copy> AstMapInner<T> {
+    /// A new empty map.
     pub fn new() -> Self {
-        Self { data: RwLock::new(BiMap::new()) }
+        Self { left: FxHashMap::default(), right: HashMap::default() }
+    }
+
+    /// Perform an insertion.
+    pub fn insert(&mut self, key: AstNodeId, value: T) {
+        self.left.insert(key, value);
+        self.right.insert(value, key);
+    }
+
+    /// Insert a key only into the right map.
+    pub fn insert_right(&mut self, key: T, value: AstNodeId) {
+        self.right.insert(key, value);
+    }
+
+    /// Get the value by left associatation, i.e. by [AstNodeId]. This
+    /// will return the first item that was registered to the [AstNodeId].
+    pub fn get_by_left(&self, key: AstNodeId) -> Option<T> {
+        self.left.get(&key).copied()
+    }
+
+    /// Get the value by right association, i.e. by [`T`].
+    pub fn get_by_right(&self, key: &T) -> Option<AstNodeId> {
+        self.right.get(key).copied()
+    }
+}
+
+/// A partial mapping from AST nodes to `T` and back.
+#[derive(Debug)]
+pub struct AstMap<T: Hash + Eq + Copy> {
+    data: RwLock<AstMapInner<T>>,
+}
+
+impl<T: Hash + Eq + Copy> AstMap<T> {
+    pub fn new() -> Self {
+        Self { data: RwLock::new(AstMapInner::new()) }
     }
 
     pub fn insert(&self, ast_id: AstNodeId, data: T) {
@@ -33,7 +72,7 @@ impl<T: Hash + Eq> AstMap<T> {
     }
 }
 
-impl<T: Hash + Eq> Default for AstMap<T> {
+impl<T: Hash + Eq + Copy> Default for AstMap<T> {
     fn default() -> Self {
         Self::new()
     }
@@ -41,11 +80,27 @@ impl<T: Hash + Eq> Default for AstMap<T> {
 
 impl<T: Hash + Eq + Copy> AstMap<T> {
     pub fn get_data_by_node(&self, ast_id: AstNodeId) -> Option<T> {
-        self.data.read().get_by_left(&ast_id).copied()
+        self.data.read().get_by_left(ast_id)
     }
 
     pub fn get_node_by_data(&self, data: T) -> Option<AstNodeId> {
-        self.data.read().get_by_right(&data).copied()
+        self.data.read().get_by_right(&data)
+    }
+
+    /// This will copy the node from `src` to `dest`. This is useful for
+    /// when we want to copy over [AstNodeId] reference from the source
+    /// to destination. If the `src` does not have a [AstNodeId] associated
+    /// with it, then this will do nothing.
+    pub fn copy_node(&self, src: T, dest: T) {
+        if src == dest {
+            return;
+        }
+
+        let old_data = { self.data.read().get_by_right(&src) };
+
+        if let Some(ast_id) = old_data {
+            self.data.write().insert_right(dest, ast_id);
+        }
     }
 }
 

--- a/compiler/hash-tir/src/locations.rs
+++ b/compiler/hash-tir/src/locations.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use hash_source::location::{SourceLocation, Span};
+use hash_source::location::SourceLocation;
 use hash_storage::store::SequenceStoreKey;
 use hash_utils::parking_lot::RwLock;
 
@@ -170,21 +170,6 @@ impl LocationStore {
     /// Get a [SourceLocation] from a specified [LocationTarget]
     pub fn get_location(&self, target: impl Into<LocationTarget>) -> Option<SourceLocation> {
         self.data.read().get(&target.into()).copied()
-    }
-
-    /// Get the associated [Span] with from the specified [LocationTarget]
-    pub fn get_span(&self, target: impl Into<LocationTarget>) -> Option<Span> {
-        self.get_location(target).map(|loc| loc.span)
-    }
-
-    /// Get the overall [Span] covering all the members of a specified
-    /// [IndexedLocationTarget].
-    pub fn get_overall_span(&self, target: impl Into<IndexedLocationTarget>) -> Option<Span> {
-        let target = target.into();
-        target
-            .to_index_range()
-            .map(|index| self.get_span(LocationTarget::from((target, index))))
-            .fold(None, |acc, span| Some(acc?.join(span?)))
     }
 
     /// Get the overall [SourceLocation] covering all the members of a specified

--- a/compiler/hash-tir/src/locations.rs
+++ b/compiler/hash-tir/src/locations.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use hash_source::location::SourceLocation;
+use hash_source::location::Span;
 use hash_storage::store::SequenceStoreKey;
 use hash_utils::parking_lot::RwLock;
 
@@ -24,7 +24,7 @@ macro_rules! location_targets {
            $(
                $name($ty),
            )*
-           Location(SourceLocation),
+           Location(Span),
         }
 
         #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
@@ -64,8 +64,8 @@ macro_rules! location_targets {
             }
         }
 
-        impl From<SourceLocation> for LocationTarget {
-            fn from(loc: SourceLocation) -> Self {
+        impl From<Span> for LocationTarget {
+            fn from(loc: Span) -> Self {
                 Self::Location(loc)
             }
         }
@@ -135,7 +135,7 @@ location_targets! {
 #[derive(Debug, Default)]
 pub struct LocationStore {
     // @@Performance: DashMap?
-    data: RwLock<HashMap<LocationTarget, SourceLocation>>,
+    data: RwLock<HashMap<LocationTarget, Span>>,
 }
 
 impl LocationStore {
@@ -144,20 +144,16 @@ impl LocationStore {
         Self::default()
     }
 
-    /// Add a [SourceLocation] to a specified [LocationTarget]
-    pub fn add_location_to_target(
-        &self,
-        target: impl Into<LocationTarget>,
-        location: SourceLocation,
-    ) {
+    /// Add a [Span] to a specified [LocationTarget]
+    pub fn add_location_to_target(&self, target: impl Into<LocationTarget>, location: Span) {
         self.data.write().insert(target.into(), location);
     }
 
-    /// Add a set of [SourceLocation]s to a specified [IndexedLocationTarget]
+    /// Add a set of [Span]s to a specified [IndexedLocationTarget]
     pub fn add_locations_to_targets(
         &self,
         targets: impl Into<IndexedLocationTarget>,
-        location: impl Fn(usize) -> Option<SourceLocation>,
+        location: impl Fn(usize) -> Option<Span>,
     ) {
         let targets = targets.into();
         for target in targets.to_index_range() {
@@ -167,17 +163,14 @@ impl LocationStore {
         }
     }
 
-    /// Get a [SourceLocation] from a specified [LocationTarget]
-    pub fn get_location(&self, target: impl Into<LocationTarget>) -> Option<SourceLocation> {
+    /// Get a [Span] from a specified [LocationTarget]
+    pub fn get_location(&self, target: impl Into<LocationTarget>) -> Option<Span> {
         self.data.read().get(&target.into()).copied()
     }
 
-    /// Get the overall [SourceLocation] covering all the members of a specified
+    /// Get the overall [Span] covering all the members of a specified
     /// [IndexedLocationTarget].
-    pub fn get_overall_location(
-        &self,
-        target: impl Into<IndexedLocationTarget>,
-    ) -> Option<SourceLocation> {
+    pub fn get_overall_location(&self, target: impl Into<IndexedLocationTarget>) -> Option<Span> {
         let target = target.into();
         target
             .to_index_range()
@@ -213,10 +206,10 @@ impl LocationStore {
 
     /// Merge the given [LocationTarget]s into a single [LocationTarget]
     /// provided that they can be merged in terms of order. All `ids` of the
-    /// [SourceLocation]s must match.
+    /// [Span]s must match.
     ///
     /// **Note**: At least one of the [LocationTarget]s must have an associated
-    /// [SourceLocation].
+    /// [Span].
     pub fn merge_locations(
         &self,
         locations: impl Iterator<Item = LocationTarget>,

--- a/compiler/hash-tir/src/utils/common.rs
+++ b/compiler/hash-tir/src/utils/common.rs
@@ -2,7 +2,7 @@
 
 use hash_source::{
     identifier::{Identifier, IDENTS},
-    location::SourceLocation,
+    location::Span,
 };
 use hash_storage::store::{CloneStore, SequenceStore, Store, TrivialKeySequenceStore};
 use hash_utils::stream_less_writeln;
@@ -123,7 +123,7 @@ pub trait CommonUtils: AccessToEnv {
     }
 
     /// Get the location of a location target.
-    fn get_location(&self, target: impl Into<LocationTarget>) -> Option<SourceLocation> {
+    fn get_location(&self, target: impl Into<LocationTarget>) -> Option<Span> {
         self.stores().location().get_location(target)
     }
 

--- a/compiler/hash-tir/src/utils/traversing.rs
+++ b/compiler/hash-tir/src/utils/traversing.rs
@@ -445,6 +445,8 @@ impl<'env> TraversingUtils<'env> {
         }?;
 
         self.stores().location().copy_location(fn_def_id, new_fn_def);
+        self.stores().ast_info().fn_defs().copy_node(fn_def_id, new_fn_def);
+
         Ok(new_fn_def)
     }
 

--- a/compiler/hash-token/src/lib.rs
+++ b/compiler/hash-token/src/lib.rs
@@ -7,26 +7,26 @@ use delimiter::{Delimiter, DelimiterVariant};
 use hash_source::{
     constant::{InternedFloat, InternedInt, InternedStr},
     identifier::Identifier,
-    location::Span,
+    location::ByteRange,
 };
 use keyword::Keyword;
 use smallvec::{smallvec, SmallVec};
 
 /// A Lexeme token that represents the smallest code unit of a hash source file.
-/// The token contains a kind which is elaborated by [TokenKind] and a [Span] in
-/// the source that is represented as a span. The span is the beginning byte
-/// offset, and the number of bytes for the said token.
+/// The token contains a kind which is elaborated by [TokenKind] and a
+/// [ByteRange] in the source that is represented as a span. The span is the
+/// beginning byte offset, and the number of bytes for the said token.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct Token {
     /// The current token type.
     pub kind: TokenKind,
     /// The span of the current token.
-    pub span: Span,
+    pub span: ByteRange,
 }
 
 impl Token {
-    /// Create a new token from a kind and a provided [Span].
-    pub fn new(kind: TokenKind, span: Span) -> Self {
+    /// Create a new token from a kind and a provided [ByteRange].
+    pub fn new(kind: TokenKind, span: ByteRange) -> Self {
         Token { kind, span }
     }
 

--- a/compiler/hash-typecheck/Cargo.toml
+++ b/compiler/hash-typecheck/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["The Hash Language authors"]
 edition = "2021"
 
 [dependencies]
-bimap = "0.6"
 dashmap = "5.1"
 derive_more = "0.99"
 itertools = "0.10"

--- a/compiler/hash-typecheck/src/errors.rs
+++ b/compiler/hash-typecheck/src/errors.rs
@@ -6,7 +6,7 @@ use hash_reporting::{
     reporter::{Reporter, Reports},
     writer::ReportWriter,
 };
-use hash_source::location::SourceLocation;
+use hash_source::location::Span;
 use hash_storage::store::{SequenceStoreKey, TrivialSequenceStoreKey};
 use hash_tir::{
     environment::env::{AccessToEnv, Env},
@@ -152,7 +152,7 @@ pub enum TcError {
     MismatchingFns { a: FnDefId, b: FnDefId },
 
     /// Invalid range pattern literal
-    InvalidRangePatternLiteral { location: SourceLocation },
+    InvalidRangePatternLiteral { location: Span },
 
     /// Invalid range pattern literal
     TryingToReferenceLocalsInType { ty: TyId },

--- a/compiler/hash-untyped-semantics/src/analysis/mod.rs
+++ b/compiler/hash-untyped-semantics/src/analysis/mod.rs
@@ -7,10 +7,7 @@ pub(crate) mod params;
 use crossbeam_channel::Sender;
 use hash_ast::{ast::AstNodeRef, origin::BlockOrigin};
 use hash_reporting::diagnostic::AccessToDiagnosticsMut;
-use hash_source::{
-    location::{SourceLocation, Span},
-    SourceId, SourceMap,
-};
+use hash_source::SourceMap;
 
 use crate::diagnostics::{
     error::{AnalysisError, AnalysisErrorKind},
@@ -21,14 +18,16 @@ use crate::diagnostics::{
 pub struct SemanticAnalyser<'s> {
     /// Whether the current visitor is within a loop construct.
     pub(crate) is_in_loop: bool,
+
     /// Whether the current visitor is within a function definition.
     pub(crate) is_in_fn: bool,
+
     /// Whether the analyser is currently checking a literal pattern
     pub(crate) is_in_lit_pat: bool,
-    /// The current id of the source that is being passed.
-    pub(crate) source_id: SourceId,
+
     /// A reference to the sources of the current job.
     pub(crate) source_map: &'s SourceMap,
+
     /// The current scope of the traversal, representing which block the
     /// analyser is walking.
     pub(crate) current_block: BlockOrigin,
@@ -39,13 +38,12 @@ pub struct SemanticAnalyser<'s> {
 
 impl<'s> SemanticAnalyser<'s> {
     /// Create a new semantic analyser
-    pub fn new(source_map: &'s SourceMap, source_id: SourceId) -> Self {
+    pub fn new(source_map: &'s SourceMap) -> Self {
         Self {
             is_in_loop: false,
             is_in_fn: false,
             is_in_lit_pat: false,
             diagnostics: AnalyserDiagnostics::default(),
-            source_id,
             source_map,
             current_block: BlockOrigin::Root,
         }
@@ -61,22 +59,17 @@ impl<'s> SemanticAnalyser<'s> {
 
     /// Append an error to [AnalyserDiagnostics]
     pub(crate) fn append_error<T>(&mut self, error: AnalysisErrorKind, node: AstNodeRef<T>) {
-        self.add_error(AnalysisError::new(error, node, self.source_id))
+        self.add_error(AnalysisError::new(error, node))
     }
 
     /// Append an warning to [AnalyserDiagnostics]
     pub(crate) fn append_warning<T>(&mut self, warning: AnalysisWarningKind, node: AstNodeRef<T>) {
-        self.add_warning(AnalysisWarning::new(warning, node, self.source_id))
+        self.add_warning(AnalysisWarning::new(warning, node))
     }
 
     /// Given a [Sender], send all of the generated warnings and messaged into
     /// the sender.
     pub(crate) fn send_generated_messages(self, sender: &Sender<AnalysisDiagnostic>) {
         self.diagnostics.items.into_iter().for_each(|t| sender.send(t).unwrap())
-    }
-
-    /// Create a [SourceLocation] from a [Span]
-    pub(crate) fn source_location(&self, span: Span) -> SourceLocation {
-        SourceLocation { span, id: self.source_id }
     }
 }

--- a/compiler/hash-untyped-semantics/src/diagnostics/error.rs
+++ b/compiler/hash-untyped-semantics/src/diagnostics/error.rs
@@ -9,7 +9,7 @@ use hash_reporting::{
     report::{ReportCodeBlock, ReportElement, ReportNote, ReportNoteKind},
     reporter::{Reporter, Reports},
 };
-use hash_source::{identifier::Identifier, location::SourceLocation, ModuleKind, SourceId};
+use hash_source::{identifier::Identifier, location::SourceLocation, ModuleKind};
 
 use super::directives::DirectiveArgument;
 use crate::analysis::params::FieldNamingExpectation;
@@ -29,8 +29,8 @@ pub struct AnalysisError {
 
 impl AnalysisError {
     /// Create a new [AnalysisError] from a passed kind and [SourceLocation].
-    pub(crate) fn new<T>(kind: AnalysisErrorKind, node: AstNodeRef<T>, id: SourceId) -> Self {
-        Self { kind, location: SourceLocation { span: node.span(), id }, id: node.id() }
+    pub(crate) fn new<T>(kind: AnalysisErrorKind, node: AstNodeRef<T>) -> Self {
+        Self { kind, location: node.span(), id: node.id() }
     }
 
     /// Get the associated [AstNodeId] with this [AnalysisError].

--- a/compiler/hash-untyped-semantics/src/diagnostics/error.rs
+++ b/compiler/hash-untyped-semantics/src/diagnostics/error.rs
@@ -9,7 +9,7 @@ use hash_reporting::{
     report::{ReportCodeBlock, ReportElement, ReportNote, ReportNoteKind},
     reporter::{Reporter, Reports},
 };
-use hash_source::{identifier::Identifier, location::SourceLocation, ModuleKind};
+use hash_source::{identifier::Identifier, location::Span, ModuleKind};
 
 use super::directives::DirectiveArgument;
 use crate::analysis::params::FieldNamingExpectation;
@@ -20,7 +20,7 @@ pub struct AnalysisError {
     kind: AnalysisErrorKind,
 
     /// Where the error occurred
-    location: SourceLocation,
+    location: Span,
 
     /// The associated [AstNodeRef<T>] with this error, which is used
     /// to sort the order that errors are emitted.
@@ -28,7 +28,7 @@ pub struct AnalysisError {
 }
 
 impl AnalysisError {
-    /// Create a new [AnalysisError] from a passed kind and [SourceLocation].
+    /// Create a new [AnalysisError] from a passed kind and [Span].
     pub(crate) fn new<T>(kind: AnalysisErrorKind, node: AstNodeRef<T>) -> Self {
         Self { kind, location: node.span(), id: node.id() }
     }

--- a/compiler/hash-untyped-semantics/src/diagnostics/warning.rs
+++ b/compiler/hash-untyped-semantics/src/diagnostics/warning.rs
@@ -5,7 +5,7 @@ use hash_reporting::{
     report::{ReportCodeBlock, ReportElement, ReportNote, ReportNoteKind},
     reporter::{Reporter, Reports},
 };
-use hash_source::{identifier::Identifier, location::SourceLocation};
+use hash_source::{identifier::Identifier, location::Span};
 
 /// A [AnalysisWarning] is warning that can occur during the semantic pass
 pub struct AnalysisWarning {
@@ -13,7 +13,7 @@ pub struct AnalysisWarning {
     kind: AnalysisWarningKind,
 
     /// Where the warning occurred
-    location: SourceLocation,
+    location: Span,
 
     /// The associated [AstNodeRef<T>] with this error, which is used
     /// to sort the order that errors are emitted.
@@ -21,7 +21,7 @@ pub struct AnalysisWarning {
 }
 
 impl AnalysisWarning {
-    /// Create a new [AnalysisWarning] from a passed kind and [SourceLocation].
+    /// Create a new [AnalysisWarning] from a passed kind and [Span].
     pub(crate) fn new<T>(kind: AnalysisWarningKind, node: AstNodeRef<T>) -> Self {
         Self { kind, location: node.span(), id: node.id() }
     }

--- a/compiler/hash-untyped-semantics/src/diagnostics/warning.rs
+++ b/compiler/hash-untyped-semantics/src/diagnostics/warning.rs
@@ -5,7 +5,7 @@ use hash_reporting::{
     report::{ReportCodeBlock, ReportElement, ReportNote, ReportNoteKind},
     reporter::{Reporter, Reports},
 };
-use hash_source::{identifier::Identifier, location::SourceLocation, SourceId};
+use hash_source::{identifier::Identifier, location::SourceLocation};
 
 /// A [AnalysisWarning] is warning that can occur during the semantic pass
 pub struct AnalysisWarning {
@@ -22,8 +22,8 @@ pub struct AnalysisWarning {
 
 impl AnalysisWarning {
     /// Create a new [AnalysisWarning] from a passed kind and [SourceLocation].
-    pub(crate) fn new<T>(kind: AnalysisWarningKind, node: AstNodeRef<T>, id: SourceId) -> Self {
-        Self { kind, location: SourceLocation { span: node.span(), id }, id: node.id() }
+    pub(crate) fn new<T>(kind: AnalysisWarningKind, node: AstNodeRef<T>) -> Self {
+        Self { kind, location: node.span(), id: node.id() }
     }
 
     /// Get the associated [AstNodeId] with this [AnalysisWarning].

--- a/compiler/hash-untyped-semantics/src/lib.rs
+++ b/compiler/hash-untyped-semantics/src/lib.rs
@@ -66,7 +66,7 @@ impl<Ctx: UntypedSemanticAnalysisCtxQuery> CompilerStage<Ctx> for UntypedSemanti
                 let source = node_map.get_interactive_block(entry_point.into());
 
                 // setup a visitor and the context
-                let mut visitor = SemanticAnalyser::new(source_map, entry_point);
+                let mut visitor = SemanticAnalyser::new(source_map);
 
                 visitor.visit_body_block(source.node_ref()).unwrap();
                 visitor.send_generated_messages(&sender);
@@ -83,7 +83,7 @@ impl<Ctx: UntypedSemanticAnalysisCtxQuery> CompilerStage<Ctx> for UntypedSemanti
                     continue;
                 }
 
-                let mut visitor = SemanticAnalyser::new(source_map, source_id);
+                let mut visitor = SemanticAnalyser::new(source_map);
 
                 // Check that all of the root scope statements are only declarations
                 let errors = visitor.visit_module(module.node_ref()).unwrap();
@@ -100,7 +100,7 @@ impl<Ctx: UntypedSemanticAnalysisCtxQuery> CompilerStage<Ctx> for UntypedSemanti
                     let sender = sender.clone();
 
                     scope.spawn(move |_| {
-                        let mut visitor = SemanticAnalyser::new(source_map, source_id);
+                        let mut visitor = SemanticAnalyser::new(source_map);
 
                         visitor.visit_expr(expr.ast_ref()).unwrap();
                         visitor.send_generated_messages(&sender);

--- a/compiler/hash-untyped-semantics/src/visitor.rs
+++ b/compiler/hash-untyped-semantics/src/visitor.rs
@@ -113,7 +113,8 @@ impl<'s> SemanticAnalyser<'s> {
         // Here we should check if in the event that an `intrinsics` directive
         // is being used only within the `prelude` module.
         if name == IDENTS.intrinsics {
-            let module_kind = self.source_map.module_kind_by_id(self.source_id);
+            let id = directive.span().id;
+            let module_kind = self.source_map.module_kind_by_id(id);
 
             if !matches!(module_kind, Some(ModuleKind::Prelude)) {
                 self.append_error(
@@ -398,7 +399,7 @@ impl AstVisitorMutSelf for SemanticAnalyser<'_> {
         node: hash_ast::ast::AstNodeRef<hash_ast::ast::ForLoopBlock>,
     ) -> Result<Self::ForLoopBlockRet, Self::Error> {
         panic_on_span!(
-            self.source_location(node.span()),
+            node.span(),
             self.source_map,
             "hit non de-sugared for-block whilst performing semantic analysis"
         );
@@ -411,7 +412,7 @@ impl AstVisitorMutSelf for SemanticAnalyser<'_> {
         node: hash_ast::ast::AstNodeRef<hash_ast::ast::WhileLoopBlock>,
     ) -> Result<Self::WhileLoopBlockRet, Self::Error> {
         panic_on_span!(
-            self.source_location(node.span()),
+            node.span(),
             self.source_map,
             "hit non de-sugared while-block whilst performing semantic analysis"
         );
@@ -444,7 +445,7 @@ impl AstVisitorMutSelf for SemanticAnalyser<'_> {
         node: hash_ast::ast::AstNodeRef<hash_ast::ast::IfClause>,
     ) -> Result<Self::IfClauseRet, Self::Error> {
         panic_on_span!(
-            self.source_location(node.span()),
+            node.span(),
             self.source_map,
             "hit non de-sugared if-clause whilst performing semantic analysis"
         );
@@ -457,7 +458,7 @@ impl AstVisitorMutSelf for SemanticAnalyser<'_> {
         node: hash_ast::ast::AstNodeRef<hash_ast::ast::IfBlock>,
     ) -> Result<Self::IfBlockRet, Self::Error> {
         panic_on_span!(
-            self.source_location(node.span()),
+            node.span(),
             self.source_map,
             "hit non de-sugared if-block whilst performing semantic analysis"
         );


### PR DESCRIPTION
- ast: Make AST spanless, and store `Span`s within `SPAN_MAP`
- ast: Use `RwLock` and `once_cell:sync::Lazy` for SpanMap
- lower: fix panic when trying to access numbered ADT fields
- ast: Add `AstNodeId` to `AstNodes`, guaranteeing node lists have spans
- ast+source: use `SourceLocation` over `Span`
- ir+lower: switch to using `AstNodeId`s for spans instead of directly using spans
- ir: add static size assertions
- source: rename `RowColSpan` to `RowColRange`
- source: rename `Span` to `ByteRange`
- source: rename `SourceLocation` to `Span`
- tir: allow `AstInfo` to have multiple items refer to the same `AstNodeId`

Todo:
- [x] review & merge #907