### PR TITLE
Speedup lowering by 20-25%

### DIFF
--- a/compiler/hash-ir/src/ty.rs
+++ b/compiler/hash-ir/src/ty.rs
@@ -528,6 +528,10 @@ macro_rules! create_common_ty_table {
                     str: IrTyId::from_index_unchecked(0),
                 };
 
+                // Create a `unit` type in order to reserve the first index of
+                // the ADT for a `()` type.
+                let _ = IrTy::tuple(&[]);
+
                 // @@Hack: find a way to nicely create this within the `create_common_ty_table!`,
                 // however this would require somehow referencing entries within the table before
                 // they are defined...

--- a/compiler/hash-lower/src/build/into.rs
+++ b/compiler/hash-lower/src/build/into.rs
@@ -54,6 +54,7 @@ impl<'tcx> BodyBuilder<'tcx> {
 
             Term::Tuple(TupleTerm { data }) => {
                 let ty = self.ty_id_from_tir_term(term);
+
                 let adt = ty.borrow().as_adt();
                 let aggregate_kind = AggregateKind::Tuple(adt);
 
@@ -510,7 +511,6 @@ impl<'tcx> BodyBuilder<'tcx> {
                 } else {
                     &adt.variants[0]
                 };
-
                 let field_count = variant.fields.len();
 
                 // Ensure we have the exact amount of arguments as the definition expects.
@@ -518,7 +518,9 @@ impl<'tcx> BodyBuilder<'tcx> {
                     panic_on_span!(
                         origin.span(),
                         self.source_map(),
-                        "default arguments on constructors are not currently supported",
+                        "default arguments on constructors are not currently supported, params={} args={}",
+                        field_count,
+                        args.len(),
                     );
                 }
 

--- a/compiler/hash-lower/src/lib.rs
+++ b/compiler/hash-lower/src/lib.rs
@@ -149,17 +149,17 @@ impl<Ctx: LoweringCtxQuery> CompilerStage<Ctx> for IrGen {
         let mut lowered_bodies = Vec::with_capacity(items.fns.len());
 
         time_item(self, "build", |_| {
-            for func in items.iter() {
+            for func in items.into_iter() {
                 let name = func.borrow().name.ident();
 
-                let mut builder = BodyBuilder::new(name, (*func).into(), ctx, settings);
+                let mut builder = BodyBuilder::new(name, func.into(), ctx, settings);
                 builder.build();
 
                 let body = builder.finish();
 
                 // This is the entry point, so we need to record that this
                 // is the entry point.
-                if let Some(def) = entry_point.def() && def == *func {
+                if let Some(def) = entry_point.def() && def == func {
                     let instance = body.info.ty().borrow().as_instance();
                     ir_storage.entry_point.set(instance, entry_point.kind().unwrap());
                 }

--- a/compiler/hash-lower/src/lower_ty.rs
+++ b/compiler/hash-lower/src/lower_ty.rs
@@ -1,6 +1,5 @@
 //! Contains all of the logic that is used by the lowering process
 //! to convert types and [Ty]s into [IrTy]s.
-
 use hash_intrinsics::{primitives::AccessToPrimitives, utils::PrimitiveUtils};
 use hash_ir::{
     intrinsics::Intrinsic,
@@ -72,10 +71,12 @@ impl<'ir> BuilderCtx<'ir> {
                 // be defined in a recursive way, the `ty_from_tir_data` will deal with
                 // its own caching, but we still want to add an entry here for `TyId` since
                 // we want to avoid computing the `ty_from_tir_data` as well.
-                let result = if let Ty::Data(data_ty) = ty {
-                    self.ty_from_tir_data(*data_ty)
-                } else {
-                    self.uncached_ty_from_tir_ty(id, ty)
+                let result = match ty {
+                    Ty::Data(data_ty) => self.ty_from_tir_data(*data_ty),
+
+                    // Hot path for unit types.
+                    Ty::Tuple(tuple) if tuple.data.is_empty() => COMMON_IR_TYS.unit,
+                    _ => self.uncached_ty_from_tir_ty(id, ty),
                 };
 
                 (result, false)
@@ -87,6 +88,11 @@ impl<'ir> BuilderCtx<'ir> {
     fn uncached_ty_from_tir_ty(&self, id: TyId, ty: &Ty) -> IrTyId {
         let ty = match *ty {
             Ty::Tuple(TupleTy { data }) => {
+                // Optimise, if this is a UNIT, then we can just return a unit type.
+                if data.is_empty() {
+                    return COMMON_IR_TYS.unit;
+                }
+
                 let mut flags = AdtFlags::empty();
                 flags |= AdtFlags::TUPLE;
 
@@ -134,8 +140,8 @@ impl<'ir> BuilderCtx<'ir> {
                         self.uncached_ty_from_tir_ty(id, ty)
                     });
                 } else {
-                    // We just return the unit type for now.
-                    IrTy::Adt(AdtId::UNIT)
+                    return COMMON_IR_TYS.unit; // We just return the unit type
+                                               // for now.
                 }
             }
             ty @ Ty::Hole(_) => {

--- a/compiler/hash-utils/src/lib.rs
+++ b/compiler/hash-utils/src/lib.rs
@@ -23,6 +23,7 @@ pub mod tree_writing;
 
 // Re-export commonly used packages
 pub use arrayvec;
+pub use backtrace;
 pub use fxhash;
 pub use index_vec;
 pub use itertools;


### PR DESCRIPTION
- lower: avoid `.value()` on `FnDef`
- lower: optimise type lowering to avoid needlessly creating `()` which removes creating a lot of unneeded ADTs for just units. In some extreme cases, this led to a speedup of 20-25% and significantly less memory usage (in order of magnitude of MB).
