### PR TITLE
TC: factor out parameter/argument validation into `hash-tir`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,7 +541,6 @@ name = "hash-exhaustiveness"
 version = "0.1.0"
 dependencies = [
  "hash-ast",
- "hash-error-codes",
  "hash-intrinsics",
  "hash-reporting",
  "hash-source",
@@ -707,7 +706,6 @@ dependencies = [
  "dashmap",
  "derive_more",
  "hash-ast",
- "hash-error-codes",
  "hash-exhaustiveness",
  "hash-intrinsics",
  "hash-pipeline",
@@ -815,6 +813,7 @@ version = "0.1.0"
 dependencies = [
  "derive_more",
  "hash-ast",
+ "hash-reporting",
  "hash-source",
  "hash-storage",
  "hash-target",
@@ -853,7 +852,6 @@ dependencies = [
  "dashmap",
  "derive_more",
  "hash-ast",
- "hash-error-codes",
  "hash-exhaustiveness",
  "hash-intrinsics",
  "hash-reporting",
@@ -874,7 +872,6 @@ dependencies = [
  "bitflags 2.4.0",
  "crossbeam-channel",
  "hash-ast",
- "hash-error-codes",
  "hash-pipeline",
  "hash-reporting",
  "hash-source",

--- a/compiler/hash-exhaustiveness/Cargo.toml
+++ b/compiler/hash-exhaustiveness/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 
 [dependencies]
 hash-ast = { path = "../hash-ast" }
-hash-error-codes = { path = "../hash-error-codes" }
 hash-intrinsics = { path = "../hash-intrinsics" }
 hash-reporting = { path = "../hash-reporting" }
 hash-source = { path = "../hash-source" }

--- a/compiler/hash-exhaustiveness/src/diagnostics.rs
+++ b/compiler/hash-exhaustiveness/src/diagnostics.rs
@@ -2,8 +2,10 @@
 //! for pattern matching.
 
 use hash_ast::ast::{MatchOrigin, RangeEnd};
-use hash_error_codes::error_codes::HashErrorCode;
-use hash_reporting::{diagnostic::DiagnosticCellStore, reporter::Reporter};
+use hash_reporting::{
+    diagnostic::DiagnosticCellStore, hash_error_codes::error_codes::HashErrorCode,
+    reporter::Reporter,
+};
 use hash_source::location::Span;
 use hash_tir::{lits::LitPat, pats::PatId, utils::common::get_location};
 use hash_utils::{

--- a/compiler/hash-reporting/src/diagnostic.rs
+++ b/compiler/hash-reporting/src/diagnostic.rs
@@ -299,7 +299,7 @@ pub trait AccessToDiagnosticsMut {
     }
 }
 
-/// A convinient trait which specifies that an error type can be converted
+/// A convenient trait which specifies that an error type can be converted
 /// into a compound error version.
 pub trait IntoCompound: Sized {
     fn into_compound(items: Vec<Self>) -> Self;
@@ -314,7 +314,7 @@ pub struct ErrorState<E> {
     pub errors: Vec<E>,
 }
 
-impl<E: IntoCompound> ErrorState<E> {
+impl<E> ErrorState<E> {
     /// Create a new [ErrorState].
     pub fn new() -> Self {
         Self { errors: vec![] }
@@ -352,7 +352,9 @@ impl<E: IntoCompound> ErrorState<E> {
     pub fn take_errors(&mut self) -> Vec<E> {
         std::mem::take(&mut self.errors)
     }
+}
 
+impl<E: IntoCompound> ErrorState<E> {
     /// Convert the accumulated [ErrorState] into a single error. This is
     /// possible since [ErrorState] implements [IntoCompound].
     pub fn into_error<T>(&mut self, t: impl FnOnce() -> Result<T, E>) -> Result<T, E> {
@@ -365,7 +367,7 @@ impl<E: IntoCompound> ErrorState<E> {
     }
 }
 
-impl<E: IntoCompound> Default for ErrorState<E> {
+impl<E> Default for ErrorState<E> {
     fn default() -> Self {
         Self::new()
     }

--- a/compiler/hash-reporting/src/lib.rs
+++ b/compiler/hash-reporting/src/lib.rs
@@ -8,3 +8,5 @@ mod render;
 pub mod report;
 pub mod reporter;
 pub mod writer;
+
+pub use hash_error_codes;

--- a/compiler/hash-semantics/Cargo.toml
+++ b/compiler/hash-semantics/Cargo.toml
@@ -12,7 +12,6 @@ once_cell = "1.17"
 bitflags = "2.0.0-rc.1"
 
 hash-ast = { path = "../hash-ast" }
-hash-error-codes = { path = "../hash-error-codes" }
 hash-exhaustiveness = { path = "../hash-exhaustiveness" }
 hash-intrinsics = { path = "../hash-intrinsics" }
 hash-pipeline = { path = "../hash-pipeline" }

--- a/compiler/hash-semantics/src/diagnostics/error.rs
+++ b/compiler/hash-semantics/src/diagnostics/error.rs
@@ -1,8 +1,7 @@
 //! Error-related data structures for errors that occur during typechecking.
-use hash_error_codes::error_codes::HashErrorCode;
 use hash_exhaustiveness::diagnostics::ExhaustivenessError;
 use hash_reporting::{
-    self,
+    hash_error_codes::error_codes::HashErrorCode,
     reporter::{Reporter, Reports},
 };
 use hash_source::location::Span;

--- a/compiler/hash-tir/Cargo.toml
+++ b/compiler/hash-tir/Cargo.toml
@@ -18,3 +18,4 @@ hash-source = { path = "../hash-source" }
 hash-storage = { path = "../hash-storage" }
 hash-target = { path = "../hash-target" }
 hash-utils = { path = "../hash-utils" }
+hash-reporting = { path = "../hash-reporting" }

--- a/compiler/hash-tir/src/utils/common.rs
+++ b/compiler/hash-tir/src/utils/common.rs
@@ -1,7 +1,10 @@
 use hash_source::location::Span;
 use hash_utils::stream_less_writeln;
 
-use crate::{environment::stores::tir_stores, locations::LocationTarget};
+use crate::{
+    environment::stores::tir_stores,
+    locations::{IndexedLocationTarget, LocationTarget},
+};
 
 /// Assert that the given term is of the given variant, and return it.
 #[macro_export]
@@ -32,6 +35,10 @@ macro_rules! ty_as_variant {
 /// Get the location of a location target.
 pub fn get_location(target: impl Into<LocationTarget>) -> Option<Span> {
     tir_stores().location().get_location(target)
+}
+
+pub fn get_overall_location(target: impl Into<IndexedLocationTarget>) -> Option<Span> {
+    tir_stores().location().get_overall_location(target)
 }
 
 pub fn dump_tir(value: impl ToString) {

--- a/compiler/hash-tir/src/utils/mod.rs
+++ b/compiler/hash-tir/src/utils/mod.rs
@@ -1,8 +1,9 @@
 //! Utility functions for working with TC primitives.
-use self::{mods::ModUtils, traversing::TraversingUtils};
+use self::{mods::ModUtils, params::ParamUtils, traversing::TraversingUtils};
 
 pub mod common;
 pub mod mods;
+pub mod params;
 pub mod traversing;
 
 macro_rules! utils {
@@ -20,5 +21,6 @@ macro_rules! utils {
 
 utils! {
   mod_utils: ModUtils,
+  param_utils: ParamUtils,
   traversing_utils: TraversingUtils,
 }

--- a/compiler/hash-tir/src/utils/params.rs
+++ b/compiler/hash-tir/src/utils/params.rs
@@ -1,6 +1,5 @@
 use std::collections::HashSet;
 
-use derive_more::Constructor;
 use hash_reporting::{
     diagnostic::{ErrorState, IntoCompound},
     hash_error_codes::error_codes::HashErrorCode,
@@ -15,7 +14,6 @@ use super::common::{get_location, get_overall_location};
 use crate::{
     args::{Arg, ArgId, ArgsId, PatArg, PatArgId, PatArgsId, PatOrCapture, SomeArgId, SomeArgsId},
     environment::env::Env,
-    impl_access_to_env,
     params::{ParamId, ParamIndex, ParamsId},
     pats::Spread,
 };
@@ -50,7 +48,7 @@ pub enum ParamError {
     RequiredParamNotFoundInArgs { param: ParamId, args: SomeArgsId },
 
     /// When a spread is specified before a positional argument, which makes
-    /// it imposiible to determine which positional argument the spread should
+    /// it impossible to determine which positional argument the spread should
     /// apply to.
     SpreadBeforePositionalArg { next_positional: SomeArgId },
 
@@ -218,14 +216,14 @@ impl IntoCompound for ParamError {
 pub type ParamResult<T> = Result<T, ParamError>;
 
 /// Operations related to module definitions.
-#[derive(Constructor)]
-pub struct ParamUtils<'tc> {
-    env: &'tc Env<'tc>,
-}
+pub struct ParamUtils;
 
-impl_access_to_env!(ParamUtils<'tc>);
+impl ParamUtils {
+    /// Create a new instance of [ParamUtils].
+    pub fn new(_: &Env) -> Self {
+        Self
+    }
 
-impl<'tc> ParamUtils<'tc> {
     /// Validate the given parameters, returning an error if they are invalid.
     ///
     /// Conditions for valid parameters are:

--- a/compiler/hash-tir/src/utils/params.rs
+++ b/compiler/hash-tir/src/utils/params.rs
@@ -1,42 +1,238 @@
 use std::collections::HashSet;
 
-use derive_more::{Constructor, Deref};
+use derive_more::Constructor;
+use hash_reporting::{
+    diagnostic::{ErrorState, IntoCompound},
+    hash_error_codes::error_codes::HashErrorCode,
+    reporter::Reporter,
+};
 use hash_storage::store::{
     statics::{SequenceStoreValue, StoreId},
     SequenceStoreKey, TrivialSequenceStoreKey,
 };
-use hash_tir::{
+
+use super::common::{get_location, get_overall_location};
+use crate::{
     args::{Arg, ArgId, ArgsId, PatArg, PatArgId, PatArgsId, PatOrCapture, SomeArgId, SomeArgsId},
+    environment::env::Env,
+    impl_access_to_env,
     params::{ParamId, ParamIndex, ParamsId},
     pats::Spread,
 };
 
-use crate::{errors::TcResult, AccessToTypechecking};
-
-#[derive(Constructor, Deref)]
-pub struct ParamOps<'a, T: AccessToTypechecking>(&'a T);
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// An error that can occur when checking [Param]s against [Args].
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ParamError {
+    /// When there are too many arguments.
     TooManyArgs { expected: ParamsId, got: SomeArgsId },
+
+    /// When an argument is specified more than once.
     DuplicateArg { first: SomeArgId, second: SomeArgId },
+
+    /// When a parameter is specified more than once.
     DuplicateParam { first: ParamId, second: ParamId },
+
+    /// When a positional argument is specified after an initial
+    /// named argument, which makes it ambiguous which parameter the
+    /// positional argument is referring to.
     PositionalArgAfterNamedArg { first_named: SomeArgId, next_positional: SomeArgId },
+
+    /// When a default parameter is found before a required parameter.
     RequiredParamAfterDefaultParam { first_default: ParamId, next_required: ParamId },
+
+    /// When an argument is named but no parameter with that name exists.
     ArgNameNotFoundInParams { arg: SomeArgId, params: ParamsId },
+
+    /// Two parameters have differing names at the same index.
     ParamNameMismatch { param_a: ParamId, param_b: ParamId },
+
+    /// When a required parameter is not found in the arguments.
     RequiredParamNotFoundInArgs { param: ParamId, args: SomeArgsId },
+
+    /// When a spread is specified before a positional argument, which makes
+    /// it imposiible to determine which positional argument the spread should
+    /// apply to.
     SpreadBeforePositionalArg { next_positional: SomeArgId },
+
+    /// A collection of errors that occurred in a compound argument.
+    Compound { errors: Vec<ParamError> },
 }
 
-impl<T: AccessToTypechecking> ParamOps<'_, T> {
+impl ParamError {
+    /// Adds the given [ParamError] to the [Reporter].
+    pub fn add_to_reporter(&self, reporter: &mut Reporter) {
+        match self {
+            ParamError::Compound { errors } => {
+                for error in errors {
+                    error.add_to_reporter(reporter);
+                }
+            }
+            ParamError::TooManyArgs { expected, got } => {
+                let error =
+                    reporter.error().code(HashErrorCode::ParameterLengthMismatch).title(format!(
+                        "received {} arguments, but expected at most {} arguments",
+                        got.len(),
+                        expected.len()
+                    ));
+                if let Some(location) = get_overall_location(*expected) {
+                    error.add_labelled_span(
+                        location,
+                        format!("expected at most {} arguments by this definition", expected.len()),
+                    );
+                }
+                if let Some(location) = get_overall_location(*got) {
+                    error.add_labelled_span(
+                        location,
+                        format!("received {} arguments here", got.len()),
+                    );
+                }
+            }
+            ParamError::DuplicateArg { first, second } => {
+                let error = reporter
+                    .error()
+                    .code(HashErrorCode::ParameterInUse)
+                    .title("received a duplicate argument");
+                if let Some(location) = get_location(first) {
+                    error.add_labelled_span(location, "first occurrence of this argument");
+                }
+                if let Some(location) = get_location(second) {
+                    error.add_labelled_span(location, "second occurrence of this argument");
+                }
+            }
+            ParamError::DuplicateParam { first, second } => {
+                let error = reporter
+                    .error()
+                    .code(HashErrorCode::ParameterInUse)
+                    .title("received a duplicate parameter");
+                if let Some(location) = get_location(first) {
+                    error.add_labelled_span(location, "first occurrence of this parameter");
+                }
+                if let Some(location) = get_location(second) {
+                    error.add_labelled_span(location, "second occurrence of this parameter");
+                }
+            }
+            ParamError::PositionalArgAfterNamedArg { first_named, next_positional } => {
+                let error = reporter
+                    .error()
+                    .code(HashErrorCode::ParameterInUse)
+                    .title("received a positional argument after a named argument");
+                if let Some(location) = get_location(first_named) {
+                    error.add_labelled_span(location, "first named argument");
+                }
+                if let Some(location) = get_location(next_positional) {
+                    error.add_labelled_span(location, "next positional argument");
+                }
+                error.add_info("positional arguments must come before named arguments");
+            }
+            ParamError::RequiredParamAfterDefaultParam {
+                first_default,
+                next_required: next_non_default,
+            } => {
+                let error = reporter
+                    .error()
+                    .code(HashErrorCode::ParameterInUse)
+                    .title("found a required parameter after a default parameter");
+                if let Some(location) = get_location(first_default) {
+                    error.add_labelled_span(location, "first default parameter");
+                }
+                if let Some(location) = get_location(next_non_default) {
+                    error.add_labelled_span(location, "next required parameter");
+                }
+                error.add_info("parameters with defaults must come after required parameters");
+            }
+            ParamError::ArgNameNotFoundInParams { arg, params } => {
+                let error = reporter.error().code(HashErrorCode::ParameterInUse).title(format!(
+                    "received an argument named `{}` but no parameter with that name exists",
+                    arg.target()
+                ));
+                if let Some(location) = get_location(arg) {
+                    error.add_labelled_span(location, "argument with this name");
+                }
+                if let Some(location) = get_overall_location(*params) {
+                    error.add_labelled_span(
+                        location,
+                        format!(
+                            "expected one of these parameters: {}",
+                            params
+                                .iter()
+                                .map(|param| format!("`{}`", param.as_param_index()))
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        ),
+                    );
+                }
+            }
+            ParamError::RequiredParamNotFoundInArgs { param, args } => {
+                let error = reporter.error().code(HashErrorCode::ParameterInUse).title(format!(
+                    "expected an argument named `{}` but none was found",
+                    param.as_param_index()
+                ));
+                if let Some(location) = get_location(param) {
+                    error.add_labelled_span(location, "parameter with this name");
+                }
+                if let Some(location) = get_overall_location(*args) {
+                    error.add_labelled_span(
+                        location,
+                        format!(
+                            "received these arguments: {}",
+                            args.iter()
+                                .map(|arg| format!("`{}`", arg.target()))
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        ),
+                    );
+                }
+            }
+            ParamError::SpreadBeforePositionalArg { next_positional } => {
+                let error = reporter
+                    .error()
+                    .code(HashErrorCode::ParameterInUse)
+                    .title("received a positional argument after a spread argument");
+                if let Some(location) = get_location(next_positional) {
+                    error.add_labelled_span(location, "next positional argument");
+                }
+                error.add_info("positional arguments must come before spread arguments");
+            }
+            ParamError::ParamNameMismatch { param_a, param_b } => {
+                let error = reporter
+                    .error()
+                    .code(HashErrorCode::ParameterInUse)
+                    .title("received two parameters with different names");
+                if let Some(location) = get_location(param_a) {
+                    error.add_labelled_span(location, "first parameter with this name");
+                }
+                if let Some(location) = get_location(param_b) {
+                    error.add_labelled_span(location, "second parameter with this name");
+                }
+            }
+        }
+    }
+}
+
+impl IntoCompound for ParamError {
+    fn into_compound(errors: Vec<ParamError>) -> ParamError {
+        ParamError::Compound { errors }
+    }
+}
+
+pub type ParamResult<T> = Result<T, ParamError>;
+
+/// Operations related to module definitions.
+#[derive(Constructor)]
+pub struct ParamUtils<'tc> {
+    env: &'tc Env<'tc>,
+}
+
+impl_access_to_env!(ParamUtils<'tc>);
+
+impl<'tc> ParamUtils<'tc> {
     /// Validate the given parameters, returning an error if they are invalid.
     ///
     /// Conditions for valid parameters are:
     /// 1. No duplicate parameter names
     /// 2. All parameters with defaults are at the end
-    pub fn validate_params(&self, params_id: ParamsId) -> TcResult<()> {
-        let mut error_state = self.new_error_state();
+    pub fn validate_params(&self, params_id: ParamsId) -> ParamResult<()> {
+        let mut error_state = ErrorState::new();
 
         let mut seen = HashSet::new();
         let mut found_default = None;
@@ -68,7 +264,7 @@ impl<T: AccessToTypechecking> ParamOps<'_, T> {
             }
         }
 
-        self.return_or_register_errors(|| Ok(()), error_state)
+        error_state.into_error(|| Ok(()))
     }
 
     /// Validate the given arguments against the given parameters, returning an
@@ -88,8 +284,8 @@ impl<T: AccessToTypechecking> ParamOps<'_, T> {
         &self,
         args_id: SomeArgsId,
         params_id: ParamsId,
-    ) -> TcResult<()> {
-        let mut error_state = self.new_error_state();
+    ) -> ParamResult<()> {
+        let mut error_state = ErrorState::new();
 
         // Check for too many arguments
         if args_id.len() > params_id.len() {
@@ -142,7 +338,7 @@ impl<T: AccessToTypechecking> ParamOps<'_, T> {
             }
         }
 
-        self.return_or_register_errors(|| Ok(()), error_state)
+        error_state.into_error(|| Ok(()))
     }
 
     /// Validate the given arguments against the given parameters and reorder
@@ -157,11 +353,11 @@ impl<T: AccessToTypechecking> ParamOps<'_, T> {
         &self,
         args_id: ArgsId,
         params_id: ParamsId,
-    ) -> TcResult<ArgsId> {
+    ) -> ParamResult<ArgsId> {
         // First validate the arguments
         self.validate_args_against_params(args_id.into(), params_id)?;
 
-        let mut error_state = self.new_error_state();
+        let mut error_state = ErrorState::new();
         let mut result: Vec<Option<Arg>> = vec![None; params_id.len()];
 
         // Note: We have already validated that the number of arguments is less than
@@ -219,7 +415,7 @@ impl<T: AccessToTypechecking> ParamOps<'_, T> {
 
         // If there were any errors, return them
         if error_state.has_errors() {
-            return self.return_or_register_errors(|| unreachable!(), error_state);
+            return error_state.into_error(|| unreachable!());
         }
 
         // Populate default values and catch missing arguments
@@ -245,7 +441,7 @@ impl<T: AccessToTypechecking> ParamOps<'_, T> {
 
         // If there were any errors, return them
         if error_state.has_errors() {
-            return self.return_or_register_errors(|| unreachable!(), error_state);
+            return error_state.into_error(|| unreachable!());
         }
 
         // Now, create the new argument list
@@ -273,11 +469,11 @@ impl<T: AccessToTypechecking> ParamOps<'_, T> {
         args_id: PatArgsId,
         spread: Option<Spread>,
         params_id: ParamsId,
-    ) -> TcResult<PatArgsId> {
+    ) -> ParamResult<PatArgsId> {
         // First validate the arguments
         self.validate_args_against_params(args_id.into(), params_id)?;
 
-        let mut error_state = self.new_error_state();
+        let mut error_state = ErrorState::new();
         let mut result: Vec<Option<PatArg>> = vec![None; params_id.len()];
 
         // Note: We have already validated that the number of arguments is less than
@@ -343,7 +539,7 @@ impl<T: AccessToTypechecking> ParamOps<'_, T> {
 
         // If there were any errors, return them
         if error_state.has_errors() {
-            return self.return_or_register_errors(|| unreachable!(), error_state);
+            return error_state.into_error(|| unreachable!());
         }
 
         // Populate missing arguments with captures
@@ -368,7 +564,7 @@ impl<T: AccessToTypechecking> ParamOps<'_, T> {
 
         // If there were any errors, return them
         if error_state.has_errors() {
-            return self.return_or_register_errors(|| unreachable!(), error_state);
+            return error_state.into_error(|| unreachable!());
         }
 
         // Now, create the new argument list

--- a/compiler/hash-typecheck/Cargo.toml
+++ b/compiler/hash-typecheck/Cargo.toml
@@ -12,7 +12,6 @@ num-bigint = "0.4"
 once_cell = "1.17"
 
 hash-ast = { path = "../hash-ast" }
-hash-error-codes = { path = "../hash-error-codes" }
 hash-exhaustiveness = { path = "../hash-exhaustiveness" }
 hash-intrinsics = { path = "../hash-intrinsics" }
 hash-reporting = { path = "../hash-reporting" }

--- a/compiler/hash-typecheck/src/errors.rs
+++ b/compiler/hash-typecheck/src/errors.rs
@@ -1,8 +1,8 @@
 use std::{fmt, mem::take};
 
 use derive_more::{Constructor, From};
-use hash_error_codes::error_codes::HashErrorCode;
 use hash_reporting::{
+    hash_error_codes::error_codes::HashErrorCode,
     reporter::{Reporter, Reports},
     writer::ReportWriter,
 };

--- a/compiler/hash-typecheck/src/errors.rs
+++ b/compiler/hash-typecheck/src/errors.rs
@@ -7,7 +7,7 @@ use hash_reporting::{
     writer::ReportWriter,
 };
 use hash_source::location::Span;
-use hash_storage::store::{SequenceStoreKey, TrivialSequenceStoreKey};
+use hash_storage::store::SequenceStoreKey;
 use hash_tir::{
     environment::{
         env::{AccessToEnv, Env},
@@ -20,10 +20,8 @@ use hash_tir::{
     pats::PatId,
     terms::TermId,
     tys::TyId,
-    utils::{common::get_location, traversing::Atom},
+    utils::{common::get_location, params::ParamError, traversing::Atom},
 };
-
-use crate::params::ParamError;
 
 /// Accumulates errors that occur during typechecking in a local scope.
 ///
@@ -306,153 +304,9 @@ impl<'tc> TcErrorReporter<'tc> {
                     error.add_labelled_span(location, "not a valid range literal");
                 }
             }
-            TcError::ParamMatch(err) => match err {
-                ParamError::TooManyArgs { expected, got } => {
-                    let error = reporter
-                        .error()
-                        .code(HashErrorCode::ParameterLengthMismatch)
-                        .title(format!(
-                            "received {} arguments, but expected at most {} arguments",
-                            got.len(),
-                            expected.len()
-                        ));
-                    if let Some(location) = locations.get_overall_location(*expected) {
-                        error.add_labelled_span(
-                            location,
-                            format!(
-                                "expected at most {} arguments by this definition",
-                                expected.len()
-                            ),
-                        );
-                    }
-                    if let Some(location) = locations.get_overall_location(*got) {
-                        error.add_labelled_span(
-                            location,
-                            format!("received {} arguments here", got.len()),
-                        );
-                    }
-                }
-                ParamError::DuplicateArg { first, second } => {
-                    let error = reporter
-                        .error()
-                        .code(HashErrorCode::ParameterInUse)
-                        .title("received a duplicate argument");
-                    if let Some(location) = locations.get_location(first) {
-                        error.add_labelled_span(location, "first occurrence of this argument");
-                    }
-                    if let Some(location) = locations.get_location(second) {
-                        error.add_labelled_span(location, "second occurrence of this argument");
-                    }
-                }
-                ParamError::DuplicateParam { first, second } => {
-                    let error = reporter
-                        .error()
-                        .code(HashErrorCode::ParameterInUse)
-                        .title("received a duplicate parameter");
-                    if let Some(location) = locations.get_location(first) {
-                        error.add_labelled_span(location, "first occurrence of this parameter");
-                    }
-                    if let Some(location) = locations.get_location(second) {
-                        error.add_labelled_span(location, "second occurrence of this parameter");
-                    }
-                }
-                ParamError::PositionalArgAfterNamedArg { first_named, next_positional } => {
-                    let error = reporter
-                        .error()
-                        .code(HashErrorCode::ParameterInUse)
-                        .title("received a positional argument after a named argument");
-                    if let Some(location) = locations.get_location(first_named) {
-                        error.add_labelled_span(location, "first named argument");
-                    }
-                    if let Some(location) = locations.get_location(next_positional) {
-                        error.add_labelled_span(location, "next positional argument");
-                    }
-                    error.add_info("positional arguments must come before named arguments");
-                }
-                ParamError::RequiredParamAfterDefaultParam {
-                    first_default,
-                    next_required: next_non_default,
-                } => {
-                    let error = reporter
-                        .error()
-                        .code(HashErrorCode::ParameterInUse)
-                        .title("found a required parameter after a default parameter");
-                    if let Some(location) = locations.get_location(first_default) {
-                        error.add_labelled_span(location, "first default parameter");
-                    }
-                    if let Some(location) = locations.get_location(next_non_default) {
-                        error.add_labelled_span(location, "next required parameter");
-                    }
-                    error.add_info("parameters with defaults must come after required parameters");
-                }
-                ParamError::ArgNameNotFoundInParams { arg, params } => {
-                    let error =
-                        reporter.error().code(HashErrorCode::ParameterInUse).title(format!(
-                        "received an argument named `{}` but no parameter with that name exists",
-                        arg.target()
-                    ));
-                    if let Some(location) = locations.get_location(arg) {
-                        error.add_labelled_span(location, "argument with this name");
-                    }
-                    if let Some(location) = locations.get_overall_location(*params) {
-                        error.add_labelled_span(
-                            location,
-                            format!(
-                                "expected one of these parameters: {}",
-                                params
-                                    .iter()
-                                    .map(|param| format!("`{}`", param.as_param_index()))
-                                    .collect::<Vec<_>>()
-                                    .join(", ")
-                            ),
-                        );
-                    }
-                }
-                ParamError::RequiredParamNotFoundInArgs { param, args } => {
-                    let error =
-                        reporter.error().code(HashErrorCode::ParameterInUse).title(format!(
-                            "expected an argument named `{}` but none was found",
-                            param.as_param_index()
-                        ));
-                    if let Some(location) = locations.get_location(param) {
-                        error.add_labelled_span(location, "parameter with this name");
-                    }
-                    if let Some(location) = locations.get_overall_location(*args) {
-                        error.add_labelled_span(
-                            location,
-                            format!(
-                                "received these arguments: {}",
-                                args.iter()
-                                    .map(|arg| format!("`{}`", arg.target()))
-                                    .collect::<Vec<_>>()
-                                    .join(", ")
-                            ),
-                        );
-                    }
-                }
-                ParamError::SpreadBeforePositionalArg { next_positional } => {
-                    let error = reporter
-                        .error()
-                        .code(HashErrorCode::ParameterInUse)
-                        .title("received a positional argument after a spread argument");
-                    if let Some(location) = locations.get_location(next_positional) {
-                        error.add_labelled_span(location, "next positional argument");
-                    }
-                    error.add_info("positional arguments must come before spread arguments");
-                }
-                ParamError::ParamNameMismatch { param_a, param_b } => {
-                    let error = reporter
-                        .error()
-                        .code(HashErrorCode::ParameterInUse)
-                        .title("received two parameters with different names");
-                    if let Some(location) = locations.get_location(param_a) {
-                        error.add_labelled_span(location, "first parameter with this name");
-                    }
-                    if let Some(location) = locations.get_location(param_b) {
-                        error.add_labelled_span(location, "second parameter with this name");
-                    }
-                }
-            },
+            TcError::ParamMatch(err) => {
+                ParamError::add_to_reporter(err, reporter);
+            }
             TcError::WrongTy { term, inferred_term_ty, kind } => {
                 let kind_name = match kind {
                     WrongTermKind::NotAFunction => "function".to_string(),

--- a/compiler/hash-typecheck/src/inference.rs
+++ b/compiler/hash-typecheck/src/inference.rs
@@ -218,7 +218,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
     ) -> TcResult<U> {
         self.register_new_atom(args, annotation_params);
         let reordered_args_id =
-            self.param_ops().validate_and_reorder_args_against_params(args, annotation_params)?;
+            self.param_utils().validate_and_reorder_args_against_params(args, annotation_params)?;
 
         let result = self.infer_some_args(
             reordered_args_id.iter(),
@@ -281,11 +281,9 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         in_arg_scope: impl FnOnce(PatArgsId) -> TcResult<U>,
     ) -> TcResult<U> {
         self.register_new_atom(pat_args, annotation_params);
-        let reordered_pat_args_id = self.param_ops().validate_and_reorder_pat_args_against_params(
-            pat_args,
-            spread,
-            annotation_params,
-        )?;
+        let reordered_pat_args_id = self
+            .param_utils()
+            .validate_and_reorder_pat_args_against_params(pat_args, spread, annotation_params)?;
 
         self.infer_some_args(
             reordered_pat_args_id.iter(),
@@ -332,7 +330,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         in_param_scope: impl FnOnce() -> TcResult<U>,
     ) -> TcResult<U> {
         // Validate the parameters
-        self.param_ops().validate_params(params)?;
+        self.param_utils().validate_params(params)?;
 
         let (result, shadowed_sub) =
             self.context().enter_scope(ScopeKind::Sub, || -> TcResult<_> {

--- a/compiler/hash-typecheck/src/lib.rs
+++ b/compiler/hash-typecheck/src/lib.rs
@@ -8,7 +8,7 @@
     if_let_guard
 )]
 
-use errors::{TcError, TcErrorState, TcResult};
+use errors::TcError;
 use hash_exhaustiveness::diagnostics::{ExhaustivenessError, ExhaustivenessWarning};
 use hash_intrinsics::intrinsics::{AccessToIntrinsics, IntrinsicAbilities};
 use hash_reporting::diagnostic::{AccessToDiagnostics, Diagnostics};
@@ -51,31 +51,11 @@ pub trait AccessToTypechecking:
         warning: ExhaustivenessWarning,
     ) -> <<Self as AccessToDiagnostics>::Diagnostics as Diagnostics>::Warning;
 
-    /// Create a new error state.
-    fn new_error_state(&self) -> TcErrorState {
-        TcErrorState::new()
-    }
-
     /// Get the entry point of the current compilation, if any.
     fn entry_point(&self) -> &EntryPointState<FnDefId>;
 
     /// Whether the typechecker should monomorphise all pure functions.
     fn should_monomorphise(&self) -> bool;
-
-    /// Absorb an error state into the diagnostics.
-    ///
-    /// Returns the error or the closure result if successful.
-    fn return_or_register_errors<T>(
-        &self,
-        t: impl FnOnce() -> TcResult<T>,
-        mut error_state: TcErrorState,
-    ) -> TcResult<T> {
-        if error_state.has_errors() {
-            Err(TcError::Compound { errors: error_state.take_errors() })
-        } else {
-            t()
-        }
-    }
 
     fn infer_ops(&self) -> InferenceOps<Self> {
         InferenceOps::new(self)

--- a/compiler/hash-typecheck/src/lib.rs
+++ b/compiler/hash-typecheck/src/lib.rs
@@ -25,7 +25,6 @@ use unification::UnificationOps;
 pub mod errors;
 pub mod inference;
 pub mod normalisation;
-pub mod params;
 pub mod substitution;
 pub mod unification;
 
@@ -92,10 +91,6 @@ pub trait AccessToTypechecking:
 
     fn norm_ops(&self) -> normalisation::NormalisationOps<Self> {
         normalisation::NormalisationOps::new(self)
-    }
-
-    fn param_ops(&self) -> params::ParamOps<Self> {
-        params::ParamOps::new(self)
     }
 }
 

--- a/compiler/hash-typecheck/src/unification.rs
+++ b/compiler/hash-typecheck/src/unification.rs
@@ -16,7 +16,7 @@ use hash_tir::{
     symbols::Symbol,
     terms::{Term, TermId},
     tys::{Ty, TyId},
-    utils::traversing::Atom,
+    utils::{traversing::Atom, AccessToUtils},
 };
 use once_cell::unsync::OnceCell;
 
@@ -443,8 +443,8 @@ impl<'tc, T: AccessToTypechecking> UnificationOps<'tc, T> {
         in_param_scope: impl FnOnce() -> TcResult<U>,
     ) -> TcResult<U> {
         // Validate the parameters and ensure they are of the same length
-        self.param_ops().validate_params(src_id)?;
-        self.param_ops().validate_params(target_id)?;
+        self.param_utils().validate_params(src_id)?;
+        self.param_utils().validate_params(target_id)?;
         if src_id.len() != target_id.len() {
             return Err(TcError::WrongParamLength {
                 given_params_id: src_id,

--- a/compiler/hash-untyped-semantics/Cargo.toml
+++ b/compiler/hash-untyped-semantics/Cargo.toml
@@ -11,7 +11,6 @@ rayon = "1.5.0"
 
 hash-ast = { path = "../hash-ast" }
 hash-utils = { path = "../hash-utils" }
-hash-error-codes = { path = "../hash-error-codes" }
 hash-pipeline = { path = "../hash-pipeline" }
 hash-reporting = { path = "../hash-reporting" }
 hash-source = { path = "../hash-source" }

--- a/compiler/hash-untyped-semantics/src/diagnostics/error.rs
+++ b/compiler/hash-untyped-semantics/src/diagnostics/error.rs
@@ -4,8 +4,8 @@ use hash_ast::{
     ast::{AstNodeId, AstNodeRef, ParamOrigin, RangeEnd, Visibility},
     origin::BlockOrigin,
 };
-use hash_error_codes::error_codes::HashErrorCode;
 use hash_reporting::{
+    hash_error_codes::error_codes::HashErrorCode,
     report::{ReportCodeBlock, ReportElement, ReportNote, ReportNoteKind},
     reporter::{Reporter, Reports},
 };


### PR DESCRIPTION
- reporting: re-export `hash-error-codes` and update references across compiler
- tc+tir: factor out parameter/argument validation into `hash-tir` from `hash-typecheck`

closes #922 

## Todos:
- Possibly refactor `TcErrorState` to just use the `hash_reporting::diagnostics::ErrorState`
