### PR TITLE
lexer: better handling of character and byte literals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -784,7 +784,6 @@ dependencies = [
  "hash-target",
  "hash-utils",
  "unicode-normalization",
- "unicode-width",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -784,6 +784,7 @@ dependencies = [
  "hash-target",
  "hash-utils",
  "unicode-normalization",
+ "unicode-width",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -783,6 +783,7 @@ dependencies = [
  "hash-source",
  "hash-target",
  "hash-utils",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -1878,6 +1879,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2018,6 +2034,15 @@ name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"

--- a/compiler/hash-driver/src/driver.rs
+++ b/compiler/hash-driver/src/driver.rs
@@ -9,7 +9,6 @@ use std::{
     time::Duration,
 };
 
-use hash_ast::node_map::InteractiveBlock;
 use hash_pipeline::{
     fs::{resolve_path, PRELUDE},
     interface::{CompilerInterface, CompilerOutputStream, CompilerResult, CompilerStage},
@@ -352,8 +351,7 @@ impl<I: CompilerInterface> Driver<I> {
 
     /// Run the compiler on a interactive line input.
     pub fn run_interactive(&mut self, input: String) {
-        let source =
-            self.compiler.workspace_mut().add_interactive_block(input, InteractiveBlock::new());
+        let source = self.compiler.workspace_mut().add_interactive_block(input);
         self.run(source)
     }
 

--- a/compiler/hash-lexer/src/error.rs
+++ b/compiler/hash-lexer/src/error.rs
@@ -1,14 +1,16 @@
 //! Hash Compiler lexer error data types.
 
-use std::{cell::Cell, fmt::Display};
+use std::{cell::Cell, fmt::Display, iter};
 
 use hash_reporting::{
     diagnostic::{DiagnosticStore, HasDiagnosticsMut},
-    report::{help, info, Report},
+    report::{help, info, note, Report},
     reporter::{Reporter, Reports},
+    unicode_normalization::UnicodeNormalization,
 };
 use hash_source::{identifier::Identifier, location::Span};
 use hash_token::{delimiter::Delimiter, Base, TokenKind};
+use hash_utils::{pluralise, thin_vec::ThinVec};
 
 use crate::Lexer;
 
@@ -113,7 +115,16 @@ pub enum LexerErrorKind {
     /// ```
     /// 'ab'
     /// ```
-    MultipleCharCodePoints,
+    MultipleCharCodePoints {
+        /// The starting character of the literal.
+        start: char,
+
+        /// Any combining marks that followed the starting character.
+        combining_marks: ThinVec<char>,
+
+        /// If the error occurred in a byte literal.
+        byte_lit: bool,
+    },
 
     /// Unclosed unicode literal, when a unicode character literal
     /// is missing the closing brace, e.g.
@@ -246,10 +257,51 @@ impl From<LexerError> for Reports {
                 span_label = Some("expected `}` here".to_string());
                 "unclosed unicode escape sequence".to_string()
             }
-            LexerErrorKind::MultipleCharCodePoints => {
-                help_notes
-                    .push(help!("{}", "if you meant to write a string literal, use `\"` instead"));
-                "character literals may only contain one codepoint".to_string()
+            LexerErrorKind::MultipleCharCodePoints { start, combining_marks, byte_lit } => {
+                // If we got some combining marks, then we report that the
+                // character literal has multiple code points, and that the
+                // combining marks are not allowed in character literals.
+                if !combining_marks.is_empty() {
+                    let escaped_marks = combining_marks
+                        .iter()
+                        .map(|c| c.escape_default().to_string())
+                        .collect::<Vec<_>>();
+
+                    help_notes.push(note!(
+                        "{}",
+                        format!(
+                            "this `{start}` is followed by combining mark{} `{}`",
+                            pluralise!(combining_marks.len()),
+                            escaped_marks.join("")
+                        )
+                    ));
+
+                    // Insert the starting character into the combined string.
+                    let combined = iter::once(start).chain(combining_marks).collect::<String>();
+
+                    // Now we try to see if the character has a normalised form, and
+                    // potentially suggest that instead.
+                    let normalised = combined.nfc().to_string();
+                    if normalised.chars().count() == 1 {
+                        let ch = normalised.chars().next().unwrap().escape_default().to_string();
+                        help_notes.push(help!(
+                            "{}",
+                            format!("if you meant to write `{normalised}` instead, use `{ch}`",)
+                        ));
+                    }
+                }
+
+                // Don't suggest string notation for byte literals.
+                if !byte_lit {
+                    help_notes.push(help!(
+                        "{}",
+                        format!("if you meant to write a string literal, use `\"` instead")
+                    ));
+                }
+
+                let prefix = if byte_lit { "byte" } else { "character" };
+
+                format!("{prefix} literals may only contain one codepoint")
             }
             LexerErrorKind::InvalidUnicodeEscape(ch) => {
                 help_notes

--- a/compiler/hash-lexer/src/lib.rs
+++ b/compiler/hash-lexer/src/lib.rs
@@ -848,10 +848,9 @@ impl<'a> Lexer<'a> {
             );
         }
 
-        // @@ErrorReporting: essentially we jump over the erroneous character literal
-        // and continue lexing
+        // The next character is either eof or `'`, so we skip it and emit an error
         if !self.is_eof() {
-            self.skip();
+            self.skip_ascii();
         }
 
         self.emit_error(

--- a/compiler/hash-parser/src/parser/name.rs
+++ b/compiler/hash-parser/src/parser/name.rs
@@ -25,7 +25,12 @@ impl<'s> AstGen<'s> {
             Some(Token { kind: TokenKind::Ident(ident), span }) if *ident != IDENTS.underscore => {
                 Ok(self.node_with_span(Name { ident: *ident }, *span))
             }
-            _ => self.err_with_location(err, ExpectedItem::Ident, None, self.expected_pos()),
+            tok => self.err_with_location(
+                err,
+                ExpectedItem::Ident,
+                None,
+                tok.map(|tok| tok.span).unwrap_or_else(|| self.eof_pos()),
+            ),
         }
     }
 

--- a/compiler/hash-pipeline/src/workspace.rs
+++ b/compiler/hash-pipeline/src/workspace.rs
@@ -274,8 +274,9 @@ impl Workspace {
     /// Add a interactive block to the [Workspace] by providing the contents and
     /// the [InteractiveBlock]. Returns the created [InteractiveId] from
     /// adding it to the source map.
-    pub fn add_interactive_block(&mut self, input: String, block: InteractiveBlock) -> SourceId {
+    pub fn add_interactive_block(&mut self, input: String) -> SourceId {
         let id = SourceMapUtils::add_interactive_block(input);
+        let block = InteractiveBlock::new();
 
         // Add this source to the node map, and to the stage info
         self.node_map.add_interactive_block(block);

--- a/compiler/hash-reporting/Cargo.toml
+++ b/compiler/hash-reporting/Cargo.toml
@@ -12,3 +12,4 @@ hash-error-codes = { path = "../hash-error-codes" }
 hash-source = { path = "../hash-source" }
 hash-utils = { path = "../hash-utils" }
 hash-target = { path = "../hash-target" }
+unicode-normalization = "0.1.22"

--- a/compiler/hash-reporting/Cargo.toml
+++ b/compiler/hash-reporting/Cargo.toml
@@ -12,4 +12,6 @@ hash-error-codes = { path = "../hash-error-codes" }
 hash-source = { path = "../hash-source" }
 hash-utils = { path = "../hash-utils" }
 hash-target = { path = "../hash-target" }
+
 unicode-normalization = "0.1.22"
+unicode-width = "0.1.8"

--- a/compiler/hash-reporting/Cargo.toml
+++ b/compiler/hash-reporting/Cargo.toml
@@ -14,4 +14,3 @@ hash-utils = { path = "../hash-utils" }
 hash-target = { path = "../hash-target" }
 
 unicode-normalization = "0.1.22"
-unicode-width = "0.1.8"

--- a/compiler/hash-reporting/src/lib.rs
+++ b/compiler/hash-reporting/src/lib.rs
@@ -9,3 +9,4 @@ pub mod report;
 pub mod reporter;
 
 pub use hash_error_codes;
+pub use unicode_normalization;

--- a/compiler/hash-reporting/src/render.rs
+++ b/compiler/hash-reporting/src/render.rs
@@ -165,6 +165,8 @@ impl ReportCodeBlock {
 
             // If it is a combining mark, its not going to be rendered within the
             // span, so we need to subtract it from the total width.
+            //
+            // @@Investigate: maybe use `unicode-width` here?
             if unicode_normalization::char::is_combining_mark(ch) {
                 combining_marks += 1;
             }

--- a/compiler/hash-reporting/src/report.rs
+++ b/compiler/hash-reporting/src/report.rs
@@ -151,6 +151,13 @@ pub macro help {
     }
 }
 
+/// Create a `note` note with the given message.
+pub macro note {
+    ($($arg:tt)*) => {
+        ReportElement::Note(ReportNote::new(ReportNoteKind::Note, format!($($arg)*)))
+    }
+}
+
 /// Create a `info` note with the given message.
 pub macro info {
     ($($arg:tt)*) => {

--- a/tests/cases/parser/literals/byte_literals/combining_marks.hash
+++ b/tests/cases/parser/literals/byte_literals/combining_marks.hash
@@ -1,0 +1,16 @@
+// run=fail, stage=parse
+
+main := () => {
+    // Single combining mark.
+    spade  := b'♠️'
+
+    // Multiple combining characters.
+    bing   := b'ṩ̂̊'
+
+    // Suggest to write the normalised character.
+    a_ring := b'Å'
+    happy  := b'☺️'
+
+    // This shouldn't print the combining characters suggestions.
+    bing_happy := b'ṩ̂̊☺️'
+}

--- a/tests/cases/parser/literals/byte_literals/combining_marks.stderr
+++ b/tests/cases/parser/literals/byte_literals/combining_marks.stderr
@@ -1,0 +1,39 @@
+error: byte literals may only contain one codepoint
+ --> $DIR/combining_marks.hash:5:15
+4 |       // Single combining mark.
+5 |       spade  := b'♠️'
+  |                 ^^^^ here
+6 |   
+  = note: this `♠` is followed by combining mark `\u{fe0f}`
+
+error: byte literals may only contain one codepoint
+ --> $DIR/combining_marks.hash:8:15
+7 |       // Multiple combining characters.
+8 |       bing   := b'ṩ̂̊'
+  |                 ^^^^ here
+9 |   
+  = note: this `s` is followed by combining marks `\u{323}\u{307}\u{302}\u{30a}`
+
+error: byte literals may only contain one codepoint
+  --> $DIR/combining_marks.hash:11:15
+10 |       // Suggest to write the normalised character.
+11 |       a_ring := b'Å'
+   |                 ^^^^ here
+12 |       happy  := b'☺️'
+   = note: this `A` is followed by combining mark `\u{30a}`
+   = help: if you meant to write `Å` instead, use `\u{c5}`
+
+error: byte literals may only contain one codepoint
+  --> $DIR/combining_marks.hash:12:15
+11 |       a_ring := b'Å'
+12 |       happy  := b'☺️'
+   |                 ^^^^ here
+13 |   
+   = note: this `☺` is followed by combining mark `\u{fe0f}`
+
+error: byte literals may only contain one codepoint
+  --> $DIR/combining_marks.hash:15:19
+14 |       // This shouldn't print the combining characters suggestions.
+15 |       bing_happy := b'ṩ̂̊☺️'
+   |                     ^^^^^ here
+16 |   }

--- a/tests/cases/parser/literals/byte_literals/non_ascii_byte_literals.hash
+++ b/tests/cases/parser/literals/byte_literals/non_ascii_byte_literals.hash
@@ -1,0 +1,7 @@
+// run=fail, stage=parse
+
+(
+b'ß',
+b'👍',
+b'😘',
+)

--- a/tests/cases/parser/literals/byte_literals/non_ascii_byte_literals.stderr
+++ b/tests/cases/parser/literals/byte_literals/non_ascii_byte_literals.stderr
@@ -1,0 +1,23 @@
+error: non-ascii character in byte literal
+ --> $DIR/non_ascii_byte_literals.hash:4:3
+3 |   (
+4 |   b'ß',
+  |     ^ must be ASCII
+5 |   b'👍',
+  = help: if you meant to use the unicode code point for `ß`, use a \xHH escape, replace it with `\xDF` 
+
+error: non-ascii character in byte literal
+ --> $DIR/non_ascii_byte_literals.hash:5:3
+4 |   b'ß',
+5 |   b'👍',
+  |     ^ must be ASCII
+this multibyte character does not fit into a single byte
+6 |   b'😘',
+
+error: non-ascii character in byte literal
+ --> $DIR/non_ascii_byte_literals.hash:6:3
+5 |   b'👍',
+6 |   b'😘',
+  |     ^ must be ASCII
+this multibyte character does not fit into a single byte
+7 |   )

--- a/tests/cases/parser/literals/byte_literals/non_ascii_byte_literals.stderr
+++ b/tests/cases/parser/literals/byte_literals/non_ascii_byte_literals.stderr
@@ -11,7 +11,7 @@ error: non-ascii character in byte literal
 4 |   b'ß',
 5 |   b'👍',
   |     ^ must be ASCII
-this multibyte character does not fit into a single byte
+  |       this multibyte character does not fit into a single byte
 6 |   b'😘',
 
 error: non-ascii character in byte literal
@@ -19,5 +19,5 @@ error: non-ascii character in byte literal
 5 |   b'👍',
 6 |   b'😘',
   |     ^ must be ASCII
-this multibyte character does not fit into a single byte
+  |       this multibyte character does not fit into a single byte
 7 |   )

--- a/tests/cases/parser/literals/characters/combining_marks.hash
+++ b/tests/cases/parser/literals/characters/combining_marks.hash
@@ -1,0 +1,16 @@
+// run=fail, stage=parse
+
+main := () => {
+    // Single combining mark.
+    spade  := '♠️'
+
+    // Multiple combining characters.
+    bing   := 'ṩ̂̊'
+
+    // Suggest to write the normalised character.
+    a_ring := 'Å'
+    happy  := '☺️'
+
+    // This shouldn't print the combining characters suggestions.
+    bing_happy := 'ṩ̂̊☺️'
+}

--- a/tests/cases/parser/literals/characters/combining_marks.stderr
+++ b/tests/cases/parser/literals/characters/combining_marks.stderr
@@ -1,0 +1,44 @@
+error: character literals may only contain one codepoint
+ --> $DIR/combining_marks.hash:5:15
+4 |       // Single combining mark.
+5 |       spade  := '♠️'
+  |                 ^^^ here
+6 |   
+  = note: this `♠` is followed by combining mark `\u{fe0f}`
+  = help: if you meant to write a string literal, use `"` instead
+
+error: character literals may only contain one codepoint
+ --> $DIR/combining_marks.hash:8:15
+7 |       // Multiple combining characters.
+8 |       bing   := 'ṩ̂̊'
+  |                 ^^^ here
+9 |   
+  = note: this `s` is followed by combining marks `\u{323}\u{307}\u{302}\u{30a}`
+  = help: if you meant to write a string literal, use `"` instead
+
+error: character literals may only contain one codepoint
+  --> $DIR/combining_marks.hash:11:15
+10 |       // Suggest to write the normalised character.
+11 |       a_ring := 'Å'
+   |                 ^^^ here
+12 |       happy  := '☺️'
+   = note: this `A` is followed by combining mark `\u{30a}`
+   = help: if you meant to write `Å` instead, use `\u{c5}`
+   = help: if you meant to write a string literal, use `"` instead
+
+error: character literals may only contain one codepoint
+  --> $DIR/combining_marks.hash:12:15
+11 |       a_ring := 'Å'
+12 |       happy  := '☺️'
+   |                 ^^^ here
+13 |   
+   = note: this `☺` is followed by combining mark `\u{fe0f}`
+   = help: if you meant to write a string literal, use `"` instead
+
+error: character literals may only contain one codepoint
+  --> $DIR/combining_marks.hash:15:19
+14 |       // This shouldn't print the combining characters suggestions.
+15 |       bing_happy := 'ṩ̂̊☺️'
+   |                     ^^^^ here
+16 |   }
+   = help: if you meant to write a string literal, use `"` instead

--- a/tests/cases/parser/literals/characters/multi_error_char.stderr
+++ b/tests/cases/parser/literals/characters/multi_error_char.stderr
@@ -18,6 +18,6 @@ error: character literals may only contain one codepoint
   --> $DIR/multi_error_char.hash:12:5
 11 |       // ~ERROR: Chracter literals are not allowed to have more than one character.
 12 |       '\x063';
-   |       ^^^^^^^^ here
+   |       ^^^^^^^ here
 13 |   }
    = help: if you meant to write a string literal, use `"` instead

--- a/tests/cases/reporting/pre_code_marks.hash
+++ b/tests/cases/reporting/pre_code_marks.hash
@@ -1,0 +1,32 @@
+// stage=parse, run=fail
+
+// Here we are testing that the reporting sub-system
+// is correctly adjusting the span labels and widths for 
+// any encountered combining characters.
+
+normal := () => {
+    // ~ERROR: expected expression
+    "aaa" + 
+}
+
+crazy := () => {
+    // ~ERROR: expected expression
+    "äää" + 
+}
+
+start := "aaa"; normal_block := ((foo, 
+bar)) => {
+
+
+}
+
+start := "äää"; crazy_block_1 := ((foo, 
+bar)) => {
+
+}
+
+start := "äää"; crazy_block_2 := ((foo, 
+bar, 
+baz, "äää")) => {
+
+}

--- a/tests/cases/reporting/pre_code_marks.stderr
+++ b/tests/cases/reporting/pre_code_marks.stderr
@@ -1,0 +1,50 @@
+error: expected an expression
+  --> $DIR/pre_code_marks.hash:9:12
+ 8 |       // ~ERROR: expected expression
+ 9 |       "aaa" + 
+   |              ^ 
+10 |   }
+
+error: expected an expression
+  --> $DIR/pre_code_marks.hash:14:15
+13 |       // ~ERROR: expected expression
+14 |       "äää" + 
+   |              ^ 
+15 |   }
+
+error: expected a name here
+  --> $DIR/pre_code_marks.hash:17:34
+15 |    }
+16 |    
+17 |    start := "aaa"; normal_block := ((foo, 
+   |  ___________________________________-
+18 | |  bar)) => {
+   | |_____- 
+19 |    
+20 |    
+   = help: expected a `identifier`
+
+error: expected a name here
+  --> $DIR/pre_code_marks.hash:23:38
+21 |    }
+22 |    
+23 |    start := "äää"; crazy_block_1 := ((foo, 
+   |  ____________________________________-
+24 | |  bar)) => {
+   | |_____- 
+25 |    
+26 |    }
+   = help: expected a `identifier`
+
+error: expected a name here
+  --> $DIR/pre_code_marks.hash:28:38
+26 |    }
+27 |    
+28 |    start := "äää"; crazy_block_2 := ((foo, 
+   |  ____________________________________-
+29 | |  bar, 
+30 | |  baz, "äää")) => {
+   | |____________- 
+31 |    
+32 |    }
+   = help: expected a `identifier`


### PR DESCRIPTION
This PR deals with several issues arising from Unicode handling in the compiler. Firstly, the compiler would completely bork when it encountered combining marks. Column offsets and reporting rendering were completely incorrect, and the lexer error message was somewhat confusing. So, this PR does the following:

- lexer: emit error for non-ASCII byte literals
- source: correctly compute column offsets (accounting for Unicode)
- reporting: account for combining marks when drawing span annotations
- lexer: improve errors for combining marks in byte and character literals
- fix #1003
