### PR TITLE
exhaustiveness: speedup checking 3x-5x

### DIFF
--- a/compiler/hash-driver/src/lib.rs
+++ b/compiler/hash-driver/src/lib.rs
@@ -65,7 +65,7 @@ impl CompilerBuilder {
                 Box::new(AstExpansionPass),
                 Box::new(AstDesugaringPass),
                 Box::new(UntypedSemanticAnalysis),
-                Box::new(SemanticAnalysis),
+                Box::<SemanticAnalysis>::default(),
                 Box::<IrGen>::default(),
                 Box::<IrOptimiser>::default(),
                 Box::<CodeGenPass>::default(),

--- a/compiler/hash-exhaustiveness/src/construct.rs
+++ b/compiler/hash-exhaustiveness/src/construct.rs
@@ -40,9 +40,7 @@ use crate::{
 
 /// The [DeconstructedCtor] represents the type of constructor that a pattern
 /// is.
-///
-/// @@Ranges: float ranges
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum DeconstructedCtor {
     /// The constructor for patterns that have a single constructor, like
     /// tuples, struct patterns and fixed-length arrays.

--- a/compiler/hash-exhaustiveness/src/deconstruct.rs
+++ b/compiler/hash-exhaustiveness/src/deconstruct.rs
@@ -9,7 +9,7 @@ use std::{
     fmt::{self, Debug},
 };
 
-use hash_storage::store::{statics::StoreId, Store};
+use hash_storage::store::statics::StoreId;
 use hash_tir::{
     intrinsics::utils::try_use_ty_as_array_ty,
     tir::{CtorDefId, DataTy, NodesId, PatId, Ty, TyId},
@@ -84,7 +84,7 @@ impl<E: ExhaustivenessEnv> ExhaustivenessChecker<'_, E> {
     /// from the provided type in the context, this is only to be used
     /// when creating `match-all` wildcard patterns.
     pub(super) fn wildcard_from_ctor(
-        &self,
+        &mut self,
         ctx: PatCtx,
         ctor_id: DeconstructedCtorId,
     ) -> DeconstructedPat {
@@ -95,15 +95,14 @@ impl<E: ExhaustivenessEnv> ExhaustivenessChecker<'_, E> {
 
     /// Create a new wildcard [DeconstructedPat], primarily used when
     /// performing specialisations.
-    pub(super) fn wildcard_from_ty(&self, ty: TyId) -> DeconstructedPat {
-        let ctor = self.ctor_store().create(DeconstructedCtor::Wildcard);
-
+    pub(super) fn wildcard_from_ty(&mut self, ty: TyId) -> DeconstructedPat {
+        let ctor = self.make_ctor(DeconstructedCtor::Wildcard);
         DeconstructedPat::new(ctor, Fields::empty(), ty, None)
     }
 
     /// Check whether this [DeconstructedPat] is an `or` pattern.
     pub(super) fn is_or_pat(&self, pat: &DeconstructedPat) -> bool {
-        self.ctor_store().map_fast(pat.ctor, |ctor| matches!(ctor, DeconstructedCtor::Or))
+        matches!(self.get_ctor(pat.ctor), DeconstructedCtor::Or)
     }
 
     /// Perform a `specialisation` on the current [DeconstructedPat]. This means
@@ -111,14 +110,14 @@ impl<E: ExhaustivenessEnv> ExhaustivenessChecker<'_, E> {
     /// will be turned into multiple `specialised` variants of the
     /// constructor,
     pub(super) fn specialise(
-        &self,
+        &mut self,
         ctx: PatCtx,
         pat_id: DeconstructedPatId,
         other_ctor_id: DeconstructedCtorId,
     ) -> SmallVec<[DeconstructedPatId; 2]> {
-        let pat = self.get_deconstructed_pat(pat_id);
-        let pat_ctor = self.get_deconstructed_ctor(pat.ctor);
-        let other_ctor = self.get_deconstructed_ctor(other_ctor_id);
+        let pat = self.get_pat(pat_id);
+        let pat_ctor = self.get_ctor(pat.ctor);
+        let other_ctor = self.get_ctor(other_ctor_id);
 
         match (pat_ctor, other_ctor) {
             (DeconstructedCtor::Wildcard, _) => {
@@ -138,15 +137,17 @@ impl<E: ExhaustivenessEnv> ExhaustivenessChecker<'_, E> {
                     ArrayKind::Fixed(_) => panic!("{this_list:?} cannot cover {other_list:?}"),
                     ArrayKind::Var(prefix, suffix) => {
                         let array_ty = try_use_ty_as_array_ty(ctx.ty).unwrap();
+                        let this_arity = this_list.arity();
+                        let other_arity = other_list.arity();
 
                         let prefix = pat.fields.fields[..prefix].to_vec();
-                        let suffix = pat.fields.fields[this_list.arity() - suffix..].to_vec();
+                        let suffix = pat.fields.fields[this_arity - suffix..].to_vec();
 
                         let wildcard = self.wildcard_from_ty(array_ty.element_ty);
 
-                        let extra_wildcards = other_list.arity() - this_list.arity();
+                        let extra_wildcards = other_arity - this_arity;
                         let extra_wildcards = (0..extra_wildcards)
-                            .map(|_| self.deconstructed_pat_store().create(wildcard.clone()))
+                            .map(|_| self.make_pat(wildcard.clone()))
                             .collect_vec();
 
                         prefix.into_iter().chain(extra_wildcards).chain(suffix).collect()
@@ -173,8 +174,8 @@ impl<E: ExhaustivenessEnv> ExhaustivenessChecker<'_, E> {
             spans.push(pat.id.unwrap());
         } else {
             for p in pat.fields.iter_patterns() {
-                let p = self.get_deconstructed_pat(p);
-                self.collect_unreachable_pats(&p, spans);
+                let p = self.get_pat(p);
+                self.collect_unreachable_pats(p, spans);
             }
         }
     }
@@ -182,9 +183,6 @@ impl<E: ExhaustivenessEnv> ExhaustivenessChecker<'_, E> {
 
 impl<E: ExhaustivenessEnv> fmt::Debug for ExhaustivenessFmtCtx<'_, DeconstructedPatId, E> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let pat_store = self.checker.deconstructed_pat_store();
-        let ctor_store = self.checker.ctor_store();
-
         // Utility for printing a joined list of things...
         let mut first = true;
         let mut start_or_continue = |s| {
@@ -196,86 +194,84 @@ impl<E: ExhaustivenessEnv> fmt::Debug for ExhaustivenessFmtCtx<'_, Deconstructed
             }
         };
 
-        pat_store.map_fast(self.item, |pat| {
-            ctor_store.map_fast(pat.ctor, |ctor| {
-                match ctor {
-                    DeconstructedCtor::Single | DeconstructedCtor::Variant(_) => {
-                        match *pat.ty.value() {
-                            Ty::TupleTy(_) => {}
-                            Ty::DataTy(ty @ DataTy { data_def, .. }) => {
-                                write!(f, "{ty}")?;
+        let pat = self.checker.get_pat(self.item);
+        let ctor = self.checker.get_ctor(pat.ctor);
 
-                                // If we have a variant, we print the specific variant that is
-                                // currently active.
-                                if let DeconstructedCtor::Variant(index) = ctor {
-                                    let ctors = data_def.borrow().ctors.assert_defined();
-                                    let ctor_name =
-                                        CtorDefId(ctors.elements(), *index).borrow().name;
-                                    write!(f, "::{ctor_name}")?;
-                                }
-                            }
-                            _ => {
-                                panic!("unexpected ty `{}` when printing deconstructed pat", pat.ty)
-                            }
-                        };
+        match ctor {
+            DeconstructedCtor::Single | DeconstructedCtor::Variant(_) => {
+                match *pat.ty.value() {
+                    Ty::TupleTy(_) => {}
+                    Ty::DataTy(ty @ DataTy { data_def, .. }) => {
+                        write!(f, "{ty}")?;
 
-                        write!(f, "(")?;
-
-                        for p in pat.fields.iter_patterns() {
-                            write!(f, "{}", start_or_continue(", "))?;
-                            write!(f, "{:?}", self.with(p))?;
+                        // If we have a variant, we print the specific variant that is
+                        // currently active.
+                        if let DeconstructedCtor::Variant(index) = ctor {
+                            let ctors = data_def.borrow().ctors.assert_defined();
+                            let ctor_name = CtorDefId(ctors.elements(), *index).borrow().name;
+                            write!(f, "::{ctor_name}")?;
                         }
-                        write!(f, ")")
                     }
-                    DeconstructedCtor::IntRange(range) => write!(f, "{range:?}"),
-                    DeconstructedCtor::Str(value) => write!(f, "{value}"),
-                    DeconstructedCtor::Array(list) => {
-                        let mut sub_patterns = pat.fields.iter_patterns();
+                    _ => {
+                        panic!("unexpected ty `{}` when printing deconstructed pat", pat.ty)
+                    }
+                };
 
-                        write!(f, "[")?;
+                write!(f, "(")?;
 
-                        match list.kind {
-                            ArrayKind::Fixed(_) => {
-                                for p in sub_patterns {
-                                    write!(f, "{}{p:?}", start_or_continue(","))?;
-                                }
-                            }
-                            ArrayKind::Var(prefix, _) => {
-                                for p in sub_patterns.by_ref().take(prefix) {
-                                    write!(f, "{}{:?}", start_or_continue(", "), self.with(p))?;
-                                }
-                                write!(f, "{}", start_or_continue(", "))?;
-                                write!(f, "..")?;
-                                for p in sub_patterns {
-                                    write!(f, "{}{:?}", start_or_continue(", "), self.with(p))?;
-                                }
-                            }
+                for p in pat.fields.iter_patterns() {
+                    write!(f, "{}", start_or_continue(", "))?;
+                    write!(f, "{:?}", self.with(p))?;
+                }
+                write!(f, ")")
+            }
+            DeconstructedCtor::IntRange(range) => write!(f, "{range:?}"),
+            DeconstructedCtor::Str(value) => write!(f, "{value}"),
+            DeconstructedCtor::Array(list) => {
+                let mut sub_patterns = pat.fields.iter_patterns();
+
+                write!(f, "[")?;
+
+                match list.kind {
+                    ArrayKind::Fixed(_) => {
+                        for p in sub_patterns {
+                            write!(f, "{}{p:?}", start_or_continue(","))?;
                         }
-
-                        write!(f, "]")
                     }
-                    DeconstructedCtor::Or => {
-                        for pat in pat.fields.iter_patterns() {
-                            write!(f, "{}{:?}", start_or_continue(" | "), self.with(pat))?;
+                    ArrayKind::Var(prefix, _) => {
+                        for p in sub_patterns.by_ref().take(prefix) {
+                            write!(f, "{}{:?}", start_or_continue(", "), self.with(p))?;
                         }
-                        Ok(())
-                    }
-                    ctor @ (DeconstructedCtor::Wildcard
-                    | DeconstructedCtor::Missing
-                    | DeconstructedCtor::NonExhaustive) => {
-                        // Just for clarity, we want to also print what specific `wildcard`
-                        // constructor it is
-                        let prefix = match ctor {
-                            DeconstructedCtor::Wildcard => "_",
-                            DeconstructedCtor::Missing => "?",
-                            DeconstructedCtor::NonExhaustive => "∞",
-                            _ => unreachable!(),
-                        };
-
-                        write!(f, "{prefix} : {}", pat.ty)
+                        write!(f, "{}", start_or_continue(", "))?;
+                        write!(f, "..")?;
+                        for p in sub_patterns {
+                            write!(f, "{}{:?}", start_or_continue(", "), self.with(p))?;
+                        }
                     }
                 }
-            })
-        })
+
+                write!(f, "]")
+            }
+            DeconstructedCtor::Or => {
+                for pat in pat.fields.iter_patterns() {
+                    write!(f, "{}{:?}", start_or_continue(" | "), self.with(pat))?;
+                }
+                Ok(())
+            }
+            ctor @ (DeconstructedCtor::Wildcard
+            | DeconstructedCtor::Missing
+            | DeconstructedCtor::NonExhaustive) => {
+                // Just for clarity, we want to also print what specific `wildcard`
+                // constructor it is
+                let prefix = match ctor {
+                    DeconstructedCtor::Wildcard => "_",
+                    DeconstructedCtor::Missing => "?",
+                    DeconstructedCtor::NonExhaustive => "∞",
+                    _ => unreachable!(),
+                };
+
+                write!(f, "{prefix} : {}", pat.ty)
+            }
+        }
     }
 }

--- a/compiler/hash-exhaustiveness/src/fields.rs
+++ b/compiler/hash-exhaustiveness/src/fields.rs
@@ -7,7 +7,7 @@
 //! [Fields] with the typechecker context available for reading and creating
 //! [DeconstructedPat](super::deconstruct::DeconstructedPat)s.
 
-use hash_storage::store::{statics::StoreId, Store};
+use hash_storage::store::statics::StoreId;
 use hash_tir::{
     intrinsics::utils::try_use_ty_as_array_ty,
     tir::{CtorDefId, DataDefCtors, DataTy, NodesId, TupleTy, Ty, TyId},
@@ -59,17 +59,17 @@ impl FromIterator<DeconstructedPatId> for Fields {
 
 impl<E: ExhaustivenessEnv> ExhaustivenessChecker<'_, E> {
     /// Create [Fields] from an [Iterator] of [Ty]s.
-    pub fn wildcards_from_tys(&self, tys: impl IntoIterator<Item = TyId>) -> Fields {
+    pub fn wildcards_from_tys(&mut self, tys: impl IntoIterator<Item = TyId>) -> Fields {
         Fields::from_iter(tys.into_iter().map(|ty| {
             let pat = self.wildcard_from_ty(ty);
-            self.deconstructed_pat_store().create(pat)
+            self.make_pat(pat)
         }))
     }
 
     /// Creates a new list of wildcard fields for a given constructor. The
     /// result will have a length of `ctor.arity()`.
-    pub(super) fn wildcards_from_ctor(&self, ctx: PatCtx, ctor: DeconstructedCtorId) -> Fields {
-        let ctor = self.get_deconstructed_ctor(ctor);
+    pub(super) fn wildcards_from_ctor(&mut self, ctx: PatCtx, ctor: DeconstructedCtorId) -> Fields {
+        let ctor = self.get_ctor(ctor);
 
         match ctor {
             ctor @ (DeconstructedCtor::Single | DeconstructedCtor::Variant(_)) => {
@@ -82,7 +82,7 @@ impl<E: ExhaustivenessEnv> ExhaustivenessChecker<'_, E> {
                     Ty::DataTy(DataTy { data_def, .. }) => {
                         // get the variant index from the deconstructed ctor
                         let variant_idx =
-                            if let DeconstructedCtor::Variant(idx) = ctor { idx } else { 0 };
+                            if let DeconstructedCtor::Variant(idx) = ctor { *idx } else { 0 };
 
                         // We know that this has to be a non-primitive, so we can immediately get
                         // the variant from the data definition

--- a/compiler/hash-exhaustiveness/src/fields.rs
+++ b/compiler/hash-exhaustiveness/src/fields.rs
@@ -12,7 +12,10 @@ use hash_tir::{
     intrinsics::utils::try_use_ty_as_array_ty,
     tir::{CtorDefId, DataDefCtors, DataTy, NodesId, TupleTy, Ty, TyId},
 };
-use hash_utils::itertools::Itertools;
+use hash_utils::{
+    itertools::Itertools,
+    thin_vec::{thin_vec, ThinVec},
+};
 
 use super::construct::DeconstructedCtor;
 use crate::{
@@ -26,13 +29,13 @@ use crate::{
 #[derive(Debug, Clone)]
 pub struct Fields {
     /// Vector of the inner ids stored by the [Fields]
-    pub fields: Vec<DeconstructedPatId>,
+    pub fields: ThinVec<DeconstructedPatId>,
 }
 
 impl Fields {
     /// Create a [Fields] with no inner elements.
     pub fn empty() -> Self {
-        Fields { fields: vec![] }
+        Fields { fields: thin_vec![] }
     }
 
     /// Returns an [Iterator] of the inner stored [DeconstructedPatId]s.

--- a/compiler/hash-exhaustiveness/src/lower.rs
+++ b/compiler/hash-exhaustiveness/src/lower.rs
@@ -6,7 +6,7 @@ use hash_ast::ast::RangeEnd;
 use hash_source::constant::InternedInt;
 use hash_storage::store::{
     statics::{SequenceStoreValue, StoreId},
-    SequenceStoreKey, Store, TrivialSequenceStoreKey,
+    SequenceStoreKey, TrivialSequenceStoreKey,
 };
 use hash_target::HasTarget;
 use hash_tir::{
@@ -70,11 +70,11 @@ impl<E: HasTarget> ExhaustivenessChecker<'_, E> {
     /// Performs a lowering operation on all of the specified branches.
     ///
     /// This takes in the `term` which is the type of the subject.
-    pub(crate) fn lower_pats_to_arms(&self, pats: &[PatId], ty: TyId) -> Vec<MatchArm> {
+    pub(crate) fn lower_pats_to_arms(&mut self, pats: &[PatId], ty: TyId) -> Vec<MatchArm> {
         pats.iter()
             .map(|id| {
                 let destructed_pat = self.deconstruct_pat(ty, *id);
-                let pat = self.deconstructed_pat_store().create(destructed_pat);
+                let pat = self.make_pat(destructed_pat);
 
                 MatchArm {
                     deconstructed_pat: pat,
@@ -86,7 +86,7 @@ impl<E: HasTarget> ExhaustivenessChecker<'_, E> {
     }
 
     /// Convert a [Pat] into a [DeconstructedPat].
-    pub(crate) fn deconstruct_pat(&self, ty_id: TyId, pat_id: PatId) -> DeconstructedPat {
+    pub(crate) fn deconstruct_pat(&mut self, ty_id: TyId, pat_id: PatId) -> DeconstructedPat {
         let (ctor, fields) = match *pat_id.value() {
             Pat::Binding(_) => (DeconstructedCtor::Wildcard, vec![]),
             Pat::Range(range) => {
@@ -217,14 +217,12 @@ impl<E: HasTarget> ExhaustivenessChecker<'_, E> {
             }
         };
 
-        let ctor = self.ctor_store().create(ctor);
+        let ctor = self.make_ctor(ctor);
 
         // Now we need to put them in the store...
         DeconstructedPat::new(
             ctor,
-            Fields::from_iter(
-                fields.into_iter().map(|field| self.deconstructed_pat_store().create(field)),
-            ),
+            Fields::from_iter(fields.into_iter().map(|field| self.make_pat(field))),
             ty_id,
             Some(pat_id),
         )
@@ -232,19 +230,15 @@ impl<E: HasTarget> ExhaustivenessChecker<'_, E> {
 
     // Convert a [DeconstructedPat] into a [Pat].
     pub(crate) fn construct_pat(&self, pat: DeconstructedPatId) -> PatId {
-        let deconstructed_store = self.deconstructed_pat_store();
-        let ctor_store = self.ctor_store();
+        let DeconstructedPat { ty, fields, id, ctor, .. } = self.get_pat(pat);
 
-        deconstructed_store.map_fast(pat, |deconstructed| {
-            let DeconstructedPat {ty, fields, ..} = deconstructed;
+        // Short-circuit, if the pattern already has an associated `PatId`...
+        if let Some(id) = id {
+            return *id;
+        }
 
-            // Short-circuit, if the pattern already has an associated `PatId`...
-            if deconstructed.id.is_some() {
-                return deconstructed.id.unwrap();
-            }
-
-            ctor_store.map_fast(deconstructed.ctor, |ctor| {
-                let pat = match ctor {
+        let ctor = self.get_ctor(*ctor);
+        let pat = match ctor {
                     DeconstructedCtor::Single | DeconstructedCtor::Variant(_) => {
                         match *ty.value() {
                             Ty::DataTy(DataTy { data_def, args }) => {
@@ -292,10 +286,8 @@ impl<E: HasTarget> ExhaustivenessChecker<'_, E> {
                     ),
                 };
 
-                // Now put the pat on the store and return it
-                Node::create_at(pat, NodeOrigin::Generated)
-            })
-        })
+        // Now put the pat on the store and return it
+        Node::create_at(pat, NodeOrigin::Generated)
     }
 
     /// Construct pattern arguments from provided [ParamsId].
@@ -306,7 +298,7 @@ impl<E: HasTarget> ExhaustivenessChecker<'_, E> {
         let fields = fields
             .iter_patterns()
             .enumerate()
-            .filter(|(_, p)| !self.get_deconstructed_pat_ctor(*p).is_wildcard())
+            .filter(|(_, p)| !self.get_pat_ctor(*p).is_wildcard())
             .map(|(index, p)| {
                 Node::at(
                     PatArg {

--- a/compiler/hash-exhaustiveness/src/matrix.rs
+++ b/compiler/hash-exhaustiveness/src/matrix.rs
@@ -48,9 +48,9 @@ impl<E: ExhaustivenessEnv> ExhaustivenessChecker<'_, E> {
     /// this recursively expands it.
     pub(crate) fn push_matrix_row(&self, matrix: &mut Matrix, row: PatStack) {
         if !row.is_empty() {
-            let pat = self.get_deconstructed_pat(row.head());
+            let pat = self.get_pat(row.head());
 
-            if self.is_or_pat(&pat) {
+            if self.is_or_pat(pat) {
                 return matrix.patterns.extend(self.expand_or_pat(&row));
             }
         }
@@ -60,22 +60,22 @@ impl<E: ExhaustivenessEnv> ExhaustivenessChecker<'_, E> {
 
     /// This computes `S(constructor, matrix)`.
     pub(crate) fn specialise_ctor(
-        &self,
+        &mut self,
         ctx: PatCtx,
         matrix: &Matrix,
         ctor_id: DeconstructedCtorId,
     ) -> Matrix {
         let mut specialised_matrix = Matrix::empty();
-        let ctor = self.get_deconstructed_ctor(ctor_id);
+        let ctor = *self.get_ctor(ctor_id);
 
         // Iterate on each row, and specialise the `head` of
         // each row within the matrix with the provided constructor,
         // the results of the specialisation as new rows in
         // the matrix.
         for row in &matrix.patterns {
-            let row_head_ctor = self.get_deconstructed_pat_ctor(row.head());
+            let row_head_ctor = self.get_pat_ctor(row.head());
 
-            if self.is_ctor_covered_by(&ctor, &row_head_ctor) {
+            if self.is_ctor_covered_by(&ctor, row_head_ctor) {
                 let new_row = self.pop_head_ctor(ctx, row, ctor_id);
                 self.push_matrix_row(&mut specialised_matrix, new_row);
             }

--- a/compiler/hash-exhaustiveness/src/range.rs
+++ b/compiler/hash-exhaustiveness/src/range.rs
@@ -52,19 +52,14 @@ use crate::{
 /// which are represented in this format. [IntRange] is a useful abstraction to
 /// represent these data types rather than listing all of the possible
 /// constructors that these data types have.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 
 pub struct IntRange {
     /// The beginning of the represented range
     pub(super) start: u128,
+
     /// The end of the represented range
     pub(super) end: u128,
-
-    /// Keeps the bias used for encoding the range. It depends on the type of
-    /// the range and possibly the pointer size of the current architecture.
-    /// The algorithm ensures we never compare `IntRange`s with different
-    /// types/architectures.
-    pub bias: u128,
 }
 
 impl IntRange {
@@ -85,7 +80,7 @@ impl IntRange {
         let (other_lo, other_hi) = other.boundaries();
 
         if lo <= other_hi && other_lo <= hi {
-            Some(IntRange { start: max(lo, other_lo), end: min(hi, other_hi), bias: self.bias })
+            Some(IntRange { start: max(lo, other_lo), end: min(hi, other_hi) })
         } else {
             None
         }
@@ -129,9 +124,25 @@ impl IntRange {
     }
 }
 
-impl fmt::Debug for IntRange {
+/// This is used to print [IntRange] with the actual values of the range
+/// rather than the bias encoded ones.
+pub struct IntRangeWithBias {
+    /// The beginning of the represented range
+    range: IntRange,
+
+    /// The bias of the represented range
+    bias: u128,
+}
+
+impl IntRangeWithBias {
+    pub fn new(range: IntRange, bias: u128) -> Self {
+        IntRangeWithBias { range, bias }
+    }
+}
+
+impl fmt::Debug for IntRangeWithBias {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let (lo, hi) = self.boundaries();
+        let (lo, hi) = self.range.boundaries();
         let bias = self.bias;
         let (lo, hi) = (lo ^ bias, hi ^ bias);
 
@@ -170,7 +181,7 @@ pub enum IntBorder {
 /// ```text
 ///   ||---|--||-|---|---|---|--|
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct SplitIntRange {
     /// The range we are splitting
     range: IntRange,
@@ -237,7 +248,7 @@ impl SplitIntRange {
                     (IntBorder::JustBefore(n), IntBorder::AfterMax) => (n, u128::MAX),
                     _ => unreachable!(), // Ruled out by the sorting and filtering we did
                 };
-                IntRange { start, end, bias: self.range.bias }
+                IntRange { start, end }
             })
     }
 }
@@ -250,7 +261,7 @@ impl<E: ExhaustivenessEnv> ExhaustivenessChecker<'_, E> {
 
         // read from the constant the actual bits and apply bias
         let val = constant.data() ^ bias;
-        IntRange { start: val, end: val, bias }
+        IntRange { start: val, end: val }
     }
 
     /// Create an [IntRange] from two specified bounds, and assuming that the
@@ -264,7 +275,7 @@ impl<E: ExhaustivenessEnv> ExhaustivenessChecker<'_, E> {
             panic!("malformed range pattern: {lo}..{}", (hi - offset));
         }
 
-        IntRange { start: lo, end: hi - offset, bias }
+        IntRange { start: lo, end: hi - offset /* bias */ }
     }
 
     /// Get the bias based on the type, if it is a signed, integer then

--- a/compiler/hash-exhaustiveness/src/range.rs
+++ b/compiler/hash-exhaustiveness/src/range.rs
@@ -37,7 +37,6 @@ use std::{
 
 use hash_ast::ast::RangeEnd;
 use hash_reporting::diagnostic::Diagnostics;
-use hash_storage::store::Store;
 use hash_tir::{
     intrinsics::utils::try_use_ty_as_int_ty,
     tir::{PatId, RangePat, TyId},
@@ -328,9 +327,8 @@ impl<E: ExhaustivenessEnv> ExhaustivenessChecker<'_, E> {
 
         let overlaps: Vec<_> = pats
             .filter_map(|pat| {
-                let d = self.get_deconstructed_pat(pat);
-                let ctor = self.ctor_store().map_fast(d.ctor, |c| c.as_int_range().cloned())?;
-
+                let d = self.get_pat(pat);
+                let ctor = self.get_ctor(d.ctor).as_int_range().copied()?;
                 Some((ctor, d.id.unwrap()))
             })
             .filter(|(other_range, _)| range.suspicious_intersection(other_range))

--- a/compiler/hash-exhaustiveness/src/stack.rs
+++ b/compiler/hash-exhaustiveness/src/stack.rs
@@ -59,7 +59,7 @@ impl<E: ExhaustivenessEnv> ExhaustivenessChecker<'_, E> {
     ///
     /// Panics if `self` is empty.
     pub(crate) fn expand_or_pat(&self, stack: &PatStack) -> Vec<PatStack> {
-        let pat = self.get_deconstructed_pat(stack.head());
+        let pat = self.get_pat(stack.head());
 
         pat.fields
             .iter_patterns()
@@ -81,7 +81,7 @@ impl<E: ExhaustivenessEnv> ExhaustivenessChecker<'_, E> {
     ///
     /// This is roughly the inverse of `Constructor::apply`.
     pub(crate) fn pop_head_ctor(
-        &self,
+        &mut self,
         ctx: PatCtx,
         stack: &PatStack,
         ctor: DeconstructedCtorId,

--- a/compiler/hash-exhaustiveness/src/storage.rs
+++ b/compiler/hash-exhaustiveness/src/storage.rs
@@ -1,31 +1,74 @@
 //! Stores [DeconstructedPat]s and [DeconstructedCtor]s.'
-use hash_storage::{new_store_key, store::DefaultStore};
+use hash_utils::index_vec::{define_index_type, IndexVec};
 
-use crate::{construct::DeconstructedCtor, deconstruct::DeconstructedPat};
+use crate::{
+    construct::DeconstructedCtor, deconstruct::DeconstructedPat, ExhaustivenessChecker,
+    ExhaustivenessEnv,
+};
 
-new_store_key!(pub DeconstructedPatId, derives = Debug);
-pub type DeconstructedPatStore = DefaultStore<DeconstructedPatId, DeconstructedPat>;
+define_index_type! {
+    /// Id of a [DeconstructedPat] in the [ExhaustivenessCtx].
+    pub struct DeconstructedPatId = u32;
 
-new_store_key!(pub DeconstructedCtorId, derives = Debug);
-pub type DeconstructedCtorStore = DefaultStore<DeconstructedCtorId, DeconstructedCtor>;
+    MAX_INDEX = u32::max_value() as usize;
+    DISABLE_MAX_INDEX_CHECK = cfg!(not(debug_assertions));
+}
+
+define_index_type! {
+    /// Id of a [DeconstructedCtor] in the [ExhaustivenessCtx].
+    pub struct DeconstructedCtorId = u32;
+
+    MAX_INDEX = u32::max_value() as usize;
+    DISABLE_MAX_INDEX_CHECK = cfg!(not(debug_assertions));
+}
+
+pub type DeconstructedPatStore = IndexVec<DeconstructedPatId, DeconstructedPat>;
+
+pub type DeconstructedCtorStore = IndexVec<DeconstructedCtorId, DeconstructedCtor>;
 
 /// The [ExhaustivenessStorage] holds data structures that are used during
 /// exhaustiveness checking as intermediate representations of patterns.
 #[derive(Debug, Default)]
-pub struct ExhaustivenessCtx {
+pub(crate) struct ExhaustivenessCtx {
     /// The [crate::deconstruct::DeconstructedPat] store.
-    pub deconstructed_pat_store: DeconstructedPatStore,
+    pub(crate) dp: DeconstructedPatStore,
 
     /// The [crate::construct::DeconstructedCtor] store.
-    pub deconstructed_ctor_store: DeconstructedCtorStore,
+    pub(crate) dc: DeconstructedCtorStore,
 }
 
 impl ExhaustivenessCtx {
     /// Create a new [ExhaustivenessCtx].
     pub fn new() -> Self {
-        Self {
-            deconstructed_ctor_store: DefaultStore::new(),
-            deconstructed_pat_store: DefaultStore::new(),
-        }
+        Self { dc: IndexVec::new(), dp: IndexVec::new() }
+    }
+}
+
+impl<'env, E: ExhaustivenessEnv> ExhaustivenessChecker<'env, E> {
+    pub(crate) fn get_ctor(&self, id: DeconstructedCtorId) -> &DeconstructedCtor {
+        &self.ecx.dc[id]
+    }
+
+    pub(crate) fn get_pat(&self, id: DeconstructedPatId) -> &DeconstructedPat {
+        &self.ecx.dp[id]
+    }
+
+    pub(crate) fn get_pat_ctor(&self, id: DeconstructedPatId) -> &DeconstructedCtor {
+        self.get_ctor(self.get_pat(id).ctor)
+    }
+
+    pub(crate) fn get_pat_mut(&mut self, id: DeconstructedPatId) -> &mut DeconstructedPat {
+        &mut self.ecx.dp[id]
+    }
+
+    pub(crate) fn make_pat(&mut self, deconstructed_pat: DeconstructedPat) -> DeconstructedPatId {
+        self.ecx.dp.push(deconstructed_pat)
+    }
+
+    pub(crate) fn make_ctor(
+        &mut self,
+        deconstructed_ctor: DeconstructedCtor,
+    ) -> DeconstructedCtorId {
+        self.ecx.dc.push(deconstructed_ctor)
     }
 }

--- a/compiler/hash-exhaustiveness/src/storage.rs
+++ b/compiler/hash-exhaustiveness/src/storage.rs
@@ -28,7 +28,7 @@ pub type DeconstructedCtorStore = IndexVec<DeconstructedCtorId, DeconstructedCto
 
 /// The [ExhaustivenessStorage] holds data structures that are used during
 /// exhaustiveness checking as intermediate representations of patterns.
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub(crate) struct ExhaustivenessCtx {
     /// The [crate::deconstruct::DeconstructedPat] store.
     pub(crate) dp: DeconstructedPatStore,

--- a/compiler/hash-exhaustiveness/src/usefulness.rs
+++ b/compiler/hash-exhaustiveness/src/usefulness.rs
@@ -7,7 +7,6 @@
 //! is detailed within [super].
 use std::iter::once;
 
-use hash_storage::store::Store;
 use hash_tir::tir::{PatId, TyId};
 use hash_utils::{itertools::Itertools, stack::ensure_sufficient_stack};
 
@@ -157,7 +156,7 @@ impl<E: ExhaustivenessEnv> ExhaustivenessChecker<'_, E> {
     /// left_ty: struct `X := struct(a: (bool, str), b: u32)`
     /// pats: `[(false, "foo"), 42]  => X( a = (false, "foo"), b = 42)`
     fn apply_constructor_on_witness(
-        &self,
+        &mut self,
         ctx: PatCtx,
         mut witness: Witness,
         ctor: DeconstructedCtorId,
@@ -172,7 +171,7 @@ impl<E: ExhaustivenessEnv> ExhaustivenessChecker<'_, E> {
             DeconstructedPat::new(ctor, fields, ctx.ty, None)
         };
 
-        let pat = self.deconstructed_pat_store().create(pat);
+        let pat = self.make_pat(pat);
         witness.0.push(pat);
         witness
     }
@@ -182,7 +181,7 @@ impl<E: ExhaustivenessEnv> ExhaustivenessChecker<'_, E> {
     /// pre-specialization. This new usefulness can then be merged
     /// with the results of specializing with the other constructors.
     fn apply_ctor(
-        &self,
+        &mut self,
         ctx: PatCtx,
         usefulness: Usefulness,
         matrix: &Matrix, // used to compute missing ctors
@@ -192,27 +191,24 @@ impl<E: ExhaustivenessEnv> ExhaustivenessChecker<'_, E> {
             Usefulness::NoWitnesses { .. } => usefulness,
             Usefulness::WithWitnesses(ref witnesses) if witnesses.is_empty() => usefulness,
             Usefulness::WithWitnesses(witnesses) => {
-                let new_witnesses = if self
-                    .ctor_store()
-                    .map_fast(ctor_id, |ctor| matches!(ctor, DeconstructedCtor::Missing))
+                let new_witnesses = if matches!(self.get_ctor(ctor_id), DeconstructedCtor::Missing)
                 {
                     // We got the special `Missing` constructor, so each of the missing constructors
                     // gives a new  pattern that is not caught by the match. We
                     // list those patterns.
                     let mut wildcard = self.split_wildcard_from_pat_ctx(ctx);
 
-                    let ctors = matrix.heads().map(|id| self.get_deconstructed_pat(id).ctor);
+                    let ctors = matrix.heads().map(|id| self.get_pat(id).ctor).collect_vec();
 
-                    self.split_wildcard(ctx, &mut wildcard, ctors);
+                    self.split_wildcard(ctx, &mut wildcard, ctors.into_iter());
 
                     // Get all the missing constructors for the current type
-                    let new_pats = self
-                        .iter_missing_ctors(&wildcard)
-                        .map(|missing_ctor| {
-                            let pat = self.wildcard_from_ctor(ctx, missing_ctor);
-                            self.deconstructed_pat_store().create(pat)
-                        })
-                        .collect_vec();
+                    let mut new_pats = vec![];
+                    let missing_ctors = self.iter_missing_ctors(&wildcard).collect_vec();
+                    for missing_ctor in missing_ctors {
+                        let pat = self.wildcard_from_ctor(ctx, missing_ctor);
+                        new_pats.push(self.make_pat(pat));
+                    }
 
                     // Prepare new witnesses by attaching each of the `new_pats` to the end of
                     // old witness `ids`
@@ -234,10 +230,9 @@ impl<E: ExhaustivenessEnv> ExhaustivenessChecker<'_, E> {
                                 .map(|pat| {
                                     // Clone and forget the `pat` and then forget that that it is
                                     // reachable
-                                    let new_pat = self.get_deconstructed_pat(*pat);
+                                    let new_pat = self.get_pat(*pat).clone();
                                     new_pat.reachable.set(false);
-
-                                    self.deconstructed_pat_store().create(new_pat)
+                                    self.make_pat(new_pat)
                                 })
                                 .collect_vec();
 
@@ -281,7 +276,7 @@ impl<E: ExhaustivenessEnv> ExhaustivenessChecker<'_, E> {
     /// exhaustiveness checking (if a wildcard pattern is useful in relation
     /// to a matrix, the matrix isn't exhaustive).
     fn is_useful(
-        &self,
+        &mut self,
         matrix: &Matrix,
         v: &PatStack,
         arm_kind: MatchArmKind,
@@ -302,16 +297,14 @@ impl<E: ExhaustivenessEnv> ExhaustivenessChecker<'_, E> {
             return ret;
         }
 
-        let head = self.get_deconstructed_pat(v.head());
-
-        let DeconstructedPat { ty, .. } = head;
+        let head @ DeconstructedPat { ty, .. } = self.get_pat(v.head());
 
         // Create a new `PatCtx`, based on on the provided parameters
-        let ctx = PatCtx::new(ty, is_top_level);
+        let ctx = PatCtx::new(*ty, is_top_level);
         let mut report = Usefulness::new_not_useful(arm_kind);
 
         // If the first pattern is an or-pattern, expand it.
-        if self.is_or_pat(&head) {
+        if self.is_or_pat(head) {
             // We try each or-pattern branch in turn.
             let mut matrix = matrix.clone();
 
@@ -335,26 +328,25 @@ impl<E: ExhaustivenessEnv> ExhaustivenessChecker<'_, E> {
                 }
             }
         } else {
-            let ctors = matrix.heads().map(|id| self.get_deconstructed_pat(id).ctor);
-
+            let ctors = matrix.heads().map(|id| self.get_pat(id).ctor).collect_vec();
             let v_ctor = head.ctor;
 
             // check that int ranges don't overlap here, in case
             // they're partially covered by other ranges.
-            if let DeconstructedCtor::IntRange(range) = self.get_deconstructed_ctor(v_ctor) {
+            if let DeconstructedCtor::IntRange(range) = self.get_ctor(v_ctor) {
                 if let Some(head_id) = head.id {
                     self.check_for_overlapping_endpoints(
                         head_id,
-                        range,
+                        *range,
                         matrix.heads(),
                         matrix.column_count().unwrap_or(0),
-                        ty,
+                        *ty,
                     );
                 }
             }
 
             // We split the head constructor of `v`.
-            let split_ctors = self.split_ctor(ctx, v_ctor, ctors);
+            let split_ctors = self.split_ctor(ctx, v_ctor, ctors.iter().copied());
             let start_matrix = &matrix;
 
             // For each constructor, we compute whether there's a value that starts with it
@@ -374,7 +366,7 @@ impl<E: ExhaustivenessEnv> ExhaustivenessChecker<'_, E> {
         }
 
         if report.is_useful() {
-            self.deconstructed_pat_store().modify_fast(v.head(), |item| item.set_reachable());
+            self.get_pat_mut(v.head()).set_reachable();
         }
 
         report
@@ -386,7 +378,7 @@ impl<E: ExhaustivenessEnv> ExhaustivenessChecker<'_, E> {
     /// Note: the input patterns must have been lowered through
     /// [super::lower::LowerPatOps]
     pub(crate) fn compute_match_usefulness(
-        &self,
+        &mut self,
         subject: TyId,
         arms: &[MatchArm],
     ) -> UsefulnessReport {
@@ -407,10 +399,10 @@ impl<E: ExhaustivenessEnv> ExhaustivenessChecker<'_, E> {
                     self.push_matrix_row(&mut matrix, v);
                 }
 
-                let pat = self.get_deconstructed_pat(arm.deconstructed_pat);
+                let pat = self.get_pat(arm.deconstructed_pat);
 
                 let reachability = if pat.is_reachable() {
-                    Reachability::Reachable(self.compute_unreachable_pats(&pat))
+                    Reachability::Reachable(self.compute_unreachable_pats(pat))
                 } else {
                     Reachability::Unreachable
                 };
@@ -418,7 +410,8 @@ impl<E: ExhaustivenessEnv> ExhaustivenessChecker<'_, E> {
             })
             .collect();
 
-        let wildcard = self.deconstructed_pat_store().create(self.wildcard_from_ty(subject));
+        let w = self.wildcard_from_ty(subject);
+        let wildcard = self.make_pat(w);
         let v = PatStack::singleton(wildcard);
         let usefulness = self.is_useful(&matrix, &v, MatchArmKind::ExhaustiveWildcard, false, true);
 

--- a/compiler/hash-exhaustiveness/src/usefulness.rs
+++ b/compiler/hash-exhaustiveness/src/usefulness.rs
@@ -334,9 +334,9 @@ impl<E: ExhaustivenessEnv> ExhaustivenessChecker<'_, E> {
             // check that int ranges don't overlap here, in case
             // they're partially covered by other ranges.
             if let DeconstructedCtor::IntRange(range) = self.get_ctor(v_ctor) {
-                if let Some(head_id) = head.id {
+                if let Some(pat) = head.id {
                     self.check_for_overlapping_endpoints(
-                        head_id,
+                        pat,
                         *range,
                         matrix.heads(),
                         matrix.column_count().unwrap_or(0),

--- a/compiler/hash-parser/src/lib.rs
+++ b/compiler/hash-parser/src/lib.rs
@@ -260,13 +260,6 @@ fn parse_source(source: ParseSource, sender: Sender<ParserAction>) {
         return;
     }
 
-    // if !source.id().is_prelude() {
-    //     SourceMapUtils::set_module_source(id, contents.clone());
-    //     for token in &tokens {
-    //         println!("{:?}, {}, {:?}", token.kind, token.span,
-    // Span::new(token.span, id).fmt_range());     }
-    // }
-
     // Update the global string table now!
     string_table().add_local_table(strings);
 
@@ -308,6 +301,5 @@ fn parse_source(source: ParseSource, sender: Sender<ParserAction>) {
     // Send both the generated module, and the `LocalSpanMap` for updating
     // the global `SPAN_MAP`.
     sender.send(ParserAction::MergeSpans { spans }).unwrap();
-
     sender.send(action).unwrap();
 }

--- a/compiler/hash-parser/src/lib.rs
+++ b/compiler/hash-parser/src/lib.rs
@@ -260,6 +260,13 @@ fn parse_source(source: ParseSource, sender: Sender<ParserAction>) {
         return;
     }
 
+    // if !source.id().is_prelude() {
+    //     SourceMapUtils::set_module_source(id, contents.clone());
+    //     for token in &tokens {
+    //         println!("{:?}, {}, {:?}", token.kind, token.span,
+    // Span::new(token.span, id).fmt_range());     }
+    // }
+
     // Update the global string table now!
     string_table().add_local_table(strings);
 

--- a/compiler/hash-pipeline/src/interface.rs
+++ b/compiler/hash-pipeline/src/interface.rs
@@ -2,14 +2,12 @@
 //! that are used by the pipeline to run various stages that transform the
 //! provided sources into runnable/executable code.
 
-use std::{
-    sync::{Arc, Mutex},
-    time::Duration,
-};
+use std::sync::{Arc, Mutex};
 
 use hash_ast::node_map::NodeMap;
 use hash_reporting::report::Report;
 use hash_source::SourceId;
+pub use hash_utils::timing::StageMetrics;
 
 use crate::{
     settings::{CompilerSettings, CompilerStageKind},
@@ -17,20 +15,6 @@ use crate::{
 };
 
 pub type CompilerResult<T> = Result<T, Vec<Report>>;
-
-/// A [StageMetrics] is a collection of timings for each section of a stage.
-#[derive(Default, Debug, Clone)]
-pub struct StageMetrics {
-    /// The collected timings for each section of the stage.
-    pub timings: Vec<(&'static str, Duration)>,
-}
-
-impl StageMetrics {
-    /// Create an iterator over the collected timings.
-    pub fn iter(&self) -> impl Iterator<Item = (&'static str, Duration)> + '_ {
-        self.timings.iter().cloned()
-    }
-}
 
 /// [CompilerStage] represents an abstract stage within the compiler pipeline.
 /// Each stage has an associated [CompilerStageKind] which can be used by

--- a/compiler/hash-semantics/src/env.rs
+++ b/compiler/hash-semantics/src/env.rs
@@ -4,6 +4,7 @@ use hash_reporting::diagnostic::{Diagnostics, HasDiagnostics};
 use hash_source::entry_point::EntryPointState;
 use hash_target::HasTarget;
 use hash_tir::tir::{FnDefId, ModDefId};
+use hash_utils::timing::HasMetrics;
 use once_cell::sync::OnceCell;
 
 use crate::{
@@ -16,7 +17,7 @@ pub trait HasSemanticDiagnostics: HasDiagnostics<Diagnostics = Self::SemanticDia
 }
 
 pub trait SemanticEnv:
-    HasNodeMap + HasSemanticDiagnostics + HasCompilerSettings + HasTarget
+    HasNodeMap + HasMetrics + HasSemanticDiagnostics + HasCompilerSettings + HasTarget
 {
     fn storage(&self) -> &SemanticStorage;
     fn storage_mut(&mut self) -> &mut SemanticStorage;

--- a/compiler/hash-semantics/src/passes/tc_env_impl.rs
+++ b/compiler/hash-semantics/src/passes/tc_env_impl.rs
@@ -8,6 +8,7 @@ use hash_tir::{
     stores::tir_stores,
 };
 use hash_typecheck::{HasTcDiagnostics, TcEnv};
+use hash_utils::timing::{CellStageMetrics, HasMetrics};
 
 use crate::{
     diagnostics::definitions::{SemanticError, SemanticWarning},
@@ -25,6 +26,12 @@ pub struct TcEnvImpl<'env, E: SemanticEnv> {
 impl<'env, E: SemanticEnv> TcEnvImpl<'env, E> {
     pub fn new(env: &'env E, source: SourceId) -> Self {
         Self { env, source, context: Context::new() }
+    }
+}
+
+impl<E: SemanticEnv> HasMetrics for TcEnvImpl<'_, E> {
+    fn metrics(&self) -> &CellStageMetrics {
+        self.env.metrics()
     }
 }
 

--- a/compiler/hash-tir/src/context.rs
+++ b/compiler/hash-tir/src/context.rs
@@ -104,7 +104,7 @@ impl Scope {
     }
 }
 
-/// Trait for types that have a context avaiable to them.
+/// Trait for types that have a context available to them.
 pub trait HasContext {
     fn context(&self) -> &Context;
 }

--- a/compiler/hash-typecheck/src/inference.rs
+++ b/compiler/hash-typecheck/src/inference.rs
@@ -1150,7 +1150,7 @@ impl<T: TcEnv> InferenceOps<'_, T> {
                         self.infer_pat(decl.bind_pat, decl.ty, decl.value)?;
 
                         // Check that the binding pattern of the declaration is irrefutable.
-                        let eck = self.exhaustiveness_checker(decl.bind_pat);
+                        let mut eck = self.exhaustiveness_checker(decl.bind_pat);
 
                         self.env.time_item("exhaustiveness", |_| {
                             eck.is_pat_irrefutable(&[decl.bind_pat], decl.ty, None)
@@ -1477,7 +1477,7 @@ impl<T: TcEnv> InferenceOps<'_, T> {
         // add the job.
         let pats =
             match_term.cases.elements().borrow().iter().map(|case| case.bind_pat).collect_vec();
-        let eck = self.exhaustiveness_checker(match_term.subject);
+        let mut eck = self.exhaustiveness_checker(match_term.subject);
         self.env.time_item("exhaustiveness", |_| {
             eck.is_match_exhaustive(&pats, match_subject_ty);
         });

--- a/compiler/hash-typecheck/src/inference.rs
+++ b/compiler/hash-typecheck/src/inference.rs
@@ -1151,7 +1151,10 @@ impl<T: TcEnv> InferenceOps<'_, T> {
 
                         // Check that the binding pattern of the declaration is irrefutable.
                         let eck = self.exhaustiveness_checker(decl.bind_pat);
-                        eck.is_pat_irrefutable(&[decl.bind_pat], decl.ty, None);
+
+                        self.env.time_item("exhaustiveness", |_| {
+                            eck.is_pat_irrefutable(&[decl.bind_pat], decl.ty, None)
+                        });
                         self.append_exhaustiveness_diagnostics(eck);
 
                         decl.ty
@@ -1475,7 +1478,9 @@ impl<T: TcEnv> InferenceOps<'_, T> {
         let pats =
             match_term.cases.elements().borrow().iter().map(|case| case.bind_pat).collect_vec();
         let eck = self.exhaustiveness_checker(match_term.subject);
-        eck.is_match_exhaustive(&pats, match_subject_ty);
+        self.env.time_item("exhaustiveness", |_| {
+            eck.is_match_exhaustive(&pats, match_subject_ty);
+        });
         self.append_exhaustiveness_diagnostics(eck);
 
         Ok(())

--- a/compiler/hash-typecheck/src/lib.rs
+++ b/compiler/hash-typecheck/src/lib.rs
@@ -20,6 +20,7 @@ use hash_tir::{
     intrinsics::make::IntrinsicAbilities,
     tir::{FnDefId, TermId},
 };
+use hash_utils::timing::HasMetrics;
 use inference::InferenceOps;
 use substitution::SubstitutionOps;
 use unification::UnificationOps;
@@ -37,7 +38,7 @@ pub trait HasTcDiagnostics: HasDiagnostics<Diagnostics = Self::TcDiagnostics> {
 }
 
 pub trait TcEnv:
-    HasTcDiagnostics + HasTarget + HasContext + HasAtomInfo + HasCompilerSettings + Sized
+    HasTcDiagnostics + HasTarget + HasContext + HasMetrics + HasAtomInfo + HasCompilerSettings + Sized
 {
     /// Get the entry point of the current compilation, if any.
     fn entry_point(&self) -> &EntryPointState<FnDefId>;

--- a/compiler/hash-utils/src/timing.rs
+++ b/compiler/hash-utils/src/timing.rs
@@ -1,14 +1,59 @@
 //! Timing/profiling utilities.
 
-use std::time::{Duration, Instant};
+use std::{
+    cell::RefCell,
+    time::{Duration, Instant},
+};
 
+use indexmap::IndexMap;
 use log::{log_enabled, Level};
+
+/// A [StageMetrics] is a collection of timings for each section of a stage.
+#[derive(Default, Debug, Clone)]
+pub struct StageMetrics {
+    /// The collected timings for each section of the stage.
+    pub timings: IndexMap<&'static str, Duration>,
+}
+
+impl StageMetrics {
+    /// Merge another set of metrics into this one.
+    pub fn merge(&mut self, other: &StageMetrics) {
+        for (name, time) in &other.timings {
+            self.timings.entry(name).and_modify(|e| *e += *time).or_insert(*time);
+        }
+    }
+
+    /// Create an iterator over the collected timings.
+    pub fn iter(&self) -> impl Iterator<Item = (&'static str, Duration)> + '_ {
+        self.timings.iter().map(|(item, time)| (*item, *time))
+    }
+}
 
 /// A trait that can be implemented by a compiler stage in order to
 /// store information about the [Duration] of some process within
 /// the stage, later reporting it if requested.
-pub trait AccessToMetrics {
-    fn add_metric(&mut self, name: &'static str, time: Duration);
+pub trait HasMutMetrics {
+    fn metrics(&mut self) -> &mut StageMetrics;
+
+    /// Add a metric to the stage.
+    fn add_metric(&mut self, name: &'static str, time: Duration) {
+        self.metrics().timings.entry(name).and_modify(|e| *e += time).or_insert(time);
+    }
+
+    /// Time an item and add the metric to the stage.
+    fn time_item<T>(&mut self, name: &'static str, f: impl FnOnce(&mut Self) -> T) -> T {
+        let mut time = Duration::default();
+        let value = timed(
+            || f(self),
+            Level::Info,
+            |duration| {
+                time = duration;
+            },
+        );
+
+        self.add_metric(name, time);
+        value
+    }
 }
 
 /// Execute the given closure while timing it, and pass the duration to the
@@ -25,21 +70,54 @@ pub fn timed<T>(op: impl FnOnce() -> T, level: log::Level, on_elapsed: impl FnOn
     }
 }
 
-/// Run a stage of the backend whilst also timing it.
-pub fn time_item<U: AccessToMetrics, T>(
-    this: &mut U,
-    stage: &'static str,
-    f: impl FnOnce(&mut U) -> T,
-) -> T {
-    let mut time = Duration::default();
-    let value = timed(
-        || f(this),
-        Level::Info,
-        |duration| {
-            time = duration;
-        },
-    );
+impl HasMutMetrics for StageMetrics {
+    fn metrics(&mut self) -> &mut StageMetrics {
+        self
+    }
+}
 
-    this.add_metric(stage, time);
-    value
+/// A [StageMetrics] is a collection of timings for each section of a stage.
+#[derive(Default, Debug, Clone)]
+pub struct CellStageMetrics {
+    /// The collected timings for each section of the stage.
+    pub timings: RefCell<IndexMap<&'static str, Duration>>,
+}
+
+impl CellStageMetrics {
+    /// Merge another set of metrics into this one.
+    pub fn merge(&self, other: &CellStageMetrics) {
+        self.timings.borrow_mut().extend(other.timings.borrow().iter())
+    }
+}
+
+/// Sister trait of [HasMutMetrics] which allows for immutable access to
+/// the metrics.
+pub trait HasMetrics {
+    fn metrics(&self) -> &CellStageMetrics;
+
+    fn add_metric(&self, name: &'static str, time: Duration) {
+        self.metrics().timings.borrow_mut().entry(name).and_modify(|e| *e += time).or_insert(time);
+    }
+
+    /// Time an the execution of item, whilst saving the result to the
+    /// metrics.
+    fn time_item<T>(&self, name: &'static str, f: impl FnOnce(&Self) -> T) -> T {
+        let mut time = Duration::default();
+        let value = timed(
+            || f(self),
+            Level::Info,
+            |duration| {
+                time = duration;
+            },
+        );
+
+        self.add_metric(name, time);
+        value
+    }
+}
+
+impl From<CellStageMetrics> for StageMetrics {
+    fn from(metrics: CellStageMetrics) -> Self {
+        StageMetrics { timings: metrics.timings.into_inner() }
+    }
 }


### PR DESCRIPTION
This PR brings speedups of exhaustiveness from 3x-5x by the following changes:

This PR switches the internal exhaustiveness stores to just use `Vec`s over the `Store` interface. This avoids the locking mechanism for stores which never need to be locked. 

Additionally, this also switches `Fields` to use a `ThinVec` over a `Vec` which leads to better performance and less memory use overall.

Finally, we don't need to store the `bias` on an `IntRange` directly, only when we need to convert back into normal values, so remove it from the `IntRange` struct.

In addition to performance improvements, the analysis phase now records the time taken for exhaustiveness to complete its operations, and reports them through the standard compiler metrics plumbing.