### PR TITLE
TIR: Add `Map` and `Visit` traits to the `tir::Visitor` in order to reduce code duplication

### DIFF
--- a/compiler/hash-semantics/src/passes/inference/mod.rs
+++ b/compiler/hash-semantics/src/passes/inference/mod.rs
@@ -78,9 +78,7 @@ impl<E: SemanticEnv> AnalysisPass for InferencePass<'_, E> {
                 tc.infer_ops().infer_term(term_id, ty_id)?;
                 Ok((term_id, ty_id))
             },
-            |(term_id, ty_id)| {
-                tc.sub_ops().atom_has_holes(term_id).or(tc.sub_ops().atom_has_holes(ty_id))
-            },
+            |(term_id, ty_id)| tc.sub_ops().has_holes(term_id).or(tc.sub_ops().has_holes(ty_id)),
         )?;
         self.ast_info.terms().insert(node.id(), term);
         Ok(())
@@ -107,7 +105,7 @@ impl<E: SemanticEnv> AnalysisPass for InferencePass<'_, E> {
                 )?;
                 Ok(mod_def_id)
             },
-            |mod_def_id| tc.sub_ops().mod_def_has_holes(mod_def_id),
+            |mod_def_id| tc.sub_ops().has_holes(mod_def_id),
         )?;
         // Mod def is already registered in the ast info
         Ok(())

--- a/compiler/hash-tir/src/lib.rs
+++ b/compiler/hash-tir/src/lib.rs
@@ -4,7 +4,7 @@
 //! It is used to perform semantic analysis and type checking. After this
 //! stage, the TIR is lowered into the IR, which continues on down the
 //! pipeline.
-#![feature(let_chains, decl_macro, trait_alias)]
+#![feature(let_chains, decl_macro, trait_alias, never_type, unwrap_infallible)]
 #![recursion_limit = "128"]
 
 pub mod atom_info;

--- a/compiler/hash-tir/src/visitor.rs
+++ b/compiler/hash-tir/src/visitor.rs
@@ -21,12 +21,6 @@ use crate::{
     },
 };
 
-/// Contains methods to traverse the Hash TIR structure.
-pub struct Visitor {
-    visited: RefCell<HashSet<Atom>>,
-    visit_fns_once: bool,
-}
-
 /// An atom in the TIR.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, From, TryInto)]
 pub enum Atom {
@@ -65,22 +59,61 @@ impl fmt::Display for Atom {
     }
 }
 
+/// Contains methods to traverse the Hash TIR structure.
+pub struct Visitor {
+    visited: RefCell<HashSet<Atom>>,
+    visit_fns_once: bool,
+}
+
+/// Contains the implementation of `fmap` and `visit` for each atom, as well as
+/// secondary components such as arguments and parameters.
+impl Visitor {
+    /// Create a new `TraversingUtils`.
+    pub fn new() -> Self {
+        Self { visited: RefCell::new(HashSet::new()), visit_fns_once: true }
+    }
+
+    pub fn set_visit_fns_once(&mut self, once: bool) {
+        self.visit_fns_once = once;
+    }
+}
+
+impl Default for Visitor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Trait to visit a TIR node `X`, by mutating the node.
 pub trait Visit<X> {
-    fn visit<E, F: VisitFn<E>>(&self, x: X, f: &mut F) -> Result<(), E>;
+    /// Visit and mutate TIR node `X` through a function.
+    fn try_visit<E, F: TryVisitFn<E>>(&self, x: X, f: &mut F) -> Result<(), E>;
+
+    /// Visit and mutate TIR node `X` through a function (infallible).
+    fn visit<F: VisitFn>(&self, x: X, f: &mut F) {
+        self.try_visit::<!, _>(x, &mut |a| Ok(f(a))).into_ok()
+    }
 }
 
 /// Trait to map a TIR node `X` to another node of the same type `X`, without
 /// mutating the original.
 pub trait Map<X> {
+    /// Map a TIR node `X` to another node of the same type `X` through a
+    /// function.
     fn map<E, F: MapFn<E>>(&self, x: X, f: F) -> Result<X, E>;
+
+    /// Deep-copy a TIR node `X`.
+    fn copy(&self, x: X) -> X {
+        self.map::<!, _>(x, |_| Ok(ControlFlow::Continue(()))).into_ok()
+    }
 }
 
 /// Function to visit an atom.
 ///
 /// This does not return a value, but instead returns a `ControlFlow` to
 /// indicate whether to continue or break the traversal.
-pub trait VisitFn<E> = FnMut(Atom) -> Result<ControlFlow<()>, E>;
+pub trait TryVisitFn<E> = FnMut(Atom) -> Result<ControlFlow<()>, E>;
+pub trait VisitFn = FnMut(Atom) -> ControlFlow<()>;
 
 /// Function to map an atom to another atom.
 ///
