### PR TITLE
lower: fix loop lowering for new TIR tweaks

### DIFF
--- a/compiler/hash-lower/src/build/block.rs
+++ b/compiler/hash-lower/src/build/block.rs
@@ -52,6 +52,7 @@ impl<'tcx> BodyBuilder<'tcx> {
                         this.control_flow_graph.goto(body_block_end, loop_body, span);
                     }
 
+                    this.reached_terminator = false;
                     next_block.unit()
                 })
             }

--- a/compiler/hash-lower/src/build/mod.rs
+++ b/compiler/hash-lower/src/build/mod.rs
@@ -172,9 +172,12 @@ pub(crate) struct BodyBuilder<'tcx> {
     /// after a block terminator.
     loop_block_info: Option<LoopBlockInfo>,
 
-    /// If the current [terms::BlockTerm] has reached a terminating statement,
-    /// i.e. a statement that is typed as `!`. Examples of such statements
-    /// are `return`, `break`, `continue`, etc.
+    /// If the lowerer has reached a terminating statement within some block, 
+    /// meaning that further statements do not require to be lowered.
+    /// 
+    /// A statement that is typed as `!`. Examples of such statements
+    /// are `return`, `break`, `continue`, or expressions that are of type 
+    /// `!`.
     reached_terminator: bool,
 
     /// A temporary [Place] that is used to throw away results from expressions

--- a/tests/cases/typecheck/property_access/out_of_bounds_access.stderr
+++ b/tests/cases/typecheck/property_access/out_of_bounds_access.stderr
@@ -1,6 +1,6 @@
-error[0016]: property `2` not found on type `(s515: i32, s517: i32)`
+error[0016]: property `2` not found on type `(i32, i32)`
  --> $DIR/out_of_bounds_access.hash:4:3
 3 |     t := (1, 2)
 4 |     t.2
-  |     ^ term has type `(s515: i32, s517: i32)`. Property `2` is not present on this type
+  |     ^ term has type `(i32, i32)`. Property `2` is not present on this type
 5 |   }


### PR DESCRIPTION
Since that the TIR loop/block structure has changed to not contain a block term, this meant that `reached_terminator` wasn't being properly set at the end of a loop statement. This patch fixes the issue and ensures `reached_terminator` is correctly reset at the end of a loop lowering operation.