@@ -89,11 +122,11 @@ pub trait VisitFn<E> = FnMut(Atom) -> Result<ControlFlow<()>, E>;
 pub trait MapFn<E> = Fn(Atom) -> Result<ControlFlow<Atom>, E> + Copy;
 
 impl Visit<Atom> for Visitor {
-    fn visit<E, F: VisitFn<E>>(&self, atom: Atom, f: &mut F) -> Result<(), E> {
+    fn try_visit<E, F: TryVisitFn<E>>(&self, atom: Atom, f: &mut F) -> Result<(), E> {
         match atom {
-            Atom::Term(term_id) => self.visit_term(term_id, f),
-            Atom::FnDef(fn_def_id) => self.visit_fn_def(fn_def_id, f),
-            Atom::Pat(pat_id) => self.visit_pat(pat_id, f),
+            Atom::Term(term_id) => self.try_visit(term_id, f),
+            Atom::FnDef(fn_def_id) => self.try_visit(fn_def_id, f),
+            Atom::Pat(pat_id) => self.try_visit(pat_id, f),
         }
     }
 }
@@ -101,72 +134,72 @@ impl Visit<Atom> for Visitor {
 impl Map<Atom> for Visitor {
     fn map<E, F: MapFn<E>>(&self, atom: Atom, f: F) -> Result<Atom, E> {
         match atom {
-            Atom::Term(term_id) => Ok(Atom::Term(self.fmap_term(term_id, f)?)),
-            Atom::FnDef(fn_def_id) => Ok(Atom::FnDef(self.fmap_fn_def(fn_def_id, f)?)),
-            Atom::Pat(pat_id) => Ok(Atom::Pat(self.fmap_pat(pat_id, f)?)),
+            Atom::Term(term_id) => Ok(Atom::Term(self.map(term_id, f)?)),
+            Atom::FnDef(fn_def_id) => Ok(Atom::FnDef(self.map(fn_def_id, f)?)),
+            Atom::Pat(pat_id) => Ok(Atom::Pat(self.map(pat_id, f)?)),
         }
     }
 }
 
 impl Visit<TermId> for Visitor {
-    fn visit<E, F: VisitFn<E>>(&self, term_id: TermId, f: &mut F) -> Result<(), E> {
+    fn try_visit<E, F: TryVisitFn<E>>(&self, term_id: TermId, f: &mut F) -> Result<(), E> {
         match f(term_id.into())? {
             ControlFlow::Break(_) => Ok(()),
             ControlFlow::Continue(()) => match *term_id.value() {
-                Term::Tuple(tuple_term) => self.visit_args(tuple_term.data, f),
+                Term::Tuple(tuple_term) => self.try_visit(tuple_term.data, f),
                 Term::Lit(_) => Ok(()),
-                Term::Array(list_ctor) => self.visit_term_list(list_ctor.elements, f),
+                Term::Array(list_ctor) => self.try_visit(list_ctor.elements, f),
                 Term::Ctor(ctor_term) => {
-                    self.visit_args(ctor_term.data_args, f)?;
-                    self.visit_args(ctor_term.ctor_args, f)
+                    self.try_visit(ctor_term.data_args, f)?;
+                    self.try_visit(ctor_term.ctor_args, f)
                 }
                 Term::Call(fn_call_term) => {
-                    self.visit_term(fn_call_term.subject, f)?;
-                    self.visit_args(fn_call_term.args, f)
+                    self.try_visit(fn_call_term.subject, f)?;
+                    self.try_visit(fn_call_term.args, f)
                 }
-                Term::Fn(fn_def_id) => self.visit_fn_def(fn_def_id, f),
+                Term::Fn(fn_def_id) => self.try_visit(fn_def_id, f),
                 Term::Block(block_term) => {
-                    self.visit_block_statements(block_term.statements, f)?;
-                    self.visit_term(block_term.expr, f)
+                    self.try_visit(block_term.statements, f)?;
+                    self.try_visit(block_term.expr, f)
                 }
                 Term::Var(_) => Ok(()),
-                Term::Loop(loop_term) => self.visit_term(loop_term.inner, f),
+                Term::Loop(loop_term) => self.try_visit(loop_term.inner, f),
                 Term::LoopControl(_) => Ok(()),
                 Term::Match(match_term) => {
-                    self.visit_term(match_term.subject, f)?;
+                    self.try_visit(match_term.subject, f)?;
                     for case in match_term.cases.elements().value() {
-                        self.visit_pat(case.bind_pat, f)?;
-                        self.visit_term(case.value, f)?;
+                        self.try_visit(case.bind_pat, f)?;
+                        self.try_visit(case.value, f)?;
                     }
                     Ok(())
                 }
-                Term::Return(return_term) => self.visit_term(return_term.expression, f),
+                Term::Return(return_term) => self.try_visit(return_term.expression, f),
                 Term::Assign(assign_term) => {
-                    self.visit_term(assign_term.subject, f)?;
-                    self.visit_term(assign_term.value, f)
+                    self.try_visit(assign_term.subject, f)?;
+                    self.try_visit(assign_term.value, f)
                 }
-                Term::Unsafe(unsafe_term) => self.visit_term(unsafe_term.inner, f),
-                Term::Access(access_term) => self.visit_term(access_term.subject, f),
+                Term::Unsafe(unsafe_term) => self.try_visit(unsafe_term.inner, f),
+                Term::Access(access_term) => self.try_visit(access_term.subject, f),
                 Term::Index(index_term) => {
-                    self.visit_term(index_term.subject, f)?;
-                    self.visit_term(index_term.index, f)
+                    self.try_visit(index_term.subject, f)?;
+                    self.try_visit(index_term.index, f)
                 }
                 Term::Cast(cast_term) => {
-                    self.visit_term(cast_term.subject_term, f)?;
-                    self.visit_term(cast_term.target_ty, f)
+                    self.try_visit(cast_term.subject_term, f)?;
+                    self.try_visit(cast_term.target_ty, f)
                 }
-                Term::TypeOf(type_of_term) => self.visit_term(type_of_term.term, f),
-                Term::Ref(ref_term) => self.visit_term(ref_term.subject, f),
-                Term::Deref(deref_term) => self.visit_term(deref_term.subject, f),
+                Term::TypeOf(type_of_term) => self.try_visit(type_of_term.term, f),
+                Term::Ref(ref_term) => self.try_visit(ref_term.subject, f),
+                Term::Deref(deref_term) => self.try_visit(deref_term.subject, f),
                 Term::Hole(_) => Ok(()),
                 Term::Intrinsic(_) => Ok(()),
-                Ty::TupleTy(tuple_ty) => self.visit_params(tuple_ty.data, f),
+                Ty::TupleTy(tuple_ty) => self.try_visit(tuple_ty.data, f),
                 Ty::FnTy(fn_ty) => {
-                    self.visit_params(fn_ty.params, f)?;
-                    self.visit_term(fn_ty.return_ty, f)
+                    self.try_visit(fn_ty.params, f)?;
+                    self.try_visit(fn_ty.return_ty, f)
                 }
-                Ty::RefTy(ref_ty) => self.visit_term(ref_ty.ty, f),
-                Ty::DataTy(data_ty) => self.visit_args(data_ty.args, f),
+                Ty::RefTy(ref_ty) => self.try_visit(ref_ty.ty, f),
+                Ty::DataTy(data_ty) => self.try_visit(data_ty.args, f),
                 Ty::Universe => Ok(()),
             },
         }
@@ -184,34 +217,34 @@ impl Map<TermId> for Visitor {
             },
             ControlFlow::Continue(()) => match *term_id.value() {
                 Term::Tuple(tuple_term) => {
-                    let data = self.fmap_args(tuple_term.data, f)?;
+                    let data = self.map(tuple_term.data, f)?;
                     Ok(Term::from(Term::Tuple(TupleTerm { data }), origin))
                 }
                 Term::Lit(lit) => Ok(Term::from(Term::Lit(lit), origin)),
                 Term::Array(list_ctor) => {
-                    let elements = self.fmap_term_list(list_ctor.elements, f)?;
+                    let elements = self.map(list_ctor.elements, f)?;
                     Ok(Term::from(Term::Array(ArrayTerm { elements }), origin))
                 }
                 Term::Ctor(ctor_term) => {
-                    let data_args = self.fmap_args(ctor_term.data_args, f)?;
-                    let ctor_args = self.fmap_args(ctor_term.ctor_args, f)?;
+                    let data_args = self.map(ctor_term.data_args, f)?;
+                    let ctor_args = self.map(ctor_term.ctor_args, f)?;
                     Ok(Term::from(CtorTerm { ctor: ctor_term.ctor, data_args, ctor_args }, origin))
                 }
                 Term::Call(fn_call_term) => {
-                    let subject = self.fmap_term(fn_call_term.subject, f)?;
-                    let args = self.fmap_args(fn_call_term.args, f)?;
+                    let subject = self.map(fn_call_term.subject, f)?;
+                    let args = self.map(fn_call_term.args, f)?;
                     Ok(Term::from(
                         CallTerm { args, subject, implicit: fn_call_term.implicit },
                         origin,
                     ))
                 }
                 Term::Fn(fn_def_id) => {
-                    let fn_def_id = self.fmap_fn_def(fn_def_id, f)?;
+                    let fn_def_id = self.map(fn_def_id, f)?;
                     Ok(Term::from(Term::Fn(fn_def_id), origin))
                 }
                 Term::Block(block_term) => {
-                    let statements = self.fmap_block_statements(block_term.statements, f)?;
-                    let expr = self.fmap_term(block_term.expr, f)?;
+                    let statements = self.map(block_term.statements, f)?;
+                    let expr = self.map(block_term.expr, f)?;
                     Ok(Term::from(
                         BlockTerm { statements, stack_id: block_term.stack_id, expr },
                         origin,
@@ -219,12 +252,12 @@ impl Map<TermId> for Visitor {
                 }
                 Term::Var(var_term) => Ok(Term::from(var_term, origin)),
                 Term::Loop(loop_term) => {
-                    let inner = self.fmap_term(loop_term.inner, f)?;
+                    let inner = self.map(loop_term.inner, f)?;
                     Ok(Term::from(LoopTerm { inner }, origin))
                 }
                 Term::LoopControl(loop_control_term) => Ok(Term::from(loop_control_term, origin)),
                 Term::Match(match_term) => {
-                    let subject = self.fmap_term(match_term.subject, f)?;
+                    let subject = self.map(match_term.subject, f)?;
 
                     let cases = Node::<MatchCase>::seq(
                         match_term
@@ -233,8 +266,8 @@ impl Map<TermId> for Visitor {
                             .iter()
                             .map(|case| {
                                 let case_value = case.value();
-                                let bind_pat = self.fmap_pat(case_value.bind_pat, f)?;
-                                let value = self.fmap_term(case_value.value, f)?;
+                                let bind_pat = self.map(case_value.bind_pat, f)?;
+                                let value = self.map(case_value.value, f)?;
                                 Ok(Node::at(
                                     MatchCase { bind_pat, value, stack_id: case_value.stack_id },
                                     case_value.origin,
@@ -252,56 +285,56 @@ impl Map<TermId> for Visitor {
                     ))
                 }
                 Term::Return(return_term) => {
-                    let expression = self.fmap_term(return_term.expression, f)?;
+                    let expression = self.map(return_term.expression, f)?;
                     Ok(Term::from(ReturnTerm { expression }, origin))
                 }
                 Term::Assign(assign_term) => {
-                    let subject = self.fmap_term(assign_term.subject, f)?;
-                    let value = self.fmap_term(assign_term.value, f)?;
+                    let subject = self.map(assign_term.subject, f)?;
+                    let value = self.map(assign_term.value, f)?;
                     Ok(Term::from(AssignTerm { subject, value }, origin))
                 }
                 Term::Unsafe(unsafe_term) => {
-                    let inner = self.fmap_term(unsafe_term.inner, f)?;
+                    let inner = self.map(unsafe_term.inner, f)?;
                     Ok(Term::from(UnsafeTerm { inner }, origin))
                 }
                 Term::Access(access_term) => {
-                    let subject = self.fmap_term(access_term.subject, f)?;
+                    let subject = self.map(access_term.subject, f)?;
                     Ok(Term::from(AccessTerm { subject, field: access_term.field }, origin))
                 }
                 Term::Index(index_term) => {
-                    let subject = self.fmap_term(index_term.subject, f)?;
-                    let index = self.fmap_term(index_term.index, f)?;
+                    let subject = self.map(index_term.subject, f)?;
+                    let index = self.map(index_term.index, f)?;
                     Ok(Term::from(IndexTerm { subject, index }, origin))
                 }
                 Term::Cast(cast_term) => {
-                    let subject_term = self.fmap_term(cast_term.subject_term, f)?;
-                    let target_ty = self.fmap_term(cast_term.target_ty, f)?;
+                    let subject_term = self.map(cast_term.subject_term, f)?;
+                    let target_ty = self.map(cast_term.target_ty, f)?;
                     Ok(Term::from(CastTerm { subject_term, target_ty }, origin))
                 }
                 Term::TypeOf(type_of_term) => {
-                    let term = self.fmap_term(type_of_term.term, f)?;
+                    let term = self.map(type_of_term.term, f)?;
                     Ok(Term::from(TyOfTerm { term }, origin))
                 }
                 Term::Ref(ref_term) => {
-                    let subject = self.fmap_term(ref_term.subject, f)?;
+                    let subject = self.map(ref_term.subject, f)?;
                     Ok(Term::from(
                         RefTerm { subject, kind: ref_term.kind, mutable: ref_term.mutable },
                         origin,
                     ))
                 }
                 Term::Deref(deref_term) => {
-                    let subject = self.fmap_term(deref_term.subject, f)?;
+                    let subject = self.map(deref_term.subject, f)?;
                     Ok(Term::from(DerefTerm { subject }, origin))
                 }
                 Term::Hole(hole_term) => Ok(Term::from(hole_term, origin)),
                 Term::Intrinsic(intrinsic) => Ok(Term::from(intrinsic, origin)),
                 Ty::TupleTy(tuple_ty) => {
-                    let data = self.fmap_params(tuple_ty.data, f)?;
+                    let data = self.map(tuple_ty.data, f)?;
                     Ok(Ty::from(TupleTy { data }, origin))
                 }
                 Ty::FnTy(fn_ty) => {
-                    let params = self.fmap_params(fn_ty.params, f)?;
-                    let return_ty = self.fmap_term(fn_ty.return_ty, f)?;
+                    let params = self.map(fn_ty.params, f)?;
+                    let return_ty = self.map(fn_ty.return_ty, f)?;
                     Ok(Ty::from(
                         FnTy {
                             params,
@@ -314,11 +347,11 @@ impl Map<TermId> for Visitor {
                     ))
                 }
                 Ty::RefTy(ref_ty) => {
-                    let ty = self.fmap_term(ref_ty.ty, f)?;
+                    let ty = self.map(ref_ty.ty, f)?;
                     Ok(Ty::from(RefTy { ty, kind: ref_ty.kind, mutable: ref_ty.mutable }, origin))
                 }
                 Ty::DataTy(data_ty) => {
-                    let args = self.fmap_args(data_ty.args, f)?;
+                    let args = self.map(data_ty.args, f)?;
                     Ok(Ty::from(DataTy { args, data_def: data_ty.data_def }, origin))
                 }
                 Ty::Universe => Ok(Ty::from(Ty::Universe, origin)),
@@ -330,21 +363,21 @@ impl Map<TermId> for Visitor {
 }
 
 impl Visit<PatId> for Visitor {
-    fn visit<E, F: VisitFn<E>>(&self, pat_id: PatId, f: &mut F) -> Result<(), E> {
+    fn try_visit<E, F: TryVisitFn<E>>(&self, pat_id: PatId, f: &mut F) -> Result<(), E> {
         match f(pat_id.into())? {
             ControlFlow::Break(()) => Ok(()),
             ControlFlow::Continue(()) => match *pat_id.value() {
                 Pat::Binding(_) | Pat::Range(_) | Pat::Lit(_) => Ok(()),
-                Pat::Tuple(tuple_pat) => self.visit_pat_args(tuple_pat.data, f),
-                Pat::Array(list_pat) => self.visit_pat_list(list_pat.pats, f),
+                Pat::Tuple(tuple_pat) => self.try_visit(tuple_pat.data, f),
+                Pat::Array(list_pat) => self.try_visit(list_pat.pats, f),
                 Pat::Ctor(ctor_pat) => {
-                    self.visit_args(ctor_pat.data_args, f)?;
-                    self.visit_pat_args(ctor_pat.ctor_pat_args, f)
+                    self.try_visit(ctor_pat.data_args, f)?;
+                    self.try_visit(ctor_pat.ctor_pat_args, f)
                 }
-                Pat::Or(or_pat) => self.visit_pat_list(or_pat.alternatives, f),
+                Pat::Or(or_pat) => self.try_visit(or_pat.alternatives, f),
                 Pat::If(if_pat) => {
-                    self.visit_pat(if_pat.pat, f)?;
-                    self.visit_term(if_pat.condition, f)
+                    self.try_visit(if_pat.pat, f)?;
+                    self.try_visit(if_pat.condition, f)
                 }
             },
         }
@@ -360,22 +393,22 @@ impl Map<PatId> for Visitor {
                 Pat::Range(range_pat) => Ok(Node::create_at(Pat::from(range_pat), origin)),
                 Pat::Lit(lit_pat) => Ok(Node::create_at(Pat::from(lit_pat), origin)),
                 Pat::Tuple(tuple_pat) => {
-                    let data = self.fmap_pat_args(tuple_pat.data, f)?;
+                    let data = self.map(tuple_pat.data, f)?;
                     Ok(Node::create_at(
                         Pat::from(TuplePat { data_spread: tuple_pat.data_spread, data }),
                         origin,
                     ))
                 }
                 Pat::Array(list_pat) => {
-                    let pats = self.fmap_pat_list(list_pat.pats, f)?;
+                    let pats = self.map(list_pat.pats, f)?;
                     Ok(Node::create_at(
                         Pat::from(ArrayPat { spread: list_pat.spread, pats }),
                         origin,
                     ))
                 }
                 Pat::Ctor(ctor_pat) => {
-                    let data_args = self.fmap_args(ctor_pat.data_args, f)?;
-                    let ctor_pat_args = self.fmap_pat_args(ctor_pat.ctor_pat_args, f)?;
+                    let data_args = self.map(ctor_pat.data_args, f)?;
+                    let ctor_pat_args = self.map(ctor_pat.ctor_pat_args, f)?;
                     Ok(Node::create_at(
                         Pat::from(CtorPat {
                             data_args,
@@ -387,12 +420,12 @@ impl Map<PatId> for Visitor {
                     ))
                 }
                 Pat::Or(or_pat) => {
-                    let alternatives = self.fmap_pat_list(or_pat.alternatives, f)?;
+                    let alternatives = self.map(or_pat.alternatives, f)?;
                     Ok(Node::create_at(Pat::from(OrPat { alternatives }), origin))
                 }
                 Pat::If(if_pat) => {
-                    let pat = self.fmap_pat(if_pat.pat, f)?;
-                    let condition = self.fmap_term(if_pat.condition, f)?;
+                    let pat = self.map(if_pat.pat, f)?;
+                    let condition = self.map(if_pat.condition, f)?;
                     Ok(Node::create_at(Pat::from(IfPat { pat, condition }), origin))
                 }
             },
@@ -403,7 +436,7 @@ impl Map<PatId> for Visitor {
 }
 
 impl Visit<BlockStatementsId> for Visitor {
-    fn visit<E, F: VisitFn<E>>(
+    fn try_visit<E, F: TryVisitFn<E>>(
         &self,
         block_statements: BlockStatementsId,
         f: &mut F,
@@ -411,12 +444,12 @@ impl Visit<BlockStatementsId> for Visitor {
         for statement in block_statements.elements().value() {
             match *statement {
                 BlockStatement::Decl(decl) => {
-                    self.visit_pat(decl.bind_pat, f)?;
-                    self.visit_term(decl.ty, f)?;
-                    decl.value.map(|v| self.visit_term(v, f)).transpose()?;
+                    self.try_visit(decl.bind_pat, f)?;
+                    self.try_visit(decl.ty, f)?;
+                    decl.value.map(|v| self.try_visit(v, f)).transpose()?;
                 }
                 BlockStatement::Expr(expr) => {
-                    self.visit_term(expr, f)?;
+                    self.try_visit(expr, f)?;
                 }
             }
         }
@@ -433,19 +466,17 @@ impl Map<BlockStatementsId> for Visitor {
         for statement in block_statements.elements().value() {
             match *statement {
                 BlockStatement::Decl(decl) => {
-                    let bind_pat = self.fmap_pat(decl.bind_pat, f)?;
-                    let ty = self.fmap_term(decl.ty, f)?;
-                    let value = decl.value.map(|v| self.fmap_term(v, f)).transpose()?;
+                    let bind_pat = self.map(decl.bind_pat, f)?;
+                    let ty = self.map(decl.ty, f)?;
+                    let value = decl.value.map(|v| self.map(v, f)).transpose()?;
                     new_list.push(Node::at(
                         BlockStatement::Decl(Decl { ty, bind_pat, value }),
                         statement.origin,
                     ));
                 }
                 BlockStatement::Expr(expr) => {
-                    new_list.push(Node::at(
-                        BlockStatement::Expr(self.fmap_term(expr, f)?),
-                        statement.origin,
-                    ));
+                    new_list
+                        .push(Node::at(BlockStatement::Expr(self.map(expr, f)?), statement.origin));
                 }
             }
         }
@@ -454,9 +485,9 @@ impl Map<BlockStatementsId> for Visitor {
 }
 
 impl Visit<TermListId> for Visitor {
-    fn visit<E, F: VisitFn<E>>(&self, term_list_id: TermListId, f: &mut F) -> Result<(), E> {
+    fn try_visit<E, F: TryVisitFn<E>>(&self, term_list_id: TermListId, f: &mut F) -> Result<(), E> {
         for term in term_list_id.elements().value() {
-            self.visit_term(term, f)?;
+            self.try_visit(term, f)?;
         }
         Ok(())
     }
@@ -465,17 +496,17 @@ impl Map<TermListId> for Visitor {
     fn map<E, F: MapFn<E>>(&self, term_list: TermListId, f: F) -> Result<TermListId, E> {
         let mut new_list = Vec::with_capacity(term_list.len());
         for term_id in term_list.elements().value() {
-            new_list.push(self.fmap_term(term_id, f)?);
+            new_list.push(self.map(term_id, f)?);
         }
         Ok(Node::create_at(TermId::seq(new_list), term_list.origin()))
     }
 }
 
 impl Visit<PatListId> for Visitor {
-    fn visit<E, F: VisitFn<E>>(&self, pat_list_id: PatListId, f: &mut F) -> Result<(), E> {
+    fn try_visit<E, F: TryVisitFn<E>>(&self, pat_list_id: PatListId, f: &mut F) -> Result<(), E> {
         for pat in pat_list_id.elements().value() {
             if let PatOrCapture::Pat(pat) = pat {
-                self.visit_pat(pat, f)?;
+                self.try_visit(pat, f)?;
             }
         }
         Ok(())
@@ -487,7 +518,7 @@ impl Map<PatListId> for Visitor {
         for pat_id in pat_list.elements().value() {
             match pat_id {
                 PatOrCapture::Pat(pat_id) => {
-                    new_list.push(PatOrCapture::Pat(self.fmap_pat(pat_id, f)?));
+                    new_list.push(PatOrCapture::Pat(self.map(pat_id, f)?));
                 }
                 PatOrCapture::Capture(node) => {
                     new_list.push(PatOrCapture::Capture(node));
@@ -499,11 +530,11 @@ impl Map<PatListId> for Visitor {
 }
 
 impl Visit<ParamsId> for Visitor {
-    fn visit<E, F: VisitFn<E>>(&self, params_id: ParamsId, f: &mut F) -> Result<(), E> {
+    fn try_visit<E, F: TryVisitFn<E>>(&self, params_id: ParamsId, f: &mut F) -> Result<(), E> {
         for param in params_id.elements().value() {
-            self.visit_term(param.ty, f)?;
+            self.try_visit(param.ty, f)?;
             if let Some(default) = param.default {
-                self.visit_term(default, f)?;
+                self.try_visit(default, f)?;
             }
         }
         Ok(())
@@ -517,11 +548,8 @@ impl Map<ParamsId> for Visitor {
                 new_params.push(Node::at(
                     Param {
                         name: param.name,
-                        ty: self.fmap_term(param.ty, f)?,
-                        default: param
-                            .default
-                            .map(|default| self.fmap_term(default, f))
-                            .transpose()?,
+                        ty: self.map(param.ty, f)?,
+                        default: param.default.map(|default| self.map(default, f)).transpose()?,
                     },
                     param.origin,
                 ));
@@ -534,9 +562,9 @@ impl Map<ParamsId> for Visitor {
 }
 
 impl Visit<ArgsId> for Visitor {
-    fn visit<E, F: VisitFn<E>>(&self, args_id: ArgsId, f: &mut F) -> Result<(), E> {
+    fn try_visit<E, F: TryVisitFn<E>>(&self, args_id: ArgsId, f: &mut F) -> Result<(), E> {
         for arg in args_id.elements().value() {
-            self.visit_term(arg.value, f)?;
+            self.try_visit(arg.value, f)?;
         }
         Ok(())
     }
@@ -546,7 +574,7 @@ impl Map<ArgsId> for Visitor {
         let mut new_args = Vec::with_capacity(args_id.len());
         for arg in args_id.elements().value() {
             new_args.push(Node::at(
-                Arg { target: arg.target, value: self.fmap_term(arg.value, f)? },
+                Arg { target: arg.target, value: self.map(arg.value, f)? },
                 arg.origin,
             ));
         }
@@ -556,10 +584,10 @@ impl Map<ArgsId> for Visitor {
 }
 
 impl Visit<PatArgsId> for Visitor {
-    fn visit<E, F: VisitFn<E>>(&self, pat_args_id: PatArgsId, f: &mut F) -> Result<(), E> {
+    fn try_visit<E, F: TryVisitFn<E>>(&self, pat_args_id: PatArgsId, f: &mut F) -> Result<(), E> {
         for arg in pat_args_id.elements().value() {
             if let PatOrCapture::Pat(pat) = arg.pat {
-                self.visit_pat(pat, f)?;
+                self.try_visit(pat, f)?;
             }
         }
         Ok(())
@@ -574,9 +602,7 @@ impl Map<PatArgsId> for Visitor {
                     PatArg {
                         target: pat_arg.target,
                         pat: match pat_arg.pat {
-                            PatOrCapture::Pat(pat_id) => {
-                                PatOrCapture::Pat(self.fmap_pat(pat_id, f)?)
-                            }
+                            PatOrCapture::Pat(pat_id) => PatOrCapture::Pat(self.map(pat_id, f)?),
                             PatOrCapture::Capture(node) => PatOrCapture::Capture(node),
                         },
                     },
@@ -591,7 +617,7 @@ impl Map<PatArgsId> for Visitor {
 }
 
 impl Visit<FnDefId> for Visitor {
-    fn visit<E, F: VisitFn<E>>(&self, fn_def_id: FnDefId, f: &mut F) -> Result<(), E> {
+    fn try_visit<E, F: TryVisitFn<E>>(&self, fn_def_id: FnDefId, f: &mut F) -> Result<(), E> {
         if self.visit_fns_once {
             {
                 if self.visited.borrow().contains(&fn_def_id.into()) {
@@ -606,9 +632,9 @@ impl Visit<FnDefId> for Visitor {
             ControlFlow::Continue(()) => {
                 let fn_def = fn_def_id.value();
                 let fn_ty = fn_def.ty;
-                self.visit_params(fn_ty.params, f)?;
-                self.visit_term(fn_ty.return_ty, f)?;
-                self.visit_term(fn_def.body, f)
+                self.try_visit(fn_ty.params, f)?;
+                self.try_visit(fn_ty.return_ty, f)?;
+                self.try_visit(fn_def.body, f)
             }
         }
     }
@@ -628,9 +654,9 @@ impl Map<FnDefId> for Visitor {
             ControlFlow::Break(fn_def_id) => Ok(FnDefId::try_from(fn_def_id).unwrap()),
             ControlFlow::Continue(()) => {
                 let fn_def = fn_def_id.value();
-                let params = self.fmap_params(fn_def.ty.params, f)?;
-                let return_ty = self.fmap_term(fn_def.ty.return_ty, f)?;
-                let body = self.fmap_term(fn_def.body, f)?;
+                let params = self.map(fn_def.ty.params, f)?;
+                let return_ty = self.map(fn_def.ty.return_ty, f)?;
+                let body = self.map(fn_def.body, f)?;
 
                 let def = Node::create_at(
                     FnDef {
@@ -656,32 +682,32 @@ impl Map<FnDefId> for Visitor {
 }
 
 impl Visit<CtorDefId> for Visitor {
-    fn visit<E, F: VisitFn<E>>(&self, ctor_def_id: CtorDefId, f: &mut F) -> Result<(), E> {
+    fn try_visit<E, F: TryVisitFn<E>>(&self, ctor_def_id: CtorDefId, f: &mut F) -> Result<(), E> {
         let ctor_def = ctor_def_id.value();
 
         // Visit the parameters
-        self.visit_params(ctor_def.params, f)?;
+        self.try_visit(ctor_def.params, f)?;
 
         // Visit the arguments
-        self.visit_args(ctor_def.result_args, f)?;
+        self.try_visit(ctor_def.result_args, f)?;
 
         Ok(())
     }
 }
 
 impl Visit<DataDefId> for Visitor {
-    fn visit<E, F: VisitFn<E>>(&self, data_def_id: DataDefId, f: &mut F) -> Result<(), E> {
+    fn try_visit<E, F: TryVisitFn<E>>(&self, data_def_id: DataDefId, f: &mut F) -> Result<(), E> {
         let (data_def_params, data_def_ctors) =
             data_def_id.map(|data_def| (data_def.params, data_def.ctors));
 
         // Params
-        self.visit_params(data_def_params, f)?;
+        self.try_visit(data_def_params, f)?;
 
         match data_def_ctors {
             DataDefCtors::Defined(data_def_ctors_id) => {
                 // Traverse the constructors
                 for ctor_idx in data_def_ctors_id.value().to_index_range() {
-                    self.visit_ctor_def(CtorDefId(data_def_ctors_id.elements(), ctor_idx), f)?;
+                    self.try_visit(CtorDefId(data_def_ctors_id.elements(), ctor_idx), f)?;
                 }
                 Ok(())
             }
@@ -694,7 +720,7 @@ impl Visit<DataDefId> for Visitor {
                 }
                 PrimitiveCtorInfo::Array(list_ctor_info) => {
                     // Traverse the inner type
-                    self.visit_term(list_ctor_info.element_ty, f)?;
+                    self.try_visit(list_ctor_info.element_ty, f)?;
                     Ok(())
                 }
             },
@@ -703,19 +729,23 @@ impl Visit<DataDefId> for Visitor {
 }
 
 impl Visit<ModMemberId> for Visitor {
-    fn visit<E, F: VisitFn<E>>(&self, mod_member_id: ModMemberId, f: &mut F) -> Result<(), E> {
+    fn try_visit<E, F: TryVisitFn<E>>(
+        &self,
+        mod_member_id: ModMemberId,
+        f: &mut F,
+    ) -> Result<(), E> {
         let value = mod_member_id.borrow().value;
         match value {
             ModMemberValue::Data(data_def_id) => {
-                self.visit_data_def(data_def_id, f)?;
+                self.try_visit(data_def_id, f)?;
                 Ok(())
             }
             ModMemberValue::Mod(mod_def_id) => {
-                self.visit_mod_def(mod_def_id, f)?;
+                self.try_visit(mod_def_id, f)?;
                 Ok(())
             }
             ModMemberValue::Fn(fn_def_id) => {
-                self.visit_fn_def(fn_def_id, f)?;
+                self.try_visit(fn_def_id, f)?;
                 Ok(())
             }
             ModMemberValue::Intrinsic(_) => {
@@ -727,169 +757,10 @@ impl Visit<ModMemberId> for Visitor {
 }
 
 impl Visit<ModDefId> for Visitor {
-    fn visit<E, F: VisitFn<E>>(&self, mod_def_id: ModDefId, f: &mut F) -> Result<(), E> {
+    fn try_visit<E, F: TryVisitFn<E>>(&self, mod_def_id: ModDefId, f: &mut F) -> Result<(), E> {
         for member in mod_def_id.borrow().members.iter() {
-            self.visit_mod_member(member, f)?;
+            self.try_visit(member, f)?;
         }
         Ok(())
-    }
-}
-
-/// Contains the implementation of `fmap` and `visit` for each atom, as well as
-/// secondary components such as arguments and parameters.
-impl Visitor {
-    /// Create a new `TraversingUtils`.
-    pub fn new() -> Self {
-        Self { visited: RefCell::new(HashSet::new()), visit_fns_once: true }
-    }
-
-    pub fn set_visit_fns_once(&mut self, visit_fns_once: bool) {
-        self.visit_fns_once = visit_fns_once;
-    }
-
-    pub fn fmap_atom<E, F: MapFn<E>>(&self, atom: Atom, f: F) -> Result<Atom, E> {
-        self.map(atom, f)
-    }
-
-    pub fn fmap_term<E, F: MapFn<E>>(&self, term_id: TermId, f: F) -> Result<TermId, E> {
-        self.map(term_id, f)
-    }
-
-    pub fn fmap_pat<E, F: MapFn<E>>(&self, pat_id: PatId, f: F) -> Result<PatId, E> {
-        self.map(pat_id, f)
-    }
-
-    pub fn fmap_block_statements<E, F: MapFn<E>>(
-        &self,
-        block_statements: BlockStatementsId,
-        f: F,
-    ) -> Result<BlockStatementsId, E> {
-        self.map(block_statements, f)
-    }
-
-    pub fn fmap_term_list<E, F: MapFn<E>>(
-        &self,
-        term_list: TermListId,
-        f: F,
-    ) -> Result<TermListId, E> {
-        self.map(term_list, f)
-    }
-
-    pub fn fmap_pat_list<E, F: MapFn<E>>(&self, pat_list: PatListId, f: F) -> Result<PatListId, E> {
-        self.map(pat_list, f)
-    }
-
-    pub fn fmap_params<E, F: MapFn<E>>(&self, params_id: ParamsId, f: F) -> Result<ParamsId, E> {
-        self.map(params_id, f)
-    }
-
-    pub fn fmap_args<E, F: MapFn<E>>(&self, args_id: ArgsId, f: F) -> Result<ArgsId, E> {
-        self.map(args_id, f)
-    }
-
-    pub fn fmap_pat_args<E, F: MapFn<E>>(
-        &self,
-        pat_args_id: PatArgsId,
-        f: F,
-    ) -> Result<PatArgsId, E> {
-        self.map(pat_args_id, f)
-    }
-
-    pub fn fmap_fn_def<E, F: MapFn<E>>(&self, fn_def_id: FnDefId, f: F) -> Result<FnDefId, E> {
-        self.map(fn_def_id, f)
-    }
-
-    pub fn visit_term<E, F: VisitFn<E>>(&self, term_id: TermId, f: &mut F) -> Result<(), E> {
-        self.visit(term_id, f)
-    }
-
-    pub fn visit_pat<E, F: VisitFn<E>>(&self, pat_id: PatId, f: &mut F) -> Result<(), E> {
-        self.visit(pat_id, f)
-    }
-
-    pub fn visit_fn_def<E, F: VisitFn<E>>(&self, fn_def_id: FnDefId, f: &mut F) -> Result<(), E> {
-        self.visit(fn_def_id, f)
-    }
-
-    pub fn visit_atom<E, F: VisitFn<E>>(&self, atom: Atom, f: &mut F) -> Result<(), E> {
-        self.visit(atom, f)
-    }
-
-    pub fn visit_term_list<E, F: VisitFn<E>>(
-        &self,
-        term_list_id: TermListId,
-        f: &mut F,
-    ) -> Result<(), E> {
-        self.visit(term_list_id, f)
-    }
-
-    pub fn visit_block_statements<E, F: VisitFn<E>>(
-        &self,
-        block_statements: BlockStatementsId,
-        f: &mut F,
-    ) -> Result<(), E> {
-        self.visit(block_statements, f)
-    }
-
-    pub fn visit_pat_list<E, F: VisitFn<E>>(
-        &self,
-        pat_list_id: PatListId,
-        f: &mut F,
-    ) -> Result<(), E> {
-        self.visit(pat_list_id, f)
-    }
-
-    pub fn visit_params<E, F: VisitFn<E>>(&self, params_id: ParamsId, f: &mut F) -> Result<(), E> {
-        self.visit(params_id, f)
-    }
-
-    pub fn visit_pat_args<E, F: VisitFn<E>>(
-        &self,
-        pat_args_id: PatArgsId,
-        f: &mut F,
-    ) -> Result<(), E> {
-        self.visit(pat_args_id, f)
-    }
-
-    pub fn visit_args<E, F: VisitFn<E>>(&self, args_id: ArgsId, f: &mut F) -> Result<(), E> {
-        self.visit(args_id, f)
-    }
-
-    pub fn visit_ctor_def<E, F: VisitFn<E>>(
-        &self,
-        ctor_def_id: CtorDefId,
-        f: &mut F,
-    ) -> Result<(), E> {
-        self.visit(ctor_def_id, f)
-    }
-
-    pub fn visit_data_def<E, F: VisitFn<E>>(
-        &self,
-        data_def_id: DataDefId,
-        f: &mut F,
-    ) -> Result<(), E> {
-        self.visit(data_def_id, f)
-    }
-
-    pub fn visit_mod_member<E, F: VisitFn<E>>(
-        &self,
-        mod_member_id: ModMemberId,
-        f: &mut F,
-    ) -> Result<(), E> {
-        self.visit(mod_member_id, f)
-    }
-
-    pub fn visit_mod_def<E, F: VisitFn<E>>(
-        &self,
-        mod_def_id: ModDefId,
-        f: &mut F,
-    ) -> Result<(), E> {
-        self.visit(mod_def_id, f)
-    }
-}
-
-impl Default for Visitor {
-    fn default() -> Self {
-        Self::new()
     }
 }

--- a/compiler/hash-tir/src/visitor.rs
+++ b/compiler/hash-tir/src/visitor.rs
@@ -59,21 +59,24 @@ impl fmt::Display for Atom {
     }
 }
 
-/// Contains methods to traverse the Hash TIR structure.
+/// Contains methods to traverse the Hash TIR structure, by implementing
+/// [`Visit`] and [`Map`] for all TIR nodes.
 pub struct Visitor {
-    // @@Todo @@Performance: remove this in favour of referencing functions symbolically.
     visited: RefCell<HashSet<Atom>>,
     visit_fns_once: bool,
 }
 
-/// Contains the implementation of `fmap` and `visit` for each atom, as well as
-/// secondary components such as arguments and parameters.
 impl Visitor {
-    /// Create a new `TraversingUtils`.
     pub fn new() -> Self {
         Self { visited: RefCell::new(HashSet::new()), visit_fns_once: true }
     }
 
+    /// Set a flag as to whether or not to visit functions only once.
+    ///
+    /// If set to `true` this keeps an internal record of which functions have
+    /// been visited, and will not visit them again.
+    // @@Todo @@Performance: remove this in favour of referencing functions
+    // symbolically.
     pub fn set_visit_fns_once(&mut self, once: bool) {
         self.visit_fns_once = once;
     }

--- a/compiler/hash-typecheck/src/inference.rs
+++ b/compiler/hash-typecheck/src/inference.rs
@@ -42,7 +42,7 @@ use hash_tir::{
         RefTy, ReturnTerm, Spread, SymbolId, Term, TermId, TermListId, TuplePat, TupleTerm,
         TupleTy, Ty, TyId, TyOfTerm, UnsafeTerm,
     },
-    visitor::{Atom, Visitor},
+    visitor::{Atom, Map, Visit, Visitor},
 };
 use hash_utils::derive_more::{Constructor, Deref};
 use itertools::Itertools;
@@ -135,9 +135,9 @@ impl<T: TcEnv> InferenceOps<'_, T> {
             self.context().enter_scope(ScopeKind::Sub, || -> TcResult<_> {
                 for (arg, param_id) in args.zip(annotation_params.iter()) {
                     let param = param_id.value();
-                    let param_ty = self.sub_ops().copy_term(param.ty);
+                    let param_ty = Visitor::new().copy(param.ty);
                     infer_arg(&arg, param_ty)?;
-                    self.sub_ops().apply_sub_to_atom_from_context(param_ty);
+                    self.sub_ops().apply_sub_from_context(param_ty);
                     if let Some(value) = get_arg_value(&arg) {
                         self.context().add_assignment(param.name, param_ty, value);
                     }
@@ -393,7 +393,7 @@ impl<T: TcEnv> InferenceOps<'_, T> {
         self.context().enter_scope(ScopeKind::Sub, || {
             self.normalise_and_check_ty(annotation_ty)?;
             let params = match *annotation_ty.value() {
-                Ty::TupleTy(tuple_ty) => self.sub_ops().copy_params(tuple_ty.data),
+                Ty::TupleTy(tuple_ty) => Visitor::new().copy(tuple_ty.data),
                 Ty::Hole(_) => Param::seq_from_args_with_hole_types(tuple_term.data),
                 _ => {
                     let inferred = Param::seq_from_args_with_hole_types(tuple_term.data);
@@ -421,7 +421,7 @@ impl<T: TcEnv> InferenceOps<'_, T> {
             self.check_by_unify(tuple_ty, annotation_ty)?;
             // @@Review: why is this needed? Shouldn't the substitution be applied during
             // `check_by_unify`?
-            self.sub_ops().apply_sub_to_atom_from_context(annotation_ty);
+            self.sub_ops().apply_sub_from_context(annotation_ty);
             Ok(())
         })
     }
@@ -582,14 +582,13 @@ impl<T: TcEnv> InferenceOps<'_, T> {
                     DataDefCtors::Primitive(primitive) => {
                         if let PrimitiveCtorInfo::Array(array_prim) = primitive {
                             // First infer the data arguments
-                            let copied_params = self.sub_ops().copy_params(data_def.params);
+                            let copied_params = Visitor::new().copy(data_def.params);
                             self.infer_args(data.args, copied_params, |_| {
                                 let sub = self.sub_ops().create_sub_from_current_scope();
                                 let subbed_element_ty =
-                                    self.sub_ops().apply_sub_to_term(array_prim.element_ty, &sub);
-                                let subbed_index = array_prim
-                                    .length
-                                    .map(|l| self.sub_ops().apply_sub_to_term(l, &sub));
+                                    self.sub_ops().apply_sub(array_prim.element_ty, &sub);
+                                let subbed_index =
+                                    array_prim.length.map(|l| self.sub_ops().apply_sub(l, &sub));
                                 Ok(Some((subbed_element_ty, subbed_index)))
                             })
                         } else {
@@ -662,7 +661,7 @@ impl<T: TcEnv> InferenceOps<'_, T> {
     pub fn get_binds_in_pat(&self, pat: PatId) -> HashSet<SymbolId> {
         let mut binds = HashSet::new();
         Visitor::new()
-            .visit_pat::<!, _>(pat, &mut |atom| {
+            .try_visit::<!, _>(pat, &mut |atom| {
                 Ok(self.get_binds_in_pat_atom_once(atom, &mut binds))
             })
             .into_ok();
@@ -672,7 +671,7 @@ impl<T: TcEnv> InferenceOps<'_, T> {
     pub fn get_binds_in_pat_args(&self, pat_args: PatArgsId) -> HashSet<SymbolId> {
         let mut binds = HashSet::new();
         Visitor::new()
-            .visit_pat_args::<!, _>(pat_args, &mut |atom| {
+            .try_visit::<!, _>(pat_args, &mut |atom| {
                 Ok(self.get_binds_in_pat_atom_once(atom, &mut binds))
             })
             .into_ok();
@@ -732,14 +731,13 @@ impl<T: TcEnv> InferenceOps<'_, T> {
         // From the given constructor data args, substitute the constructor params and
         // result arguments. In the process, infer the data args more if
         // possible.
-        let copied_params = self.sub_ops().copy_params(data_def.params);
+        let copied_params = Visitor::new().copy(data_def.params);
         let (inferred_ctor_data_args, subbed_ctor_params, subbed_ctor_result_args) = self
             .infer_args(ctor_data_args, copied_params, |inferred_data_args| {
                 let sub = self.sub_ops().create_sub_from_current_scope();
-                let subbed_ctor_params = self.sub_ops().apply_sub_to_params(ctor.params, &sub);
-                let subbed_ctor_result_args =
-                    self.sub_ops().apply_sub_to_args(ctor.result_args, &sub);
-                self.sub_ops().apply_sub_to_args_in_place(inferred_data_args, &sub);
+                let subbed_ctor_params = self.sub_ops().apply_sub(ctor.params, &sub);
+                let subbed_ctor_result_args = self.sub_ops().apply_sub(ctor.result_args, &sub);
+                self.sub_ops().apply_sub_in_place(inferred_data_args, &sub);
                 Ok((inferred_data_args, subbed_ctor_params, subbed_ctor_result_args))
             })?;
 
@@ -750,9 +748,9 @@ impl<T: TcEnv> InferenceOps<'_, T> {
         let (final_result_args, resulting_sub, binds) =
             self.infer_args(term.ctor_args, subbed_ctor_params, |inferred_term_ctor_args| {
                 let ctor_sub = self.sub_ops().create_sub_from_current_scope();
-                self.sub_ops().apply_sub_to_args_in_place(subbed_ctor_result_args, &ctor_sub);
-                self.sub_ops().apply_sub_to_args_in_place(inferred_term_ctor_args, &ctor_sub);
-                self.sub_ops().apply_sub_to_args_in_place(inferred_ctor_data_args, &ctor_sub);
+                self.sub_ops().apply_sub_in_place(subbed_ctor_result_args, &ctor_sub);
+                self.sub_ops().apply_sub_in_place(inferred_term_ctor_args, &ctor_sub);
+                self.sub_ops().apply_sub_in_place(inferred_ctor_data_args, &ctor_sub);
 
                 // These arguments might have been updated so we need to set them
                 term.data_args = inferred_ctor_data_args;
@@ -779,12 +777,12 @@ impl<T: TcEnv> InferenceOps<'_, T> {
         // arguments, the constructor data arguments, and finally the annotation
         // type.
         let final_sub = self.sub_ops().create_sub_from_current_scope();
-        self.sub_ops().apply_sub_to_args_in_place(subbed_ctor_result_args, &final_sub);
-        self.sub_ops().apply_sub_to_args_in_place(inferred_ctor_data_args, &final_sub);
+        self.sub_ops().apply_sub_in_place(subbed_ctor_result_args, &final_sub);
+        self.sub_ops().apply_sub_in_place(inferred_ctor_data_args, &final_sub);
         // Set data args because they might have been updated again
         term.data_args = inferred_ctor_data_args;
         original_term_id.set(original_term_id.value().with_data(term.into()));
-        self.sub_ops().apply_sub_to_term_in_place(annotation_ty, &final_sub);
+        self.sub_ops().apply_sub_in_place(annotation_ty, &final_sub);
 
         for (data_arg, result_data_arg) in term.data_args.iter().zip(subbed_ctor_result_args.iter())
         {
@@ -873,20 +871,20 @@ impl<T: TcEnv> InferenceOps<'_, T> {
                         });
                     }
 
-                    let copied_params = self.sub_ops().copy_params(fn_ty.params);
-                    let copied_return_ty = self.sub_ops().copy_term(fn_ty.return_ty);
+                    let copied_params = Visitor::new().copy(fn_ty.params);
+                    let copied_return_ty = Visitor::new().copy(fn_ty.return_ty);
 
                     let mut fn_call_term = *fn_call_term;
                     self.infer_args(fn_call_term.args, copied_params, |inferred_fn_call_args| {
                         fn_call_term.args = inferred_fn_call_args;
                         original_term_id.set(original_term_id.value().with_data(fn_call_term.into()));
 
-                        self.sub_ops().apply_sub_to_atom_from_context(copied_return_ty);
+                        self.sub_ops().apply_sub_from_context(copied_return_ty);
                         self.check_by_unify(copied_return_ty, annotation_ty)?;
                         Ok(())
                     })?;
 
-                    self.sub_ops().apply_sub_to_atom_from_context(fn_call_term.subject);
+                    self.sub_ops().apply_sub_from_context(fn_call_term.subject);
                     self.potentially_monomorphise_fn_call(original_term_id, fn_ty, annotation_ty)?;
 
                     Ok(())
@@ -1038,7 +1036,7 @@ impl<T: TcEnv> InferenceOps<'_, T> {
         match self.context().try_get_decl(term) {
             Some(decl) => {
                 if let Some(ty) = decl.ty {
-                    let ty = self.sub_ops().copy_term(ty);
+                    let ty = Visitor::new().copy(ty);
                     self.check_ty(ty)?;
                     self.uni_ops().unify_terms(ty, annotation_ty)?;
                     Ok(())
@@ -1198,7 +1196,7 @@ impl<T: TcEnv> InferenceOps<'_, T> {
             };
 
             let sub = self.sub_ops().create_sub_from_current_scope();
-            self.sub_ops().apply_sub_to_term_in_place(annotation_ty, &sub);
+            self.sub_ops().apply_sub_in_place(annotation_ty, &sub);
 
             let sub_ops = self.sub_ops();
             let vars_in_scope = sub_ops.get_unassigned_vars_in_current_scope();
@@ -1296,7 +1294,7 @@ impl<T: TcEnv> InferenceOps<'_, T> {
                         let sub = self
                             .sub_ops()
                             .create_sub_from_args_of_params(data_ty.args, data_def.params);
-                        self.sub_ops().apply_sub_to_params(ctor.params, &sub)
+                        self.sub_ops().apply_sub(ctor.params, &sub)
                     }
                     None => {
                         // Not a record type because it has more than one constructor
@@ -1327,8 +1325,7 @@ impl<T: TcEnv> InferenceOps<'_, T> {
             // i.e. `x: (T: Type, t: T);  x.t: x.T`
             let param_access_sub =
                 self.sub_ops().create_sub_from_param_access(params, access_term.subject);
-            let subbed_param_ty =
-                self.sub_ops().apply_sub_to_term(param.borrow().ty, &param_access_sub);
+            let subbed_param_ty = self.sub_ops().apply_sub(param.borrow().ty, &param_access_sub);
             self.check_by_unify(subbed_param_ty, annotation_ty)?;
             Ok(())
         } else {
@@ -1376,8 +1373,7 @@ impl<T: TcEnv> InferenceOps<'_, T> {
                     let sub = self
                         .sub_ops()
                         .create_sub_from_args_of_params(data_ty.args, data_def.params);
-                    let array_ty =
-                        self.sub_ops().apply_sub_to_term(array_primitive.element_ty, &sub);
+                    let array_ty = self.sub_ops().apply_sub(array_primitive.element_ty, &sub);
                     Ok(array_ty)
                 } else {
                     wrong_subject_ty()
@@ -1432,11 +1428,11 @@ impl<T: TcEnv> InferenceOps<'_, T> {
         for case in match_term.cases.iter() {
             let case_data = case.value();
             self.context().enter_scope(case_data.stack_id.into(), || -> TcResult<_> {
-                let subject_ty_copy = self.sub_ops().copy_term(match_subject_ty);
+                let subject_ty_copy = Visitor::new().copy(match_subject_ty);
 
                 self.infer_pat(case_data.bind_pat, subject_ty_copy, Some(match_term.subject))?;
                 let new_unified_ty =
-                    Ty::expect_is(case_data.value, self.sub_ops().copy_term(unified_ty));
+                    Ty::expect_is(case_data.value, Visitor::new().copy(unified_ty));
 
                 if let Some(match_subject_var) = match_subject_var {
                     if let Some(pat_term) = self.try_use_pat_as_term(case_data.bind_pat) {
@@ -1561,7 +1557,7 @@ impl<T: TcEnv> InferenceOps<'_, T> {
             }
             Ty::DataTy(mut data_ty) => {
                 let data_def = data_ty.data_def.value();
-                let copied_params = self.sub_ops().copy_params(data_def.params);
+                let copied_params = Visitor::new().copy(data_def.params);
                 self.infer_args(data_ty.args, copied_params, |inferred_data_ty_args| {
                     data_ty.args = inferred_data_ty_args;
                     term_id.set(term_id.value().with_data(data_ty.into()));
@@ -1718,14 +1714,13 @@ impl<T: TcEnv> InferenceOps<'_, T> {
         // From the given constructor data args, substitute the constructor params and
         // result arguments. In the process, infer the data args more if
         // possible.
-        let copied_params = self.sub_ops().copy_params(data_def.params);
+        let copied_params = Visitor::new().copy(data_def.params);
         let (inferred_ctor_data_args, subbed_ctor_params, subbed_ctor_result_args) = self
             .infer_args(ctor_data_args, copied_params, |inferred_data_args| {
                 let sub = self.sub_ops().create_sub_from_current_scope();
-                let subbed_ctor_params = self.sub_ops().apply_sub_to_params(ctor.params, &sub);
-                let subbed_ctor_result_args =
-                    self.sub_ops().apply_sub_to_args(ctor.result_args, &sub);
-                self.sub_ops().apply_sub_to_args_in_place(inferred_data_args, &sub);
+                let subbed_ctor_params = self.sub_ops().apply_sub(ctor.params, &sub);
+                let subbed_ctor_result_args = self.sub_ops().apply_sub(ctor.result_args, &sub);
+                self.sub_ops().apply_sub_in_place(inferred_data_args, &sub);
                 Ok((inferred_data_args, subbed_ctor_params, subbed_ctor_result_args))
             })?;
 
@@ -1739,9 +1734,9 @@ impl<T: TcEnv> InferenceOps<'_, T> {
             subbed_ctor_params,
             |inferred_pat_ctor_args| {
                 let ctor_sub = self.sub_ops().create_sub_from_current_scope();
-                self.sub_ops().apply_sub_to_args_in_place(subbed_ctor_result_args, &ctor_sub);
-                self.sub_ops().apply_sub_to_pat_args_in_place(inferred_pat_ctor_args, &ctor_sub);
-                self.sub_ops().apply_sub_to_args_in_place(inferred_ctor_data_args, &ctor_sub);
+                self.sub_ops().apply_sub_in_place(subbed_ctor_result_args, &ctor_sub);
+                self.sub_ops().apply_sub_in_place(inferred_pat_ctor_args, &ctor_sub);
+                self.sub_ops().apply_sub_in_place(inferred_ctor_data_args, &ctor_sub);
 
                 // These arguments might have been updated so we need to set them
                 pat.data_args = inferred_ctor_data_args;
@@ -1773,13 +1768,13 @@ impl<T: TcEnv> InferenceOps<'_, T> {
         // arguments, the constructor data arguments, and finally the annotation
         // type.
         let final_sub = self.sub_ops().create_sub_from_current_scope();
-        self.sub_ops().apply_sub_to_args_in_place(subbed_ctor_result_args, &final_sub);
-        self.sub_ops().apply_sub_to_args_in_place(inferred_ctor_data_args, &final_sub);
-        self.sub_ops().apply_sub_to_pat_args_in_place(pat.ctor_pat_args, &final_sub);
+        self.sub_ops().apply_sub_in_place(subbed_ctor_result_args, &final_sub);
+        self.sub_ops().apply_sub_in_place(inferred_ctor_data_args, &final_sub);
+        self.sub_ops().apply_sub_in_place(pat.ctor_pat_args, &final_sub);
         // Set data args because they might have been updated again
         pat.data_args = inferred_ctor_data_args;
         original_pat_id.set(original_pat_id.value().with_data(pat.into()));
-        self.sub_ops().apply_sub_to_term_in_place(annotation_ty, &final_sub);
+        self.sub_ops().apply_sub_in_place(annotation_ty, &final_sub);
 
         for (data_arg, result_data_arg) in pat.data_args.iter().zip(subbed_ctor_result_args.iter())
         {

--- a/compiler/hash-typecheck/src/inference.rs
+++ b/compiler/hash-typecheck/src/inference.rs
@@ -660,21 +660,14 @@ impl<T: TcEnv> InferenceOps<'_, T> {
 
     pub fn get_binds_in_pat(&self, pat: PatId) -> HashSet<SymbolId> {
         let mut binds = HashSet::new();
-        Visitor::new()
-            .try_visit::<!, _>(pat, &mut |atom| {
-                Ok(self.get_binds_in_pat_atom_once(atom, &mut binds))
-            })
-            .into_ok();
+        Visitor::new().visit(pat, &mut |atom| self.get_binds_in_pat_atom_once(atom, &mut binds));
         binds
     }
 
     pub fn get_binds_in_pat_args(&self, pat_args: PatArgsId) -> HashSet<SymbolId> {
         let mut binds = HashSet::new();
         Visitor::new()
-            .try_visit::<!, _>(pat_args, &mut |atom| {
-                Ok(self.get_binds_in_pat_atom_once(atom, &mut binds))
-            })
-            .into_ok();
+            .visit(pat_args, &mut |atom| self.get_binds_in_pat_atom_once(atom, &mut binds));
         binds
     }
 

--- a/compiler/hash-typecheck/src/substitution.rs
+++ b/compiler/hash-typecheck/src/substitution.rs
@@ -8,10 +8,10 @@ use hash_tir::{
     context::ContextMember,
     sub::Sub,
     tir::{
-        AccessTerm, ArgsId, Hole, ModDefId, NodeId, ParamId, ParamIndex, ParamsId, Pat, PatArgsId,
-        SymbolId, Term, TermId, Ty,
+        AccessTerm, ArgsId, Hole, NodeId, ParamId, ParamIndex, ParamsId, Pat, SymbolId, Term,
+        TermId, Ty,
     },
-    visitor::{Atom, Visitor},
+    visitor::{Atom, Map, Visit, Visitor},
 };
 use hash_utils::{derive_more::Deref, log::warn};
 
@@ -57,10 +57,10 @@ impl<'a, T: TcEnv> SubstitutionOps<'a, T> {
         let mut shadowed_sub = sub.clone();
         for param in params.iter() {
             let param = param.value();
-            self.apply_sub_to_term_in_place(param.ty, &shadowed_sub);
+            self.apply_sub_in_place(param.ty, &shadowed_sub);
             shadowed_sub.remove(param.name);
             if let Some(default) = param.default {
-                self.apply_sub_to_term_in_place(default, &shadowed_sub);
+                self.apply_sub_in_place(default, &shadowed_sub);
             }
         }
         shadowed_sub
@@ -75,12 +75,12 @@ impl<'a, T: TcEnv> SubstitutionOps<'a, T> {
         match atom {
             Atom::Term(term) => {
                 if let Some(ty) = self.try_get_inferred_ty(term) {
-                    self.apply_sub_to_atom_in_place(ty.into(), sub);
+                    self.apply_sub_in_place(ty, sub);
                 }
             }
             Atom::Pat(pat) => {
                 if let Some(ty) = self.try_get_inferred_ty(pat) {
-                    self.apply_sub_to_atom_in_place(ty.into(), sub);
+                    self.apply_sub_in_place(ty, sub);
                 }
             }
             Atom::FnDef(_) => {}
@@ -101,7 +101,7 @@ impl<'a, T: TcEnv> SubstitutionOps<'a, T> {
                 }
                 Ty::FnTy(fn_ty) => {
                     let shadowed_sub = self.apply_sub_to_params_and_get_shadowed(fn_ty.params, sub);
-                    self.apply_sub_to_term_in_place(fn_ty.return_ty, &shadowed_sub);
+                    self.apply_sub_in_place(fn_ty.return_ty, &shadowed_sub);
                     ControlFlow::Break(())
                 }
                 _ => ControlFlow::Continue(()),
@@ -110,8 +110,8 @@ impl<'a, T: TcEnv> SubstitutionOps<'a, T> {
                 let fn_def = fn_def_id.value();
                 let fn_ty = fn_def.ty;
                 let shadowed_sub = self.apply_sub_to_params_and_get_shadowed(fn_ty.params, sub);
-                self.apply_sub_to_term_in_place(fn_ty.return_ty, &shadowed_sub);
-                self.apply_sub_to_term_in_place(fn_def.body, &shadowed_sub);
+                self.apply_sub_in_place(fn_ty.return_ty, &shadowed_sub);
+                self.apply_sub_in_place(fn_def.body, &shadowed_sub);
                 ControlFlow::Break(())
             }
             Atom::Pat(_) => ControlFlow::Continue(()),
@@ -185,7 +185,7 @@ impl<'a, T: TcEnv> SubstitutionOps<'a, T> {
     pub fn atom_contains_vars(&self, atom: Atom, filter: &HashSet<SymbolId>) -> bool {
         let mut can_apply = false;
         self.traversing_utils
-            .visit_atom::<!, _>(atom, &mut |atom| {
+            .try_visit::<!, _>(atom, &mut |atom| {
                 Ok(self.atom_contains_vars_once(atom, filter, &mut can_apply))
             })
             .into_ok();
@@ -196,57 +196,32 @@ impl<'a, T: TcEnv> SubstitutionOps<'a, T> {
     pub fn can_apply_sub_to_atom(&self, atom: Atom, sub: &Sub) -> bool {
         let mut can_apply = false;
         self.traversing_utils
-            .visit_atom::<!, _>(atom, &mut |atom| {
+            .try_visit::<!, _>(atom, &mut |atom| {
                 Ok(self.can_apply_sub_to_atom_once(atom, sub, &mut can_apply))
             })
             .into_ok();
         can_apply
     }
 
-    pub fn apply_sub_to_term_in_place(&self, term_id: TermId, sub: &Sub) {
+    pub fn apply_sub_in_place<U>(&self, item: U, sub: &Sub)
+    where
+        Visitor: Visit<U>,
+    {
         self.traversing_utils
-            .visit_term::<!, _>(term_id, &mut |atom| {
-                Ok(self.apply_sub_to_atom_in_place_once(atom, sub))
-            })
+            .try_visit::<!, _>(
+                item,
+                &mut |atom| Ok(self.apply_sub_to_atom_in_place_once(atom, sub)),
+            )
             .into_ok()
     }
 
-    pub fn apply_sub_to_params_in_place(&self, params_id: ParamsId, sub: &Sub) {
-        self.traversing_utils
-            .visit_params::<!, _>(params_id, &mut |atom| {
-                Ok(self.apply_sub_to_atom_in_place_once(atom, sub))
-            })
-            .into_ok()
-    }
-
-    pub fn apply_sub_to_atom_in_place(&self, atom: Atom, sub: &Sub) {
-        self.traversing_utils
-            .visit_atom::<!, _>(atom, &mut |atom| {
-                Ok(self.apply_sub_to_atom_in_place_once(atom, sub))
-            })
-            .into_ok()
-    }
-
-    pub fn apply_sub_to_pat_args_in_place(&self, pat_args_id: PatArgsId, sub: &Sub) {
-        self.traversing_utils
-            .visit_pat_args::<!, _>(pat_args_id, &mut |atom| {
-                Ok(self.apply_sub_to_atom_in_place_once(atom, sub))
-            })
-            .into_ok()
-    }
-
-    pub fn apply_sub_to_args_in_place(&self, args_id: ArgsId, sub: &Sub) {
-        self.traversing_utils
-            .visit_args::<!, _>(args_id, &mut |atom| {
-                Ok(self.apply_sub_to_atom_in_place_once(atom, sub))
-            })
-            .into_ok()
-    }
-
-    pub fn apply_sub_to_atom_from_context(&self, atom: impl Into<Atom>) {
-        let atom = atom.into();
+    pub fn apply_sub_from_context<U>(&self, item: U)
+    where
+        Visitor: Visit<U>,
+    {
+        let atom = item;
         let sub = self.create_sub_from_current_scope();
-        self.apply_sub_to_atom_in_place(atom, &sub);
+        self.apply_sub_in_place(atom, &sub);
     }
 
     /// Determines whether the given atom contains a hole.
@@ -254,7 +229,7 @@ impl<'a, T: TcEnv> SubstitutionOps<'a, T> {
     /// If a hole is found, `ControlFlow::Break(())` is returned. Otherwise,
     /// `ControlFlow::Continue(())` is returned. `has_holes` is updated
     /// accordingly.
-    pub fn has_holes_once(&self, atom: Atom, has_holes: &mut Option<Atom>) -> ControlFlow<()> {
+    pub fn atom_has_holes_once(&self, atom: Atom, has_holes: &mut Option<Atom>) -> ControlFlow<()> {
         match atom {
             Atom::Term(term) => match *term.value() {
                 Term::Hole(_) => {
@@ -262,7 +237,7 @@ impl<'a, T: TcEnv> SubstitutionOps<'a, T> {
                     ControlFlow::Break(())
                 }
                 Term::Ctor(ctor_term) => {
-                    if let Some(atom) = self.args_have_holes(ctor_term.ctor_args) {
+                    if let Some(atom) = self.has_holes(ctor_term.ctor_args) {
                         *has_holes = Some(atom);
                     }
                     ControlFlow::Break(())
@@ -271,7 +246,7 @@ impl<'a, T: TcEnv> SubstitutionOps<'a, T> {
             },
             Atom::Pat(pat) => match *pat.value() {
                 Pat::Ctor(ctor_pat) => {
-                    if let Some(atom) = self.pat_args_have_holes(ctor_pat.ctor_pat_args) {
+                    if let Some(atom) = self.has_holes(ctor_pat.ctor_pat_args) {
                         *has_holes = Some(atom);
                     }
                     ControlFlow::Break(())
@@ -282,59 +257,14 @@ impl<'a, T: TcEnv> SubstitutionOps<'a, T> {
         }
     }
 
-    /// Determines whether the given atom contains one or more holes.
-    pub fn atom_has_holes(&self, atom: impl Into<Atom>) -> Option<Atom> {
+    /// Determines whether the given TIR node contains one or more holes.
+    pub fn has_holes<U>(&self, item: U) -> Option<Atom>
+    where
+        Visitor: Visit<U>,
+    {
         let mut has_holes = None;
         self.traversing_utils
-            .visit_atom::<!, _>(atom.into(), &mut |atom| {
-                Ok(self.has_holes_once(atom, &mut has_holes))
-            })
-            .into_ok();
-        has_holes
-    }
-
-    /// Determines whether the given module definition contains one or more
-    /// holes.
-    pub fn mod_def_has_holes(&self, mod_def_id: ModDefId) -> Option<Atom> {
-        let mut has_holes = None;
-        self.traversing_utils
-            .visit_mod_def::<!, _>(mod_def_id, &mut |atom| {
-                Ok(self.has_holes_once(atom, &mut has_holes))
-            })
-            .into_ok();
-        has_holes
-    }
-
-    /// Determines whether the given set of arguments contains one or more
-    /// holes.
-    pub fn pat_args_have_holes(&self, pat_args_id: PatArgsId) -> Option<Atom> {
-        let mut has_holes = None;
-        self.traversing_utils
-            .visit_pat_args::<!, _>(pat_args_id, &mut |atom| {
-                Ok(self.has_holes_once(atom, &mut has_holes))
-            })
-            .into_ok();
-        has_holes
-    }
-
-    /// Determines whether the given set of arguments contains one or more
-    /// holes.
-    pub fn args_have_holes(&self, args_id: ArgsId) -> Option<Atom> {
-        let mut has_holes = None;
-        self.traversing_utils
-            .visit_args::<!, _>(args_id, &mut |atom| Ok(self.has_holes_once(atom, &mut has_holes)))
-            .into_ok();
-        has_holes
-    }
-
-    /// Determines whether the given set of parameters contains one or more
-    /// holes.
-    pub fn params_have_holes(&self, params_id: ParamsId) -> Option<Atom> {
-        let mut has_holes = None;
-        self.traversing_utils
-            .visit_params::<!, _>(params_id, &mut |atom| {
-                Ok(self.has_holes_once(atom, &mut has_holes))
-            })
+            .try_visit::<!, _>(item, &mut |atom| Ok(self.atom_has_holes_once(atom, &mut has_holes)))
             .into_ok();
         has_holes
     }
@@ -382,40 +312,25 @@ impl<'a, T: TcEnv> SubstitutionOps<'a, T> {
     pub fn apply_sub_to_sub_in_place(&self, origin: &Sub, target: &Sub) -> Sub {
         let mut sub = Sub::identity();
         for (var, value) in target.iter() {
-            let value = self.apply_sub_to_term(value, origin);
+            let value = self.apply_sub(value, origin);
             sub.insert(var, value);
         }
         sub
     }
 
-    pub fn apply_sub_to_atom(&self, atom: Atom, sub: &Sub) -> Atom {
-        let copy = self.copy_atom(atom);
-        self.apply_sub_to_atom_in_place(copy, sub);
-        copy
-    }
-
-    pub fn apply_sub_to_args(&self, args: ArgsId, sub: &Sub) -> ArgsId {
-        let copy = self.copy_args(args);
-        self.apply_sub_to_args_in_place(copy, sub);
-        copy
-    }
-
-    pub fn apply_sub_to_params(&self, params: ParamsId, sub: &Sub) -> ParamsId {
-        let copy = self.copy_params(params);
-        self.apply_sub_to_params_in_place(copy, sub);
-        copy
-    }
-
-    pub fn apply_sub_to_term(&self, term: TermId, sub: &Sub) -> TermId {
-        let copy = self.copy_term(term);
-        self.apply_sub_to_term_in_place(copy, sub);
+    pub fn apply_sub<U: Copy>(&self, item: U, sub: &Sub) -> U
+    where
+        Visitor: Visit<U> + Map<U>,
+    {
+        let copy = self.traversing_utils.copy(item);
+        self.apply_sub_in_place(copy, sub);
         copy
     }
 
     /// Insert the given variable and value into the given substitution if
     /// the value is not a variable with the same name.
     pub fn insert_to_sub_if_needed(&self, sub: &mut Sub, name: SymbolId, value: TermId) {
-        let subbed_value = self.apply_sub_to_term(value, sub);
+        let subbed_value = self.apply_sub(value, sub);
         if !matches!(*subbed_value.value(), Term::Var(v) if v == name) {
             sub.insert(name, subbed_value);
         }
@@ -514,27 +429,5 @@ impl<'a, T: TcEnv> SubstitutionOps<'a, T> {
             }
         }
         reversed_sub
-    }
-
-    /// Copies an atom, returning a new atom.
-    pub fn copy_atom(&self, atom: Atom) -> Atom {
-        self.traversing_utils.fmap_atom::<!, _>(atom, |_a| Ok(ControlFlow::Continue(()))).into_ok()
-    }
-
-    /// Copies a type, returning a new type.
-    pub fn copy_term(&self, term: TermId) -> TermId {
-        self.traversing_utils.fmap_term::<!, _>(term, |_a| Ok(ControlFlow::Continue(()))).into_ok()
-    }
-
-    /// Copies parameters, returning new parameters.
-    pub fn copy_params(&self, params: ParamsId) -> ParamsId {
-        self.traversing_utils
-            .fmap_params::<!, _>(params, |_a| Ok(ControlFlow::Continue(())))
-            .into_ok()
-    }
-
-    /// Copies parameters, returning new parameters.
-    pub fn copy_args(&self, args: ArgsId) -> ArgsId {
-        self.traversing_utils.fmap_args::<!, _>(args, |_a| Ok(ControlFlow::Continue(()))).into_ok()
     }
 }

--- a/compiler/hash-typecheck/src/substitution.rs
+++ b/compiler/hash-typecheck/src/substitution.rs
@@ -185,10 +185,7 @@ impl<'a, T: TcEnv> SubstitutionOps<'a, T> {
     pub fn atom_contains_vars(&self, atom: Atom, filter: &HashSet<SymbolId>) -> bool {
         let mut can_apply = false;
         self.traversing_utils
-            .try_visit::<!, _>(atom, &mut |atom| {
-                Ok(self.atom_contains_vars_once(atom, filter, &mut can_apply))
-            })
-            .into_ok();
+            .visit(atom, &mut |atom| self.atom_contains_vars_once(atom, filter, &mut can_apply));
         can_apply
     }
 
@@ -196,10 +193,7 @@ impl<'a, T: TcEnv> SubstitutionOps<'a, T> {
     pub fn can_apply_sub_to_atom(&self, atom: Atom, sub: &Sub) -> bool {
         let mut can_apply = false;
         self.traversing_utils
-            .try_visit::<!, _>(atom, &mut |atom| {
-                Ok(self.can_apply_sub_to_atom_once(atom, sub, &mut can_apply))
-            })
-            .into_ok();
+            .visit(atom, &mut |atom| self.can_apply_sub_to_atom_once(atom, sub, &mut can_apply));
         can_apply
     }
 
@@ -208,11 +202,7 @@ impl<'a, T: TcEnv> SubstitutionOps<'a, T> {
         Visitor: Visit<U>,
     {
         self.traversing_utils
-            .try_visit::<!, _>(
-                item,
-                &mut |atom| Ok(self.apply_sub_to_atom_in_place_once(atom, sub)),
-            )
-            .into_ok()
+            .visit(item, &mut |atom| self.apply_sub_to_atom_in_place_once(atom, sub));
     }
 
     pub fn apply_sub_from_context<U>(&self, item: U)
@@ -264,8 +254,7 @@ impl<'a, T: TcEnv> SubstitutionOps<'a, T> {
     {
         let mut has_holes = None;
         self.traversing_utils
-            .try_visit::<!, _>(item, &mut |atom| Ok(self.atom_has_holes_once(atom, &mut has_holes)))
-            .into_ok();
+            .visit(item, &mut |atom| self.atom_has_holes_once(atom, &mut has_holes));
         has_holes
     }
 

--- a/compiler/hash-typecheck/src/unification.rs
+++ b/compiler/hash-typecheck/src/unification.rs
@@ -150,10 +150,10 @@ impl<'tc, T: TcEnv> UnificationOps<'tc, T> {
             })?;
 
             let forward_sub = self.sub_ops().create_sub_from_param_names(f1.params, f2.params);
-            f2.return_ty = self.sub_ops().apply_sub_to_term(f2.return_ty, &forward_sub);
+            f2.return_ty = self.sub_ops().apply_sub(f2.return_ty, &forward_sub);
 
             let backward_sub = self.sub_ops().create_sub_from_param_names(f2.params, f1.params);
-            f1.return_ty = self.sub_ops().apply_sub_to_term(f1.return_ty, &backward_sub);
+            f1.return_ty = self.sub_ops().apply_sub(f1.return_ty, &backward_sub);
 
             src_id.set(src_id.value().with_data(f1.into()));
             target_id.set(target_id.value().with_data(f2.into()));
@@ -222,7 +222,7 @@ impl<'tc, T: TcEnv> UnificationOps<'tc, T> {
             self.unify_terms(src_id, target_id)?;
             Ok(self.sub_ops().create_sub_from_current_scope())
         })?;
-        let subbed_initial = self.sub_ops().apply_sub_to_term(initial, &sub);
+        let subbed_initial = self.sub_ops().apply_sub(initial, &sub);
         self.add_unification_from_sub(&sub);
         Ok((subbed_initial, sub))
     }
@@ -396,8 +396,8 @@ impl<'tc, T: TcEnv> UnificationOps<'tc, T> {
 
                     // Unify the types
                     self.unify_terms(src_param.ty, target_param.ty)?;
-                    self.sub_ops().apply_sub_to_term_in_place(target_param.ty, &forward_sub);
-                    self.sub_ops().apply_sub_to_term_in_place(src_param.ty, &backward_sub);
+                    self.sub_ops().apply_sub_in_place(target_param.ty, &forward_sub);
+                    self.sub_ops().apply_sub_in_place(src_param.ty, &backward_sub);
                 }
 
                 // Run the in-scope closure


### PR DESCRIPTION
Instead of having `fmap_*` and `visit_*` functions for each TIR node, this PR replaces those with implementations of `Visit<*>` and `Map<*>`, so that functions can be implemented for any `T` that has `Map<T>` or `Visit<T>`. This reduces a lot of duplication in TC substitutions, and allows specialised functions to be created generically, for example to copy nodes, or to visit infallibly.