### PR TITLE
tc: Add some documentation to module items (Part 1)

### DIFF
--- a/compiler/hash-typecheck/src/env.rs
+++ b/compiler/hash-typecheck/src/env.rs
@@ -12,12 +12,19 @@ use crate::{
     tc::{FnInferMode, Tc},
 };
 
+/// A wrapper trait around `HasDiagnostics` for specifically diagnostics that
+/// can accomodate `TcError`s, `ExhaustivenessError`s and
+/// `ExhaustivenessWarning`s. (and `TcWarning`s in the future.)
 pub trait HasTcDiagnostics: HasDiagnostics<Diagnostics = Self::TcDiagnostics> {
     type ForeignError: From<TcError> + From<ExhaustivenessError>;
     type ForeignWarning: From<ExhaustivenessWarning>;
     type TcDiagnostics: Diagnostics<Error = Self::ForeignError, Warning = Self::ForeignWarning>;
 }
 
+/// The typechecking environment.
+///
+/// This trait declares all the required information that the typechecking stage
+/// needs from the rest of the compiler in order to operate.
 pub trait TcEnv:
     HasTcDiagnostics + HasTarget + HasAtomInfo + HasCompilerSettings + HasMetrics + Sized
 {
@@ -32,6 +39,7 @@ pub trait TcEnv:
         self.settings().semantic_settings.mono_tir
     }
 
+    /// Create a new typechecker using the given context.
     fn checker<'a>(&'a self, context: &'a Context) -> Tc<Self> {
         Tc {
             env: self,

--- a/compiler/hash-typecheck/src/lib.rs
+++ b/compiler/hash-typecheck/src/lib.rs
@@ -1,3 +1,16 @@
+//! The Hash typechecker crate.
+//!
+//! This crate implements the typechecking for the Hash language.
+//!
+//! Typechecking occurs on the level of the TIR. Typechecking operations for
+//! each TIR node can be found in the `operations` module, while general TC
+//! traits can be found in `traits`. The `utilities` module includes various
+//! other functionality to deal with things such as entry points, purity checks,
+//! exhaustiveness, compile-time evaluation, etc. The TC error definitions and
+//! reporting are in the `errors` module. The `env` module contains a trait
+//! that defines all the required items for the typechecker to work, provided by
+//! the greater compiler context.
+
 #![feature(control_flow_enum, let_chains)]
 
 pub mod env;

--- a/compiler/hash-typecheck/src/lib.rs
+++ b/compiler/hash-typecheck/src/lib.rs
@@ -1,12 +1,4 @@
-#![feature(
-    unwrap_infallible,
-    never_type,
-    try_trait_v2,
-    try_blocks,
-    control_flow_enum,
-    let_chains,
-    if_let_guard
-)]
+#![feature(control_flow_enum, let_chains)]
 
 pub mod env;
 pub mod errors;

--- a/compiler/hash-typecheck/src/operations/access.rs
+++ b/compiler/hash-typecheck/src/operations/access.rs
@@ -14,13 +14,13 @@ use crate::{
 };
 
 impl<E: TcEnv> Operations<AccessTerm> for Tc<'_, E> {
-    type TyNode = TyId;
+    type AnnotNode = TyId;
     type Node = TermId;
 
     fn check(
         &self,
         access_term: &mut AccessTerm,
-        annotation_ty: Self::TyNode,
+        annotation_ty: Self::AnnotNode,
         item_node: Self::Node,
     ) -> TcResult<()> {
         let subject_ty = Ty::hole_for(access_term.subject);

--- a/compiler/hash-typecheck/src/operations/access.rs
+++ b/compiler/hash-typecheck/src/operations/access.rs
@@ -10,10 +10,10 @@ use crate::{
         normalised_if, stuck_normalising, NormalisationState, NormaliseResult,
     },
     tc::Tc,
-    traits::{Operations, OperationsOnNode},
+    traits::{OperationsOn, OperationsOnNode},
 };
 
-impl<E: TcEnv> Operations<AccessTerm> for Tc<'_, E> {
+impl<E: TcEnv> OperationsOn<AccessTerm> for Tc<'_, E> {
     type AnnotNode = TyId;
     type Node = TermId;
 

--- a/compiler/hash-typecheck/src/operations/args.rs
+++ b/compiler/hash-typecheck/src/operations/args.rs
@@ -23,18 +23,18 @@ use crate::{
         already_normalised, normalised_if, NormalisationState, NormaliseResult, NormaliseSignal,
     },
     tc::Tc,
-    traits::{OperationsOnNode, RecursiveOperationsOnNode},
+    traits::{OperationsOnNode, ScopedOperationsOnNode},
     utils::matching::MatchResult,
 };
 
-impl<E: TcEnv> RecursiveOperationsOnNode<ArgsId> for Tc<'_, E> {
-    type TyNode = ParamsId;
-    type RecursiveArg = ArgsId;
+impl<E: TcEnv> ScopedOperationsOnNode<ArgsId> for Tc<'_, E> {
+    type AnnotNode = ParamsId;
+    type CallbackArg = ArgsId;
 
-    fn check_node_rec<T, F: FnMut(Self::RecursiveArg) -> TcResult<T>>(
+    fn check_node_scoped<T, F: FnMut(Self::CallbackArg) -> TcResult<T>>(
         &self,
         args: ArgsId,
-        annotation_params: Self::TyNode,
+        annotation_params: Self::AnnotNode,
         mut in_arg_scope: F,
     ) -> TcResult<T> {
         self.register_new_atom(args, annotation_params);
@@ -58,7 +58,7 @@ impl<E: TcEnv> RecursiveOperationsOnNode<ArgsId> for Tc<'_, E> {
         Ok(result)
     }
 
-    fn try_normalise_node_rec(&self, args_id: ArgsId) -> NormaliseResult<ControlFlow<ArgsId>> {
+    fn try_normalise_node(&self, args_id: ArgsId) -> NormaliseResult<ControlFlow<ArgsId>> {
         let args = args_id.value();
         let st = NormalisationState::new();
 
@@ -82,7 +82,7 @@ impl<E: TcEnv> RecursiveOperationsOnNode<ArgsId> for Tc<'_, E> {
         normalised_if(|| new_node, &st)
     }
 
-    fn unify_nodes_rec<T, F: FnMut(Self::RecursiveArg) -> TcResult<T>>(
+    fn unify_nodes_scoped<T, F: FnMut(Self::CallbackArg) -> TcResult<T>>(
         &self,
         src_id: ArgsId,
         target_id: ArgsId,
@@ -123,14 +123,14 @@ impl<E: TcEnv> Tc<'_, E> {
     }
 }
 
-impl<E: TcEnv> RecursiveOperationsOnNode<(PatArgsId, Option<Spread>)> for Tc<'_, E> {
-    type TyNode = ParamsId;
-    type RecursiveArg = PatArgsId;
+impl<E: TcEnv> ScopedOperationsOnNode<(PatArgsId, Option<Spread>)> for Tc<'_, E> {
+    type AnnotNode = ParamsId;
+    type CallbackArg = PatArgsId;
 
-    fn check_node_rec<T, F: FnMut(Self::RecursiveArg) -> TcResult<T>>(
+    fn check_node_scoped<T, F: FnMut(Self::CallbackArg) -> TcResult<T>>(
         &self,
         (pat_args, spread): (PatArgsId, Option<Spread>),
-        annotation_params: Self::TyNode,
+        annotation_params: Self::AnnotNode,
         mut f: F,
     ) -> TcResult<T> {
         self.register_new_atom(pat_args, annotation_params);
@@ -161,14 +161,14 @@ impl<E: TcEnv> RecursiveOperationsOnNode<(PatArgsId, Option<Spread>)> for Tc<'_,
         )
     }
 
-    fn try_normalise_node_rec(
+    fn try_normalise_node(
         &self,
         _item: (PatArgsId, Option<Spread>),
     ) -> NormaliseResult<ControlFlow<(PatArgsId, Option<Spread>)>> {
         already_normalised()
     }
 
-    fn unify_nodes_rec<T, F: FnMut(Self::RecursiveArg) -> TcResult<T>>(
+    fn unify_nodes_scoped<T, F: FnMut(Self::CallbackArg) -> TcResult<T>>(
         &self,
         (pat_args_id, _): (PatArgsId, Option<Spread>),
         _: (PatArgsId, Option<Spread>),

--- a/compiler/hash-typecheck/src/operations/args.rs
+++ b/compiler/hash-typecheck/src/operations/args.rs
@@ -213,7 +213,7 @@ impl<E: TcEnv> Tc<'_, E> {
             })?;
 
         // Add the shadowed substitutions to the ambient scope
-        self.add_unification_from_sub(&shadowed_sub);
+        self.add_sub_to_scope(&shadowed_sub);
         Ok(result)
     }
 

--- a/compiler/hash-typecheck/src/operations/arrays.rs
+++ b/compiler/hash-typecheck/src/operations/arrays.rs
@@ -25,7 +25,7 @@ use crate::{
         normalise_nested, normalised_if, stuck_normalising, NormalisationState, NormaliseResult,
     },
     tc::Tc,
-    traits::{Operations, OperationsOnNode, RecursiveOperationsOnNode},
+    traits::{Operations, OperationsOnNode, ScopedOperationsOnNode},
 };
 
 impl<E: TcEnv> Tc<'_, E> {
@@ -114,7 +114,7 @@ impl<E: TcEnv> Tc<'_, E> {
                         if let PrimitiveCtorInfo::Array(array_prim) = primitive {
                             // First infer the data arguments
                             let copied_params = self.visitor().copy(data_def.params);
-                            self.check_node_rec(data.args, copied_params, |_| {
+                            self.check_node_scoped(data.args, copied_params, |_| {
                                 let sub = self.substituter().create_sub_from_current_scope();
                                 let subbed_element_ty =
                                     self.substituter().apply_sub(array_prim.element_ty, &sub);
@@ -150,13 +150,13 @@ impl<E: TcEnv> Tc<'_, E> {
 }
 
 impl<E: TcEnv> Operations<ArrayTerm> for Tc<'_, E> {
-    type TyNode = TyId;
+    type AnnotNode = TyId;
     type Node = TermId;
 
     fn check(
         &self,
         array_term: &mut ArrayTerm,
-        annotation_ty: Self::TyNode,
+        annotation_ty: Self::AnnotNode,
         _: Self::Node,
     ) -> TcResult<()> {
         self.normalise_and_check_ty(annotation_ty)?;
@@ -230,13 +230,13 @@ impl<E: TcEnv> Operations<ArrayTerm> for Tc<'_, E> {
 }
 
 impl<E: TcEnv> Operations<ArrayPat> for Tc<'_, E> {
-    type TyNode = TyId;
+    type AnnotNode = TyId;
     type Node = PatId;
 
     fn check(
         &self,
         list_pat: &mut ArrayPat,
-        annotation_ty: Self::TyNode,
+        annotation_ty: Self::AnnotNode,
         original_pat_id: Self::Node,
     ) -> TcResult<()> {
         self.normalise_and_check_ty(annotation_ty)?;
@@ -286,13 +286,13 @@ impl<E: TcEnv> Operations<ArrayPat> for Tc<'_, E> {
 }
 
 impl<E: TcEnv> Operations<IndexTerm> for Tc<'_, E> {
-    type TyNode = TyId;
+    type AnnotNode = TyId;
     type Node = TermId;
 
     fn check(
         &self,
         index_term: &mut IndexTerm,
-        annotation_ty: Self::TyNode,
+        annotation_ty: Self::AnnotNode,
         original_term_id: Self::Node,
     ) -> TcResult<()> {
         self.check_ty(annotation_ty)?;

--- a/compiler/hash-typecheck/src/operations/arrays.rs
+++ b/compiler/hash-typecheck/src/operations/arrays.rs
@@ -25,7 +25,7 @@ use crate::{
         normalise_nested, normalised_if, stuck_normalising, NormalisationState, NormaliseResult,
     },
     tc::Tc,
-    traits::{Operations, OperationsOnNode, ScopedOperationsOnNode},
+    traits::{OperationsOn, OperationsOnNode, ScopedOperationsOnNode},
 };
 
 impl<E: TcEnv> Tc<'_, E> {
@@ -149,7 +149,7 @@ impl<E: TcEnv> Tc<'_, E> {
     }
 }
 
-impl<E: TcEnv> Operations<ArrayTerm> for Tc<'_, E> {
+impl<E: TcEnv> OperationsOn<ArrayTerm> for Tc<'_, E> {
     type AnnotNode = TyId;
     type Node = TermId;
 
@@ -229,7 +229,7 @@ impl<E: TcEnv> Operations<ArrayTerm> for Tc<'_, E> {
     }
 }
 
-impl<E: TcEnv> Operations<ArrayPat> for Tc<'_, E> {
+impl<E: TcEnv> OperationsOn<ArrayPat> for Tc<'_, E> {
     type AnnotNode = TyId;
     type Node = PatId;
 
@@ -285,7 +285,7 @@ impl<E: TcEnv> Operations<ArrayPat> for Tc<'_, E> {
     }
 }
 
-impl<E: TcEnv> Operations<IndexTerm> for Tc<'_, E> {
+impl<E: TcEnv> OperationsOn<IndexTerm> for Tc<'_, E> {
     type AnnotNode = TyId;
     type Node = TermId;
 

--- a/compiler/hash-typecheck/src/operations/blocks.rs
+++ b/compiler/hash-typecheck/src/operations/blocks.rs
@@ -19,13 +19,13 @@ use crate::{
 };
 
 impl<E: TcEnv> Operations<BlockTerm> for Tc<'_, E> {
-    type TyNode = TyId;
+    type AnnotNode = TyId;
     type Node = TermId;
 
     fn check(
         &self,
         block_term: &mut BlockTerm,
-        annotation_ty: Self::TyNode,
+        annotation_ty: Self::AnnotNode,
         original_term_id: Self::Node,
     ) -> TcResult<()> {
         self.context().enter_scope(block_term.stack_id.into(), || {

--- a/compiler/hash-typecheck/src/operations/blocks.rs
+++ b/compiler/hash-typecheck/src/operations/blocks.rs
@@ -14,11 +14,11 @@ use crate::{
     errors::{TcError, TcResult},
     options::normalisation::{normalised_to, NormalisationState, NormaliseResult},
     tc::{FnInferMode, Tc},
-    traits::{Operations, OperationsOnNode},
+    traits::{OperationsOn, OperationsOnNode},
     utils::matching::MatchResult,
 };
 
-impl<E: TcEnv> Operations<BlockTerm> for Tc<'_, E> {
+impl<E: TcEnv> OperationsOn<BlockTerm> for Tc<'_, E> {
     type AnnotNode = TyId;
     type Node = TermId;
 

--- a/compiler/hash-typecheck/src/operations/calls.rs
+++ b/compiler/hash-typecheck/src/operations/calls.rs
@@ -18,11 +18,11 @@ use crate::{
         NormaliseResult, NormaliseSignal,
     },
     tc::Tc,
-    traits::{Operations, OperationsOnNode, ScopedOperationsOnNode},
+    traits::{OperationsOn, OperationsOnNode, ScopedOperationsOnNode},
     utils::intrinsic_abilities::IntrinsicAbilitiesImpl,
 };
 
-impl<E: TcEnv> Operations<CallTerm> for Tc<'_, E> {
+impl<E: TcEnv> OperationsOn<CallTerm> for Tc<'_, E> {
     type AnnotNode = TyId;
     type Node = TermId;
 

--- a/compiler/hash-typecheck/src/operations/calls.rs
+++ b/compiler/hash-typecheck/src/operations/calls.rs
@@ -18,18 +18,18 @@ use crate::{
         NormaliseResult, NormaliseSignal,
     },
     tc::Tc,
-    traits::{Operations, OperationsOnNode, RecursiveOperationsOnNode},
+    traits::{Operations, OperationsOnNode, ScopedOperationsOnNode},
     utils::intrinsic_abilities::IntrinsicAbilitiesImpl,
 };
 
 impl<E: TcEnv> Operations<CallTerm> for Tc<'_, E> {
-    type TyNode = TyId;
+    type AnnotNode = TyId;
     type Node = TermId;
 
     fn check(
         &self,
         call_term: &mut CallTerm,
-        annotation_ty: Self::TyNode,
+        annotation_ty: Self::AnnotNode,
         original_term_id: Self::Node,
     ) -> TcResult<()> {
         self.context().enter_scope(ScopeKind::Sub, || {
@@ -65,7 +65,7 @@ impl<E: TcEnv> Operations<CallTerm> for Tc<'_, E> {
                     let copied_return_ty = self.visitor().copy(fn_ty.return_ty);
 
                     let mut fn_call_term = *call_term;
-                    self.check_node_rec(fn_call_term.args, copied_params, |inferred_fn_call_args| {
+                    self.check_node_scoped(fn_call_term.args, copied_params, |inferred_fn_call_args| {
                         fn_call_term.args = inferred_fn_call_args;
                         original_term_id.set(original_term_id.value().with_data(fn_call_term.into()));
 
@@ -152,7 +152,7 @@ impl<E: TcEnv> Operations<CallTerm> for Tc<'_, E> {
         _target_node: Self::Node,
     ) -> TcResult<()> {
         self.unify_nodes(src.subject, target.subject)?;
-        self.unify_nodes_rec(src.args, target.args, |_| Ok(()))?;
+        self.unify_nodes_scoped(src.args, target.args, |_| Ok(()))?;
         Ok(())
     }
 }

--- a/compiler/hash-typecheck/src/operations/casting.rs
+++ b/compiler/hash-typecheck/src/operations/casting.rs
@@ -10,13 +10,13 @@ use crate::{
 };
 
 impl<E: TcEnv> Operations<CastTerm> for Tc<'_, E> {
-    type TyNode = TyId;
+    type AnnotNode = TyId;
     type Node = TermId;
 
     fn check(
         &self,
         cast_term: &mut CastTerm,
-        annotation_ty: Self::TyNode,
+        annotation_ty: Self::AnnotNode,
         _: Self::Node,
     ) -> crate::errors::TcResult<()> {
         self.check_node(cast_term.subject_term, cast_term.target_ty)?;

--- a/compiler/hash-typecheck/src/operations/casting.rs
+++ b/compiler/hash-typecheck/src/operations/casting.rs
@@ -6,10 +6,10 @@ use crate::{
     env::TcEnv,
     options::normalisation::{normalised_option, NormaliseResult},
     tc::Tc,
-    traits::{Operations, OperationsOnNode},
+    traits::{OperationsOn, OperationsOnNode},
 };
 
-impl<E: TcEnv> Operations<CastTerm> for Tc<'_, E> {
+impl<E: TcEnv> OperationsOn<CastTerm> for Tc<'_, E> {
     type AnnotNode = TyId;
     type Node = TermId;
 

--- a/compiler/hash-typecheck/src/operations/commands.rs
+++ b/compiler/hash-typecheck/src/operations/commands.rs
@@ -16,13 +16,13 @@ use crate::{
 };
 
 impl<E: TcEnv> Operations<ReturnTerm> for Tc<'_, E> {
-    type TyNode = TyId;
+    type AnnotNode = TyId;
     type Node = TermId;
 
     fn check(
         &self,
         return_term: &mut ReturnTerm,
-        annotation_ty: Self::TyNode,
+        annotation_ty: Self::AnnotNode,
         original_term_id: Self::Node,
     ) -> crate::errors::TcResult<()> {
         let closest_fn_def = self.context().get_first_fn_def_in_scope();
@@ -63,13 +63,13 @@ impl<E: TcEnv> Operations<ReturnTerm> for Tc<'_, E> {
 }
 
 impl<E: TcEnv> Operations<LoopControlTerm> for Tc<'_, E> {
-    type TyNode = TyId;
+    type AnnotNode = TyId;
     type Node = TermId;
 
     fn check(
         &self,
         _: &mut LoopControlTerm,
-        annotation_ty: Self::TyNode,
+        annotation_ty: Self::AnnotNode,
         _: Self::Node,
     ) -> crate::errors::TcResult<()> {
         // Always `never`.
@@ -103,13 +103,13 @@ impl<E: TcEnv> Operations<LoopControlTerm> for Tc<'_, E> {
 }
 
 impl<E: TcEnv> Operations<LoopTerm> for Tc<'_, E> {
-    type TyNode = TyId;
+    type AnnotNode = TyId;
     type Node = TermId;
 
     fn check(
         &self,
         loop_term: &mut LoopTerm,
-        annotation_ty: Self::TyNode,
+        annotation_ty: Self::AnnotNode,
         original_term_id: Self::Node,
     ) -> crate::errors::TcResult<()> {
         // Forward to the inner term.
@@ -147,13 +147,13 @@ impl<E: TcEnv> Operations<LoopTerm> for Tc<'_, E> {
 }
 
 impl<E: TcEnv> Operations<AssignTerm> for Tc<'_, E> {
-    type TyNode = TyId;
+    type AnnotNode = TyId;
     type Node = TermId;
 
     fn check(
         &self,
         assign_term: &mut AssignTerm,
-        annotation_ty: Self::TyNode,
+        annotation_ty: Self::AnnotNode,
         original_term_id: Self::Node,
     ) -> crate::errors::TcResult<()> {
         let subject_ty = Ty::hole_for(assign_term.subject);

--- a/compiler/hash-typecheck/src/operations/commands.rs
+++ b/compiler/hash-typecheck/src/operations/commands.rs
@@ -12,10 +12,10 @@ use crate::{
     env::TcEnv,
     options::normalisation::{normalised_to, NormaliseResult, NormaliseSignal},
     tc::Tc,
-    traits::{Operations, OperationsOnNode},
+    traits::{OperationsOn, OperationsOnNode},
 };
 
-impl<E: TcEnv> Operations<ReturnTerm> for Tc<'_, E> {
+impl<E: TcEnv> OperationsOn<ReturnTerm> for Tc<'_, E> {
     type AnnotNode = TyId;
     type Node = TermId;
 
@@ -62,7 +62,7 @@ impl<E: TcEnv> Operations<ReturnTerm> for Tc<'_, E> {
     }
 }
 
-impl<E: TcEnv> Operations<LoopControlTerm> for Tc<'_, E> {
+impl<E: TcEnv> OperationsOn<LoopControlTerm> for Tc<'_, E> {
     type AnnotNode = TyId;
     type Node = TermId;
 
@@ -102,7 +102,7 @@ impl<E: TcEnv> Operations<LoopControlTerm> for Tc<'_, E> {
     }
 }
 
-impl<E: TcEnv> Operations<LoopTerm> for Tc<'_, E> {
+impl<E: TcEnv> OperationsOn<LoopTerm> for Tc<'_, E> {
     type AnnotNode = TyId;
     type Node = TermId;
 
@@ -146,7 +146,7 @@ impl<E: TcEnv> Operations<LoopTerm> for Tc<'_, E> {
     }
 }
 
-impl<E: TcEnv> Operations<AssignTerm> for Tc<'_, E> {
+impl<E: TcEnv> OperationsOn<AssignTerm> for Tc<'_, E> {
     type AnnotNode = TyId;
     type Node = TermId;
 

--- a/compiler/hash-typecheck/src/operations/data.rs
+++ b/compiler/hash-typecheck/src/operations/data.rs
@@ -112,7 +112,7 @@ impl<E: TcEnv> Operations<CtorTerm> for Tc<'_, E> {
         let expected_data_ty =
             Ty::expect_is(original_term_id, Ty::from(annotation_data_ty, annotation_ty.origin()));
         self.unification_opts.pat_binds.enter(Some(binds), || {
-            self.add_unification_from_sub(&resulting_sub);
+            self.add_sub_to_scope(&resulting_sub);
             self.unify_nodes(expected_data_ty, annotation_ty)
         })?;
 
@@ -385,7 +385,7 @@ impl<E: TcEnv> Operations<CtorPat> for Tc<'_, E> {
         let expected_data_ty =
             Ty::expect_is(original_pat_id, Ty::from(annotation_data_ty, annotation_ty.origin()));
         self.unification_opts.pat_binds.enter(Some(binds), || {
-            self.add_unification_from_sub(&resulting_sub);
+            self.add_sub_to_scope(&resulting_sub);
             self.unify_nodes(expected_data_ty, annotation_ty)
         })?;
 

--- a/compiler/hash-typecheck/src/operations/data.rs
+++ b/compiler/hash-typecheck/src/operations/data.rs
@@ -16,10 +16,10 @@ use crate::{
     errors::{TcError, TcResult},
     options::normalisation::{already_normalised, normalise_nested, NormaliseResult},
     tc::Tc,
-    traits::{Operations, OperationsOnNode, ScopedOperationsOnNode},
+    traits::{OperationsOn, OperationsOnNode, ScopedOperationsOnNode},
 };
 
-impl<E: TcEnv> Operations<CtorTerm> for Tc<'_, E> {
+impl<E: TcEnv> OperationsOn<CtorTerm> for Tc<'_, E> {
     type AnnotNode = TyId;
     type Node = TermId;
 
@@ -166,7 +166,7 @@ impl<E: TcEnv> Operations<CtorTerm> for Tc<'_, E> {
     }
 }
 
-impl<E: TcEnv> Operations<DataTy> for Tc<'_, E> {
+impl<E: TcEnv> OperationsOn<DataTy> for Tc<'_, E> {
     type AnnotNode = TyId;
     type Node = TermId;
 
@@ -288,7 +288,7 @@ impl<E: TcEnv> OperationsOnNode<CtorDefId> for Tc<'_, E> {
     }
 }
 
-impl<E: TcEnv> Operations<CtorPat> for Tc<'_, E> {
+impl<E: TcEnv> OperationsOn<CtorPat> for Tc<'_, E> {
     type AnnotNode = TyId;
     type Node = PatId;
 

--- a/compiler/hash-typecheck/src/operations/data.rs
+++ b/compiler/hash-typecheck/src/operations/data.rs
@@ -16,17 +16,17 @@ use crate::{
     errors::{TcError, TcResult},
     options::normalisation::{already_normalised, normalise_nested, NormaliseResult},
     tc::Tc,
-    traits::{Operations, OperationsOnNode, RecursiveOperationsOnNode},
+    traits::{Operations, OperationsOnNode, ScopedOperationsOnNode},
 };
 
 impl<E: TcEnv> Operations<CtorTerm> for Tc<'_, E> {
-    type TyNode = TyId;
+    type AnnotNode = TyId;
     type Node = TermId;
 
     fn check(
         &self,
         term: &mut CtorTerm,
-        annotation_ty: Self::TyNode,
+        annotation_ty: Self::AnnotNode,
         original_term_id: Self::Node,
     ) -> TcResult<()> {
         let mut term = *term;
@@ -76,7 +76,7 @@ impl<E: TcEnv> Operations<CtorTerm> for Tc<'_, E> {
         // possible.
         let copied_params = self.visitor().copy(data_def.params);
         let (inferred_ctor_data_args, subbed_ctor_params, subbed_ctor_result_args) = self
-            .check_node_rec(ctor_data_args, copied_params, |inferred_data_args| {
+            .check_node_scoped(ctor_data_args, copied_params, |inferred_data_args| {
                 let sub = self.substituter().create_sub_from_current_scope();
                 let subbed_ctor_params = self.substituter().apply_sub(ctor.params, &sub);
                 let subbed_ctor_result_args = self.substituter().apply_sub(ctor.result_args, &sub);
@@ -88,8 +88,10 @@ impl<E: TcEnv> Operations<CtorTerm> for Tc<'_, E> {
         // parameters. Substitute any results to the constructor arguments, the
         // result arguments of the constructor, and the constructor data
         // arguments.
-        let (final_result_args, resulting_sub, binds) =
-            self.check_node_rec(term.ctor_args, subbed_ctor_params, |inferred_term_ctor_args| {
+        let (final_result_args, resulting_sub, binds) = self.check_node_scoped(
+            term.ctor_args,
+            subbed_ctor_params,
+            |inferred_term_ctor_args| {
                 let ctor_sub = self.substituter().create_sub_from_current_scope();
                 self.substituter().apply_sub_in_place(subbed_ctor_result_args, &ctor_sub);
                 self.substituter().apply_sub_in_place(inferred_term_ctor_args, &ctor_sub);
@@ -104,7 +106,8 @@ impl<E: TcEnv> Operations<CtorTerm> for Tc<'_, E> {
                 let hidden_ctor_sub =
                     self.substituter().hide_param_binds(ctor.params.iter(), &ctor_sub);
                 Ok((subbed_ctor_result_args, hidden_ctor_sub, HashSet::new()))
-            })?;
+            },
+        )?;
 
         // Set the annotation data type to the final result arguments, and unify
         // the annotation type with the expected type.
@@ -157,25 +160,25 @@ impl<E: TcEnv> Operations<CtorTerm> for Tc<'_, E> {
         if src.ctor != target.ctor {
             return self.mismatching_atoms(src_node, target_node);
         }
-        self.unify_nodes_rec(src.data_args, target.data_args, |_| Ok(()))?;
-        self.unify_nodes_rec(src.ctor_args, target.ctor_args, |_| Ok(()))?;
+        self.unify_nodes_scoped(src.data_args, target.data_args, |_| Ok(()))?;
+        self.unify_nodes_scoped(src.ctor_args, target.ctor_args, |_| Ok(()))?;
         Ok(())
     }
 }
 
 impl<E: TcEnv> Operations<DataTy> for Tc<'_, E> {
-    type TyNode = TyId;
+    type AnnotNode = TyId;
     type Node = TermId;
 
     fn check(
         &self,
         data_ty: &mut DataTy,
-        annotation_ty: Self::TyNode,
+        annotation_ty: Self::AnnotNode,
         term_id: Self::Node,
     ) -> TcResult<()> {
         let data_def = data_ty.data_def.value();
         let copied_params = self.visitor().copy(data_def.params);
-        self.check_node_rec(data_ty.args, copied_params, |inferred_data_ty_args| {
+        self.check_node_scoped(data_ty.args, copied_params, |inferred_data_ty_args| {
             data_ty.args = inferred_data_ty_args;
             term_id.set(term_id.value().with_data((*data_ty).into()));
             Ok(())
@@ -202,18 +205,18 @@ impl<E: TcEnv> Operations<DataTy> for Tc<'_, E> {
         if src.data_def != target.data_def {
             return self.mismatching_atoms(src_node, target_node);
         }
-        self.unify_nodes_rec(src.args, target.args, |_| Ok(()))
+        self.unify_nodes_scoped(src.args, target.args, |_| Ok(()))
     }
 }
 
 impl<E: TcEnv> OperationsOnNode<DataDefId> for Tc<'_, E> {
-    type TyNode = ();
+    type AnnotNode = ();
 
-    fn check_node(&self, data_def_id: DataDefId, _: Self::TyNode) -> TcResult<()> {
+    fn check_node(&self, data_def_id: DataDefId, _: Self::AnnotNode) -> TcResult<()> {
         let (data_def_params, data_def_ctors) =
             data_def_id.map(|data_def| (data_def.params, data_def.ctors));
 
-        self.check_node_rec(data_def_params, (), |_| {
+        self.check_node_scoped(data_def_params, (), |_| {
             match data_def_ctors {
                 DataDefCtors::Defined(data_def_ctors_id) => {
                     let mut error_state = ErrorState::new();
@@ -261,11 +264,11 @@ impl<E: TcEnv> OperationsOnNode<DataDefId> for Tc<'_, E> {
 }
 
 impl<E: TcEnv> OperationsOnNode<CtorDefId> for Tc<'_, E> {
-    type TyNode = ();
+    type AnnotNode = ();
 
-    fn check_node(&self, ctor: CtorDefId, _: Self::TyNode) -> TcResult<()> {
+    fn check_node(&self, ctor: CtorDefId, _: Self::AnnotNode) -> TcResult<()> {
         let ctor_def = ctor.value();
-        self.check_node_rec(ctor_def.params, (), |()| {
+        self.check_node_scoped(ctor_def.params, (), |()| {
             let return_ty = Ty::from(
                 DataTy { data_def: ctor_def.data_def_id, args: ctor_def.result_args },
                 ctor.origin(),
@@ -286,13 +289,13 @@ impl<E: TcEnv> OperationsOnNode<CtorDefId> for Tc<'_, E> {
 }
 
 impl<E: TcEnv> Operations<CtorPat> for Tc<'_, E> {
-    type TyNode = TyId;
+    type AnnotNode = TyId;
     type Node = PatId;
 
     fn check(
         &self,
         pat: &mut CtorPat,
-        annotation_ty: Self::TyNode,
+        annotation_ty: Self::AnnotNode,
         original_pat_id: Self::Node,
     ) -> TcResult<()> {
         let mut pat = *pat;
@@ -342,7 +345,7 @@ impl<E: TcEnv> Operations<CtorPat> for Tc<'_, E> {
         // possible.
         let copied_params = self.visitor().copy(data_def.params);
         let (inferred_ctor_data_args, subbed_ctor_params, subbed_ctor_result_args) = self
-            .check_node_rec(ctor_data_args, copied_params, |inferred_data_args| {
+            .check_node_scoped(ctor_data_args, copied_params, |inferred_data_args| {
                 let sub = self.substituter().create_sub_from_current_scope();
                 let subbed_ctor_params = self.substituter().apply_sub(ctor.params, &sub);
                 let subbed_ctor_result_args = self.substituter().apply_sub(ctor.result_args, &sub);
@@ -354,7 +357,7 @@ impl<E: TcEnv> Operations<CtorPat> for Tc<'_, E> {
         // parameters. Substitute any results to the constructor arguments, the
         // result arguments of the constructor, and the constructor data
         // arguments.
-        let (final_result_args, resulting_sub, binds) = self.check_node_rec(
+        let (final_result_args, resulting_sub, binds) = self.check_node_scoped(
             (pat.ctor_pat_args, pat.ctor_pat_args_spread),
             subbed_ctor_params,
             |inferred_pat_ctor_args| {

--- a/compiler/hash-typecheck/src/operations/fns.rs
+++ b/compiler/hash-typecheck/src/operations/fns.rs
@@ -13,10 +13,10 @@ use crate::{
     errors::TcResult,
     options::normalisation::{already_normalised, NormaliseResult},
     tc::{FnInferMode, Tc},
-    traits::{Operations, OperationsOnNode, ScopedOperationsOnNode},
+    traits::{OperationsOn, OperationsOnNode, ScopedOperationsOnNode},
 };
 
-impl<E: TcEnv> Operations<FnTy> for Tc<'_, E> {
+impl<E: TcEnv> OperationsOn<FnTy> for Tc<'_, E> {
     type AnnotNode = TyId;
     type Node = TyId;
 
@@ -90,7 +90,7 @@ impl<E: TcEnv> Tc<'_, E> {
     }
 }
 
-impl<E: TcEnv> Operations<FnDefId> for Tc<'_, E> {
+impl<E: TcEnv> OperationsOn<FnDefId> for Tc<'_, E> {
     type AnnotNode = TyId;
     type Node = TermId;
 

--- a/compiler/hash-typecheck/src/operations/holes.rs
+++ b/compiler/hash-typecheck/src/operations/holes.rs
@@ -23,13 +23,13 @@ impl<E: TcEnv> Tc<'_, E> {
 }
 
 impl<E: TcEnv> Operations<Hole> for Tc<'_, E> {
-    type TyNode = TyId;
+    type AnnotNode = TyId;
     type Node = TermId;
 
     fn check(
         &self,
         _item: &mut Hole,
-        _item_ty: Self::TyNode,
+        _item_ty: Self::AnnotNode,
         _item_node: Self::Node,
     ) -> crate::errors::TcResult<()> {
         // No-op

--- a/compiler/hash-typecheck/src/operations/holes.rs
+++ b/compiler/hash-typecheck/src/operations/holes.rs
@@ -5,7 +5,7 @@ use hash_tir::tir::{Hole, TermId, TyId, VarTerm};
 
 use crate::{
     env::TcEnv, errors::TcResult, options::normalisation::NormaliseResult, tc::Tc,
-    traits::Operations,
+    traits::OperationsOn,
 };
 
 impl<E: TcEnv> Tc<'_, E> {
@@ -22,7 +22,7 @@ impl<E: TcEnv> Tc<'_, E> {
     }
 }
 
-impl<E: TcEnv> Operations<Hole> for Tc<'_, E> {
+impl<E: TcEnv> OperationsOn<Hole> for Tc<'_, E> {
     type AnnotNode = TyId;
     type Node = TermId;
 

--- a/compiler/hash-typecheck/src/operations/intrinsics.rs
+++ b/compiler/hash-typecheck/src/operations/intrinsics.rs
@@ -13,13 +13,13 @@ use crate::{
 };
 
 impl<E: TcEnv> Operations<Intrinsic> for Tc<'_, E> {
-    type TyNode = TyId;
+    type AnnotNode = TyId;
     type Node = TermId;
 
     fn check(
         &self,
         intrinsic: &mut Intrinsic,
-        annotation_ty: Self::TyNode,
+        annotation_ty: Self::AnnotNode,
         _: Self::Node,
     ) -> crate::errors::TcResult<()> {
         // ##GeneratedOrigin: intrinsics do not belong to the source code

--- a/compiler/hash-typecheck/src/operations/intrinsics.rs
+++ b/compiler/hash-typecheck/src/operations/intrinsics.rs
@@ -9,10 +9,10 @@ use crate::{
     env::TcEnv,
     options::normalisation::{already_normalised, NormaliseResult},
     tc::Tc,
-    traits::Operations,
+    traits::OperationsOn,
 };
 
-impl<E: TcEnv> Operations<Intrinsic> for Tc<'_, E> {
+impl<E: TcEnv> OperationsOn<Intrinsic> for Tc<'_, E> {
     type AnnotNode = TyId;
     type Node = TermId;
 

--- a/compiler/hash-typecheck/src/operations/lits.rs
+++ b/compiler/hash-typecheck/src/operations/lits.rs
@@ -75,9 +75,9 @@ impl<E: TcEnv> Tc<'_, E> {
 }
 
 impl<E: TcEnv> OperationsOnNode<LitId> for Tc<'_, E> {
-    type TyNode = TyId;
+    type AnnotNode = TyId;
 
-    fn check_node(&self, lit: LitId, annotation_ty: Self::TyNode) -> TcResult<()> {
+    fn check_node(&self, lit: LitId, annotation_ty: Self::AnnotNode) -> TcResult<()> {
         self.normalise_and_check_ty(annotation_ty)?;
         let inferred_ty = Ty::data_ty(
             match *lit.value() {

--- a/compiler/hash-typecheck/src/operations/matching.rs
+++ b/compiler/hash-typecheck/src/operations/matching.rs
@@ -21,13 +21,13 @@ use crate::{
 };
 
 impl<E: TcEnv> Operations<MatchTerm> for Tc<'_, E> {
-    type TyNode = TyId;
+    type AnnotNode = TyId;
     type Node = TermId;
 
     fn check(
         &self,
         match_term: &mut MatchTerm,
-        annotation_ty: Self::TyNode,
+        annotation_ty: Self::AnnotNode,
         _original_node_id: Self::Node,
     ) -> crate::errors::TcResult<()> {
         self.check_ty(annotation_ty)?;

--- a/compiler/hash-typecheck/src/operations/matching.rs
+++ b/compiler/hash-typecheck/src/operations/matching.rs
@@ -16,11 +16,11 @@ use crate::{
         normalised_to, stuck_normalising, NormalisationState, NormaliseResult, NormaliseSignal,
     },
     tc::Tc,
-    traits::{Operations, OperationsOnNode},
+    traits::{OperationsOn, OperationsOnNode},
     utils::matching::MatchResult,
 };
 
-impl<E: TcEnv> Operations<MatchTerm> for Tc<'_, E> {
+impl<E: TcEnv> OperationsOn<MatchTerm> for Tc<'_, E> {
     type AnnotNode = TyId;
     type Node = TermId;
 

--- a/compiler/hash-typecheck/src/operations/mods.rs
+++ b/compiler/hash-typecheck/src/operations/mods.rs
@@ -12,7 +12,7 @@ use crate::{
     errors::TcError,
     options::normalisation::{already_normalised, NormaliseResult},
     tc::{FnInferMode, Tc},
-    traits::{Operations, OperationsOnNode},
+    traits::{OperationsOn, OperationsOnNode},
     utils::dumping::potentially_dump_tir,
 };
 

--- a/compiler/hash-typecheck/src/operations/mods.rs
+++ b/compiler/hash-typecheck/src/operations/mods.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 
 impl<E: TcEnv> OperationsOnNode<ModDefId> for Tc<'_, E> {
-    type TyNode = ();
+    type AnnotNode = ();
 
     fn check_node(&self, mod_def_id: ModDefId, _: ()) -> crate::errors::TcResult<()> {
         self.context().enter_scope(mod_def_id.into(), || {
@@ -44,9 +44,13 @@ impl<E: TcEnv> OperationsOnNode<ModDefId> for Tc<'_, E> {
 }
 
 impl<E: TcEnv> OperationsOnNode<ModMemberId> for Tc<'_, E> {
-    type TyNode = ();
+    type AnnotNode = ();
 
-    fn check_node(&self, mod_member: ModMemberId, _: Self::TyNode) -> crate::errors::TcResult<()> {
+    fn check_node(
+        &self,
+        mod_member: ModMemberId,
+        _: Self::AnnotNode,
+    ) -> crate::errors::TcResult<()> {
         let value = mod_member.borrow().value;
         match value {
             ModMemberValue::Data(data_def_id) => {

--- a/compiler/hash-typecheck/src/operations/params.rs
+++ b/compiler/hash-typecheck/src/operations/params.rs
@@ -11,17 +11,17 @@ use crate::{
     errors::{TcError, TcResult},
     options::normalisation::{already_normalised, NormaliseResult},
     tc::Tc,
-    traits::{OperationsOnNode, RecursiveOperationsOnNode},
+    traits::{OperationsOnNode, ScopedOperationsOnNode},
 };
 
-impl<E: TcEnv> RecursiveOperationsOnNode<ParamsId> for Tc<'_, E> {
-    type TyNode = ();
-    type RecursiveArg = ();
+impl<E: TcEnv> ScopedOperationsOnNode<ParamsId> for Tc<'_, E> {
+    type AnnotNode = ();
+    type CallbackArg = ();
 
-    fn check_node_rec<T, F: FnMut(Self::RecursiveArg) -> TcResult<T>>(
+    fn check_node_scoped<T, F: FnMut(Self::CallbackArg) -> TcResult<T>>(
         &self,
         params: ParamsId,
-        _: Self::TyNode,
+        _: Self::AnnotNode,
         mut in_param_scope: F,
     ) -> TcResult<T> {
         // Validate the parameters
@@ -48,11 +48,11 @@ impl<E: TcEnv> RecursiveOperationsOnNode<ParamsId> for Tc<'_, E> {
         Ok(result)
     }
 
-    fn try_normalise_node_rec(&self, _item: ParamsId) -> NormaliseResult<ControlFlow<ParamsId>> {
+    fn try_normalise_node(&self, _item: ParamsId) -> NormaliseResult<ControlFlow<ParamsId>> {
         already_normalised()
     }
 
-    fn unify_nodes_rec<T, F: FnMut(Self::RecursiveArg) -> TcResult<T>>(
+    fn unify_nodes_scoped<T, F: FnMut(Self::CallbackArg) -> TcResult<T>>(
         &self,
         src_id: ParamsId,
         target_id: ParamsId,

--- a/compiler/hash-typecheck/src/operations/params.rs
+++ b/compiler/hash-typecheck/src/operations/params.rs
@@ -44,7 +44,7 @@ impl<E: TcEnv> RecursiveOperationsOnNode<ParamsId> for Tc<'_, E> {
             })?;
 
         // Add the shadowed substitutions to the ambient scope
-        self.add_unification_from_sub(&shadowed_sub);
+        self.add_sub_to_scope(&shadowed_sub);
         Ok(result)
     }
 
@@ -101,7 +101,7 @@ impl<E: TcEnv> RecursiveOperationsOnNode<ParamsId> for Tc<'_, E> {
             })?;
 
         // Add the shadowed substitutions to the ambient scope
-        self.add_unification_from_sub(&shadowed_sub);
+        self.add_sub_to_scope(&shadowed_sub);
 
         Ok(result)
     }

--- a/compiler/hash-typecheck/src/operations/pats.rs
+++ b/compiler/hash-typecheck/src/operations/pats.rs
@@ -41,12 +41,12 @@ impl<E: TcEnv> Tc<'_, E> {
 }
 
 impl<E: TcEnv> OperationsOnNode<PatId> for Tc<'_, E> {
-    type TyNode = (TyId, Option<TermId>);
+    type AnnotNode = (TyId, Option<TermId>);
 
     fn check_node(
         &self,
         pat_id: PatId,
-        (annotation_ty, binds_to): Self::TyNode,
+        (annotation_ty, binds_to): Self::AnnotNode,
     ) -> crate::errors::TcResult<()> {
         self.register_new_atom(pat_id, annotation_ty);
 
@@ -76,13 +76,13 @@ impl<E: TcEnv> OperationsOnNode<PatId> for Tc<'_, E> {
 }
 
 impl<E: TcEnv> Operations<IfPat> for Tc<'_, E> {
-    type TyNode = TyId;
+    type AnnotNode = TyId;
     type Node = PatId;
 
     fn check(
         &self,
         pat: &mut IfPat,
-        annotation_ty: Self::TyNode,
+        annotation_ty: Self::AnnotNode,
         _: Self::Node,
     ) -> crate::errors::TcResult<()> {
         self.check_node(pat.pat, (annotation_ty, None))?;
@@ -119,13 +119,13 @@ impl<E: TcEnv> Operations<IfPat> for Tc<'_, E> {
 }
 
 impl<E: TcEnv> Operations<OrPat> for Tc<'_, E> {
-    type TyNode = TyId;
+    type AnnotNode = TyId;
     type Node = PatId;
 
     fn check(
         &self,
         pat: &mut OrPat,
-        annotation_ty: Self::TyNode,
+        annotation_ty: Self::AnnotNode,
         _: Self::Node,
     ) -> crate::errors::TcResult<()> {
         self.check_unified_pat_list(pat.alternatives, annotation_ty)?;

--- a/compiler/hash-typecheck/src/operations/pats.rs
+++ b/compiler/hash-typecheck/src/operations/pats.rs
@@ -16,7 +16,7 @@ use crate::{
     errors::TcResult,
     options::normalisation::{normalise_nested, NormaliseResult},
     tc::Tc,
-    traits::{Operations, OperationsOnNode},
+    traits::{OperationsOn, OperationsOnNode},
 };
 
 impl<E: TcEnv> Tc<'_, E> {
@@ -75,7 +75,7 @@ impl<E: TcEnv> OperationsOnNode<PatId> for Tc<'_, E> {
     }
 }
 
-impl<E: TcEnv> Operations<IfPat> for Tc<'_, E> {
+impl<E: TcEnv> OperationsOn<IfPat> for Tc<'_, E> {
     type AnnotNode = TyId;
     type Node = PatId;
 
@@ -118,7 +118,7 @@ impl<E: TcEnv> Operations<IfPat> for Tc<'_, E> {
     }
 }
 
-impl<E: TcEnv> Operations<OrPat> for Tc<'_, E> {
+impl<E: TcEnv> OperationsOn<OrPat> for Tc<'_, E> {
     type AnnotNode = TyId;
     type Node = PatId;
 

--- a/compiler/hash-typecheck/src/operations/range.rs
+++ b/compiler/hash-typecheck/src/operations/range.rs
@@ -44,13 +44,13 @@ impl<E: TcEnv> Tc<'_, E> {
 }
 
 impl<E: TcEnv> Operations<RangePat> for Tc<'_, E> {
-    type TyNode = TyId;
+    type AnnotNode = TyId;
     type Node = PatId;
 
     fn check(
         &self,
         range_pat: &mut RangePat,
-        annotation_ty: Self::TyNode,
+        annotation_ty: Self::AnnotNode,
         _: Self::Node,
     ) -> crate::errors::TcResult<()> {
         let RangePat { lo, hi, .. } = range_pat;

--- a/compiler/hash-typecheck/src/operations/range.rs
+++ b/compiler/hash-typecheck/src/operations/range.rs
@@ -7,7 +7,7 @@ use crate::{
     env::TcEnv,
     options::normalisation::{normalise_nested, NormaliseResult},
     tc::Tc,
-    traits::{Operations, OperationsOnNode},
+    traits::{OperationsOn, OperationsOnNode},
     utils::matching::MatchResult,
 };
 
@@ -43,7 +43,7 @@ impl<E: TcEnv> Tc<'_, E> {
     }
 }
 
-impl<E: TcEnv> Operations<RangePat> for Tc<'_, E> {
+impl<E: TcEnv> OperationsOn<RangePat> for Tc<'_, E> {
     type AnnotNode = TyId;
     type Node = PatId;
 

--- a/compiler/hash-typecheck/src/operations/refs.rs
+++ b/compiler/hash-typecheck/src/operations/refs.rs
@@ -10,10 +10,10 @@ use crate::{
         normalise_nested, normalised_if, normalised_to, NormalisationState, NormaliseResult,
     },
     tc::Tc,
-    traits::{Operations, OperationsOnNode},
+    traits::{OperationsOn, OperationsOnNode},
 };
 
-impl<E: TcEnv> Operations<RefTerm> for Tc<'_, E> {
+impl<E: TcEnv> OperationsOn<RefTerm> for Tc<'_, E> {
     type AnnotNode = TyId;
     type Node = TermId;
 
@@ -76,7 +76,7 @@ impl<E: TcEnv> Operations<RefTerm> for Tc<'_, E> {
     }
 }
 
-impl<E: TcEnv> Operations<DerefTerm> for Tc<'_, E> {
+impl<E: TcEnv> OperationsOn<DerefTerm> for Tc<'_, E> {
     type AnnotNode = TyId;
     type Node = TermId;
 
@@ -131,7 +131,7 @@ impl<E: TcEnv> Operations<DerefTerm> for Tc<'_, E> {
     }
 }
 
-impl<E: TcEnv> Operations<RefTy> for Tc<'_, E> {
+impl<E: TcEnv> OperationsOn<RefTy> for Tc<'_, E> {
     type AnnotNode = TyId;
     type Node = TermId;
 

--- a/compiler/hash-typecheck/src/operations/refs.rs
+++ b/compiler/hash-typecheck/src/operations/refs.rs
@@ -14,13 +14,13 @@ use crate::{
 };
 
 impl<E: TcEnv> Operations<RefTerm> for Tc<'_, E> {
-    type TyNode = TyId;
+    type AnnotNode = TyId;
     type Node = TermId;
 
     fn check(
         &self,
         ref_term: &mut RefTerm,
-        annotation_ty: Self::TyNode,
+        annotation_ty: Self::AnnotNode,
         original_term_id: Self::Node,
     ) -> crate::errors::TcResult<()> {
         self.normalise_and_check_ty(annotation_ty)?;
@@ -77,13 +77,13 @@ impl<E: TcEnv> Operations<RefTerm> for Tc<'_, E> {
 }
 
 impl<E: TcEnv> Operations<DerefTerm> for Tc<'_, E> {
-    type TyNode = TyId;
+    type AnnotNode = TyId;
     type Node = TermId;
 
     fn check(
         &self,
         deref_term: &mut DerefTerm,
-        annotation_ty: Self::TyNode,
+        annotation_ty: Self::AnnotNode,
         _item_node: Self::Node,
     ) -> crate::errors::TcResult<()> {
         let deref_inner_inferred = Ty::hole_for(deref_term.subject);
@@ -132,13 +132,13 @@ impl<E: TcEnv> Operations<DerefTerm> for Tc<'_, E> {
 }
 
 impl<E: TcEnv> Operations<RefTy> for Tc<'_, E> {
-    type TyNode = TyId;
+    type AnnotNode = TyId;
     type Node = TermId;
 
     fn check(
         &self,
         ref_ty: &mut RefTy,
-        annotation_ty: Self::TyNode,
+        annotation_ty: Self::AnnotNode,
         _original_term_id: Self::Node,
     ) -> crate::errors::TcResult<()> {
         // Infer the inner type

--- a/compiler/hash-typecheck/src/operations/safety.rs
+++ b/compiler/hash-typecheck/src/operations/safety.rs
@@ -7,10 +7,10 @@ use crate::{
     errors::TcResult,
     options::normalisation::{normalised_option, NormaliseResult},
     tc::Tc,
-    traits::{Operations, OperationsOnNode},
+    traits::{OperationsOn, OperationsOnNode},
 };
 
-impl<E: TcEnv> Operations<UnsafeTerm> for Tc<'_, E> {
+impl<E: TcEnv> OperationsOn<UnsafeTerm> for Tc<'_, E> {
     type AnnotNode = TyId;
     type Node = TermId;
 

--- a/compiler/hash-typecheck/src/operations/safety.rs
+++ b/compiler/hash-typecheck/src/operations/safety.rs
@@ -11,13 +11,13 @@ use crate::{
 };
 
 impl<E: TcEnv> Operations<UnsafeTerm> for Tc<'_, E> {
-    type TyNode = TyId;
+    type AnnotNode = TyId;
     type Node = TermId;
 
     fn check(
         &self,
         unsafe_term: &mut UnsafeTerm,
-        annotation_ty: Self::TyNode,
+        annotation_ty: Self::AnnotNode,
         _: Self::Node,
     ) -> TcResult<()> {
         // @@Todo

--- a/compiler/hash-typecheck/src/operations/terms.rs
+++ b/compiler/hash-typecheck/src/operations/terms.rs
@@ -11,7 +11,7 @@ use crate::{
     errors::TcResult,
     options::normalisation::NormaliseResult,
     tc::{FnInferMode, Tc},
-    traits::{Operations, OperationsOnNode},
+    traits::{OperationsOn, OperationsOnNode},
     utils::dumping::potentially_dump_tir,
 };
 

--- a/compiler/hash-typecheck/src/operations/terms.rs
+++ b/compiler/hash-typecheck/src/operations/terms.rs
@@ -32,9 +32,9 @@ impl<E: TcEnv> Tc<'_, E> {
 }
 
 impl<E: TcEnv> OperationsOnNode<TermId> for Tc<'_, E> {
-    type TyNode = TyId;
+    type AnnotNode = TyId;
 
-    fn check_node(&self, term_id: TermId, annotation_ty: Self::TyNode) -> TcResult<()> {
+    fn check_node(&self, term_id: TermId, annotation_ty: Self::AnnotNode) -> TcResult<()> {
         self.register_new_atom(term_id, annotation_ty);
         match *term_id.value() {
             Term::Tuple(mut tuple_term) => self.check(&mut tuple_term, annotation_ty, term_id)?,

--- a/compiler/hash-typecheck/src/operations/tuples.rs
+++ b/compiler/hash-typecheck/src/operations/tuples.rs
@@ -12,10 +12,10 @@ use crate::{
     errors::{TcError, TcResult},
     options::normalisation::{normalise_nested, NormaliseResult},
     tc::Tc,
-    traits::{Operations, ScopedOperationsOnNode},
+    traits::{OperationsOn, ScopedOperationsOnNode},
 };
 
-impl<E: TcEnv> Operations<TupleTerm> for Tc<'_, E> {
+impl<E: TcEnv> OperationsOn<TupleTerm> for Tc<'_, E> {
     type AnnotNode = TyId;
     type Node = TermId;
 
@@ -80,7 +80,7 @@ impl<E: TcEnv> Operations<TupleTerm> for Tc<'_, E> {
     }
 }
 
-impl<E: TcEnv> Operations<TupleTy> for Tc<'_, E> {
+impl<E: TcEnv> OperationsOn<TupleTy> for Tc<'_, E> {
     type AnnotNode = TyId;
     type Node = TyId;
 
@@ -114,7 +114,7 @@ impl<E: TcEnv> Operations<TupleTy> for Tc<'_, E> {
     }
 }
 
-impl<E: TcEnv> Operations<TuplePat> for Tc<'_, E> {
+impl<E: TcEnv> OperationsOn<TuplePat> for Tc<'_, E> {
     type AnnotNode = TyId;
     type Node = PatId;
 

--- a/compiler/hash-typecheck/src/operations/ty_of.rs
+++ b/compiler/hash-typecheck/src/operations/ty_of.rs
@@ -14,13 +14,13 @@ use crate::{
 };
 
 impl<E: TcEnv> Operations<TyOfTerm> for Tc<'_, E> {
-    type TyNode = TyId;
+    type AnnotNode = TyId;
     type Node = TermId;
 
     fn check(
         &self,
         ty_of_term: &mut TyOfTerm,
-        annotation_ty: Self::TyNode,
+        annotation_ty: Self::AnnotNode,
         original_term_id: Self::Node,
     ) -> TcResult<()> {
         let inferred_ty = Ty::hole_for(ty_of_term.term);

--- a/compiler/hash-typecheck/src/operations/ty_of.rs
+++ b/compiler/hash-typecheck/src/operations/ty_of.rs
@@ -10,10 +10,10 @@ use crate::{
     errors::TcResult,
     options::normalisation::{normalised_to, stuck_normalising, NormaliseResult},
     tc::Tc,
-    traits::{Operations, OperationsOnNode},
+    traits::{OperationsOn, OperationsOnNode},
 };
 
-impl<E: TcEnv> Operations<TyOfTerm> for Tc<'_, E> {
+impl<E: TcEnv> OperationsOn<TyOfTerm> for Tc<'_, E> {
     type AnnotNode = TyId;
     type Node = TermId;
 

--- a/compiler/hash-typecheck/src/operations/universe.rs
+++ b/compiler/hash-typecheck/src/operations/universe.rs
@@ -7,7 +7,7 @@ use crate::{
     errors::TcResult,
     options::normalisation::{already_normalised, NormaliseResult},
     tc::Tc,
-    traits::{Operations, OperationsOnNode},
+    traits::{OperationsOn, OperationsOnNode},
 };
 
 impl<E: TcEnv> Tc<'_, E> {
@@ -16,7 +16,7 @@ impl<E: TcEnv> Tc<'_, E> {
     }
 }
 
-impl<E: TcEnv> Operations<UniverseTy> for Tc<'_, E> {
+impl<E: TcEnv> OperationsOn<UniverseTy> for Tc<'_, E> {
     type AnnotNode = TyId;
     type Node = TyId;
 

--- a/compiler/hash-typecheck/src/operations/universe.rs
+++ b/compiler/hash-typecheck/src/operations/universe.rs
@@ -17,10 +17,10 @@ impl<E: TcEnv> Tc<'_, E> {
 }
 
 impl<E: TcEnv> Operations<UniverseTy> for Tc<'_, E> {
-    type TyNode = TyId;
+    type AnnotNode = TyId;
     type Node = TyId;
 
-    fn check(&self, _: &mut UniverseTy, item_ty: Self::TyNode, _: Self::Node) -> TcResult<()> {
+    fn check(&self, _: &mut UniverseTy, item_ty: Self::AnnotNode, _: Self::Node) -> TcResult<()> {
         // Type: Type
         self.check_is_universe(item_ty)
     }

--- a/compiler/hash-typecheck/src/operations/vars.rs
+++ b/compiler/hash-typecheck/src/operations/vars.rs
@@ -17,13 +17,13 @@ use crate::{
 };
 
 impl<E: TcEnv> Operations<VarTerm> for Tc<'_, E> {
-    type TyNode = TyId;
+    type AnnotNode = TyId;
     type Node = TermId;
 
     fn check(
         &self,
         term: &mut VarTerm,
-        annotation_ty: Self::TyNode,
+        annotation_ty: Self::AnnotNode,
         _: Self::Node,
     ) -> TcResult<()> {
         let term = *term;
@@ -88,13 +88,13 @@ impl<E: TcEnv> Operations<VarTerm> for Tc<'_, E> {
 }
 
 impl<E: TcEnv> Operations<BindingPat> for Tc<'_, E> {
-    type TyNode = (TyId, Option<TermId>);
+    type AnnotNode = (TyId, Option<TermId>);
     type Node = PatId;
 
     fn check(
         &self,
         var: &mut BindingPat,
-        (annotation_ty, binds_to): Self::TyNode,
+        (annotation_ty, binds_to): Self::AnnotNode,
         _: Self::Node,
     ) -> TcResult<()> {
         self.check_ty(annotation_ty)?;

--- a/compiler/hash-typecheck/src/operations/vars.rs
+++ b/compiler/hash-typecheck/src/operations/vars.rs
@@ -13,10 +13,10 @@ use crate::{
     errors::TcResult,
     options::normalisation::{already_normalised, normalised_to, NormaliseResult},
     tc::Tc,
-    traits::{Operations, OperationsOnNode},
+    traits::{OperationsOn, OperationsOnNode},
 };
 
-impl<E: TcEnv> Operations<VarTerm> for Tc<'_, E> {
+impl<E: TcEnv> OperationsOn<VarTerm> for Tc<'_, E> {
     type AnnotNode = TyId;
     type Node = TermId;
 
@@ -87,7 +87,7 @@ impl<E: TcEnv> Operations<VarTerm> for Tc<'_, E> {
     }
 }
 
-impl<E: TcEnv> Operations<BindingPat> for Tc<'_, E> {
+impl<E: TcEnv> OperationsOn<BindingPat> for Tc<'_, E> {
     type AnnotNode = (TyId, Option<TermId>);
     type Node = PatId;
 

--- a/compiler/hash-typecheck/src/options/mod.rs
+++ b/compiler/hash-typecheck/src/options/mod.rs
@@ -1,2 +1,6 @@
+//! Contains definitions about flags and options that are read and written from
+//! during different typechecking operations such as unification or
+//! normalisation.
+
 pub mod normalisation;
 pub mod unification;

--- a/compiler/hash-typecheck/src/options/normalisation.rs
+++ b/compiler/hash-typecheck/src/options/normalisation.rs
@@ -10,9 +10,11 @@ use crate::errors::TcError;
 /// A signal which can be emitted during normalisation.
 #[derive(Debug, Clone, From)]
 pub enum NormaliseSignal {
-    /// A `LoopControlTerm::Break` was encountered in a loop.
+    /// A [`LoopControlTerm::Break`](hash_tir::tir::LoopControlTerm::Break) was
+    /// encountered in a loop.
     Break,
-    /// A `LoopControlTerm::Continue` was encountered in a loop.
+    /// A [`LoopControlTerm::Continue`](`hash_tir::tir::LoopControlTerm::Continue`) was encountered in a
+    /// loop.
     Continue,
     /// A `ReturnTerm` was encountered in a function, with the given return
     /// value.
@@ -179,13 +181,14 @@ impl NormalisationState {
 }
 
 /// The mode in which to normalise terms.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum NormalisationMode {
     /// Normalise the term as much as possible.
     Full,
-    /// Normalise the term to a single step (default).
+    /// Normalise the term to a single step.
     ///
     /// This will not execute any impure code.
+    #[default]
     Weak,
 }
 
@@ -204,6 +207,6 @@ impl Default for NormalisationOptions {
 
 impl NormalisationOptions {
     pub fn new() -> Self {
-        Self { mode: LightState::new(NormalisationMode::Weak) }
+        Self { mode: LightState::new(NormalisationMode::default()) }
     }
 }

--- a/compiler/hash-typecheck/src/options/normalisation.rs
+++ b/compiler/hash-typecheck/src/options/normalisation.rs
@@ -1,3 +1,5 @@
+//! Various structures that are used to keep track of normalisation progress and
+//! options that can be set for normalisation.
 use std::{cell::Cell, ops::ControlFlow};
 
 use hash_tir::tir::TermId;
@@ -8,13 +10,36 @@ use crate::errors::TcError;
 /// A signal which can be emitted during normalisation.
 #[derive(Debug, Clone, From)]
 pub enum NormaliseSignal {
+    /// A `LoopControlTerm::Break` was encountered in a loop.
     Break,
+    /// A `LoopControlTerm::Continue` was encountered in a loop.
     Continue,
+    /// A `ReturnTerm` was encountered in a function, with the given return
+    /// value.
     Return(TermId),
+    /// An typechecking error occurred during normalisation.
     Err(TcError),
 }
 
 /// The result of a normalisation operation.
+///
+/// - `Err(e)` means that the normalisation has stopped with the given signal.
+///   This might be an error, or some other signal such as a loop break or a
+///   function return.
+///
+/// - `Ok(None)` means that the normalisation was completed but the atom was
+///   already normalised so nothing needed to be done.
+///
+/// - `Ok(Some(t))` means that the normalisation was completed and the atom was
+///   normalised to `t`
+///
+/// Usually this type is used with `T = ControlFlow<U>` for some `U`. In this
+/// case, `ControlFlow::Break` is used to signal that the normalisation was
+/// completed and the atom was normalised to some `u: U`, and
+/// `ControlFlow::Continue` is used to signal that the normalisation should
+/// continue by recursing into the input `U`.
+// @@Improvement: maybe we can make this into a custom enum and implement
+// `std::ops::Try` for it?
 pub type NormaliseResult<T = ()> = Result<Option<T>, NormaliseSignal>;
 
 /// Signals that the atom is already normalised.
@@ -23,6 +48,9 @@ pub fn already_normalised<T>() -> NormaliseResult<T> {
 }
 
 /// Signals that the normalisation is stuck.
+///
+/// This is equivalent to the atom being already normalised, since no more
+/// steps can be taken. The difference is mostly for visual clarity.
 pub fn stuck_normalising<T>() -> NormaliseResult<T> {
     Ok(None)
 }
@@ -76,7 +104,7 @@ pub fn ctrl_continue<T>() -> NormaliseResult<ControlFlow<T>> {
 }
 
 /// Lift a `From` implementation into a conversion between normalisation
-/// results.
+/// results containing `ControlFlow`.
 pub fn normalisation_result_control_flow_into<T, U: From<T>>(
     t: NormaliseResult<ControlFlow<T>>,
 ) -> NormaliseResult<ControlFlow<U>> {
@@ -98,7 +126,10 @@ pub fn normalisation_result_into<T, U: From<T>>(t: NormaliseResult<T>) -> Normal
     }
 }
 
-/// Whether an atom has been evaluated or not.
+/// Used to keep track of whether normalisation has occurred or not.
+///
+/// Multiple normalisation operations can update the state, and in the end
+/// the accumulated result can be read through `has_normalised()`.
 #[derive(Debug, Clone, Default)]
 pub struct NormalisationState {
     has_normalised: Cell<bool>,
@@ -152,7 +183,7 @@ impl NormalisationState {
 pub enum NormalisationMode {
     /// Normalise the term as much as possible.
     Full,
-    /// Normalise the term to a single step.
+    /// Normalise the term to a single step (default).
     ///
     /// This will not execute any impure code.
     Weak,

--- a/compiler/hash-typecheck/src/options/unification.rs
+++ b/compiler/hash-typecheck/src/options/unification.rs
@@ -1,3 +1,5 @@
+//! Structures that are used to keep track of options that can be set for
+//! unification.
 use std::collections::HashSet;
 
 use hash_tir::tir::SymbolId;
@@ -6,11 +8,11 @@ use hash_utils::state::{HeavyState, LightState};
 /// Options for unification.
 #[derive(Debug)]
 pub struct UnificationOptions {
-    /// Whether to substitute the unified terms in-place.
+    /// Whether to substitute the unified terms in-place (default is true).
     pub modify_terms: LightState<bool>,
     /// A set of symbols which are bound by a pattern, so they should be unified
-    /// with any other symbol. @@Reconsider: this is probably not necessary with
-    /// some restructuring in unification.
+    /// with any other symbol (default is None). @@Reconsider: this is probably
+    /// not necessary with some restructuring in unification.
     pub pat_binds: HeavyState<Option<HashSet<SymbolId>>>,
 }
 

--- a/compiler/hash-typecheck/src/tc.rs
+++ b/compiler/hash-typecheck/src/tc.rs
@@ -12,6 +12,11 @@ use crate::{
 };
 
 /// The mode in which to infer the type of a function.
+// @@Hack: this is currently a hack to get around the insufficient hole-filling
+// mechanism of the typechecker. Ideally, we should eventually have a proper
+// hole-filling mechanism which re-unifies things until everything is filled
+// in. Then we can remove these two "inference passes" which are rather ad-hoc
+// at the moment.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FnInferMode {
     /// Infer the type of a function but do not look at its body.
@@ -38,10 +43,12 @@ pub struct Tc<'tc, E> {
 }
 
 impl<E: TcEnv> Tc<'_, E> {
+    /// Convenience function to create a new TIR visitor.
     pub fn visitor(&self) -> Visitor {
         Visitor::new()
     }
 
+    /// Create a substituter for this typechecker.
     pub fn substituter(&self) -> Substituter<E> {
         Substituter::new(self)
     }

--- a/compiler/hash-typecheck/src/tc.rs
+++ b/compiler/hash-typecheck/src/tc.rs
@@ -1,3 +1,5 @@
+//! Contains the main typechecker structure, which holds the state of the
+//! typechecker and is what all other `Operations` are implemented on.
 use hash_target::HasTarget;
 use hash_tir::{
     context::{Context, HasContext},

--- a/compiler/hash-typecheck/src/traits.rs
+++ b/compiler/hash-typecheck/src/traits.rs
@@ -11,7 +11,7 @@ use crate::{env::HasTcEnv, errors::TcResult, options::normalisation::NormaliseRe
 /// Main trait for typechecking on TIR atoms.
 ///
 /// `X` is the TIR atom type.
-pub trait Operations<X>: HasTcEnv {
+pub trait OperationsOn<X>: HasTcEnv {
     /// The atom's annotation in the TIR.
     ///
     /// For example, if `X = MatchTerm`, `AnnotNode = TyId`.
@@ -72,7 +72,7 @@ pub trait OperationsOnNode<X: Copy>: HasTcEnv {
 }
 
 /// Each `OperationsOnNode` is also an `Operations`.
-impl<X: Copy, T: HasTcEnv + OperationsOnNode<X>> Operations<X> for T {
+impl<X: Copy, T: HasTcEnv + OperationsOnNode<X>> OperationsOn<X> for T {
     type AnnotNode = T::AnnotNode;
     type Node = X;
 
@@ -95,7 +95,7 @@ impl<X: Copy, T: HasTcEnv + OperationsOnNode<X>> Operations<X> for T {
 /// One example is `Params`, which adds the parameter names to the context. For
 /// this reason, each TC operation here also receives a closure to run inside
 /// the context created by the node.
-pub trait ScopedOperations<X>: HasTcEnv {
+pub trait ScopedOperationsOn<X>: HasTcEnv {
     /// The atom's annotation in the TIR.
     type AnnotNode;
 
@@ -170,7 +170,7 @@ pub trait ScopedOperationsOnNode<X: Copy>: HasTcEnv {
 }
 
 /// Each `ScopedOperationsOnNode` is also a `ScopedOperations`.
-impl<X: Copy, U: ScopedOperationsOnNode<X> + HasTcEnv> ScopedOperations<X> for U {
+impl<X: Copy, U: ScopedOperationsOnNode<X> + HasTcEnv> ScopedOperationsOn<X> for U {
     type AnnotNode = U::AnnotNode;
     type Node = X;
     type CallbackArg = U::CallbackArg;

--- a/compiler/hash-typecheck/src/utils/cte.rs
+++ b/compiler/hash-typecheck/src/utils/cte.rs
@@ -1,3 +1,7 @@
+//! Helper functions that relate to compile-time evaluation of code.
+//!
+//! This includes monomorphisation of generics, as well as general compile-time
+//! evaluation through the `#run` directive.
 use hash_attrs::{attr::attr_store, builtin::attrs};
 use hash_tir::tir::{FnTy, HasAstNodeId, TermId, TyId};
 
@@ -31,6 +35,10 @@ impl<E: TcEnv> Tc<'_, E> {
     }
 
     /// Potentially monomorphise a function call, if it is pure.
+    // @@Improvement: Ideally, we should have a different motive than just purity
+    // when deciding to monomorphise a function call. There could be some kind of
+    // flag such as `#cte` (that could be default for implicit functions), such that
+    // `pure` is an orthogonal concept.
     pub fn potentially_monomorphise_fn_call(
         &self,
         fn_call: TermId,

--- a/compiler/hash-typecheck/src/utils/dumping.rs
+++ b/compiler/hash-typecheck/src/utils/dumping.rs
@@ -1,3 +1,5 @@
+//! Utilities for dumping the TIR during typechecking.
+
 use hash_attrs::{attr::attr_store, builtin::attrs};
 use hash_tir::{dump::dump_tir, tir::HasAstNodeId};
 

--- a/compiler/hash-typecheck/src/utils/entry_point.rs
+++ b/compiler/hash-typecheck/src/utils/entry_point.rs
@@ -1,3 +1,4 @@
+//! Functionality relating to finding the entry point of a program.
 use hash_attrs::{attr::attr_store, builtin::attrs};
 use hash_source::{entry_point::EntryPointKind, identifier::IDENTS, ModuleKind};
 use hash_storage::store::statics::{SequenceStoreValue, StoreId};
@@ -18,7 +19,7 @@ impl<T: TcEnv> Tc<'_, T> {
         let fn_def_symbol = fn_def_id.borrow().name;
         let fn_def_name = fn_def_symbol.borrow().name.unwrap();
 
-        // check if on item if it has `entry_point`
+        // Check if on item if it has `entry_point`
         let has_entry_point_attr =
             attr_store().node_has_attr(fn_def_id.node_id_or_default(), attrs::ENTRY_POINT);
 
@@ -33,8 +34,8 @@ impl<T: TcEnv> Tc<'_, T> {
         };
 
         if let Some(entry_point) = entry_point {
-            // @@MissingOrigin
-            // Maybe it is better to check this manually?
+            // @@MissingOrigin Maybe it is better to check this through a manual procedure
+            // rather than wrapping it in a function call?
             let call_term = Node::create_at(
                 Term::Call(CallTerm {
                     subject: Node::create_at(Term::Fn(fn_def_id), NodeOrigin::Generated),

--- a/compiler/hash-typecheck/src/utils/exhaustiveness.rs
+++ b/compiler/hash-typecheck/src/utils/exhaustiveness.rs
@@ -1,3 +1,6 @@
+//! Interaction with the `hash-exhaustiveness` crate for checking
+//! refutability and exhaustiveness of patterns.
+
 use hash_exhaustiveness::ExhaustivenessChecker;
 use hash_reporting::diagnostic::Diagnostics;
 use hash_tir::tir::HasAstNodeId;
@@ -15,7 +18,7 @@ impl<T: TcEnv> Tc<'_, T> {
     /// Merge all of the produced diagnostics into the current diagnostics.
     ///
     /// @@Hack: remove this when we have a better way to send exhaustiveness
-    /// jobs and add them to general tc diagnostics.
+    /// jobs and add them to general TC diagnostics.
     pub fn append_exhaustiveness_diagnostics(&self, checker: ExhaustivenessChecker<T>) {
         let (errors, warnings) = checker.into_diagnostics().into_diagnostics();
 

--- a/compiler/hash-typecheck/src/utils/intrinsic_abilities.rs
+++ b/compiler/hash-typecheck/src/utils/intrinsic_abilities.rs
@@ -1,3 +1,6 @@
+//! Wrapper around the typechecker to provide an interface to
+//! intrinsic functions.
+
 use hash_reporting::diagnostic::Diagnostics;
 use hash_target::{HasTarget, Target};
 use hash_tir::{
@@ -9,6 +12,11 @@ use hash_utils::derive_more::{Constructor, Deref};
 
 use crate::{env::TcEnv, tc::Tc};
 
+/// Wrapper around the typechecker to provide an interface to
+/// intrinsic functions.
+///
+/// Intrinsic functions expect something that implements `IntrinsicAbilities`,
+/// which is implemented for this struct.
 #[derive(Deref, Constructor)]
 pub struct IntrinsicAbilitiesImpl<'tc, T: TcEnv> {
     tc: &'tc Tc<'tc, T>,
@@ -28,6 +36,7 @@ impl<T: TcEnv> HasTarget for IntrinsicAbilitiesImpl<'_, T> {
 
 impl<T: TcEnv> IntrinsicAbilities for IntrinsicAbilitiesImpl<'_, T> {
     fn normalise_term(&self, term: TermId) -> Result<Option<TermId>, String> {
+        // Allow intrinsics to normalise terms through the typechecker:
         self.tc.potentially_normalise_node_no_signals(term).map_err(|e| {
             self.tc.diagnostics().add_error(e.into());
             "normalisation error".to_string()

--- a/compiler/hash-typecheck/src/utils/matching.rs
+++ b/compiler/hash-typecheck/src/utils/matching.rs
@@ -1,3 +1,8 @@
+//! Functions to perform pattern matching between terms and patterns. This is
+//! used for normalisation.
+// @@Improvement: perhaps the contents of this module should be reorganised into
+// traits similar to `Operations` which allow a node `X` to be matched against a
+// pattern `P`.
 use hash_ast::ast::RangeEnd;
 use hash_storage::store::{statics::StoreId, TrivialSequenceStoreKey};
 use hash_tir::{

--- a/compiler/hash-typecheck/src/utils/mod.rs
+++ b/compiler/hash-typecheck/src/utils/mod.rs
@@ -1,3 +1,6 @@
+//! Contains various utilities used by the type checker, which do not fit into
+//! any of the `operations` modules.
+
 pub mod cte;
 pub mod dumping;
 pub mod entry_point;

--- a/compiler/hash-typecheck/src/utils/normalisation.rs
+++ b/compiler/hash-typecheck/src/utils/normalisation.rs
@@ -1,4 +1,7 @@
-//! Operations for normalising terms and types.
+//! General utilities for normalising TIR terms.
+//!
+//! These are generic wrapper functions around
+//! `Operations::try_normalise`, for convenience.
 use std::{cell::Cell, ops::ControlFlow};
 
 use hash_storage::store::statics::SingleStoreId;
@@ -18,7 +21,10 @@ use crate::{
 impl<'env, T: TcEnv + 'env> Tc<'env, T> {
     /// Normalise the given atom, in-place.
     ///
-    /// returns `true` if the atom was normalised.
+    /// Returns `true` if the atom was normalised, `false` if it was already
+    /// normalised.
+    ///
+    /// This does not emit any normalisation signals.
     pub fn normalise_node_in_place_no_signals<N>(&self, atom: N) -> TcResult<bool>
     where
         Visitor: Map<N>,
@@ -32,7 +38,10 @@ impl<'env, T: TcEnv + 'env> Tc<'env, T> {
         }
     }
 
-    /// Normalise the given atom.
+    /// Normalise the given atom, if applicable, or return `None` if already
+    /// normalised.
+    ///
+    /// This does not emit any normalisation signals.
     pub fn potentially_normalise_node_no_signals<N>(&self, atom: N) -> TcResult<Option<N>>
     where
         Visitor: Map<N>,
@@ -49,6 +58,8 @@ impl<'env, T: TcEnv + 'env> Tc<'env, T> {
     }
 
     /// Normalise the given atom.
+    ///
+    /// This does not return any normalisation signals.
     pub fn normalise_node_no_signals<N: Copy>(&self, atom: N) -> TcResult<N>
     where
         Visitor: Map<N>,
@@ -64,8 +75,7 @@ impl<'env, T: TcEnv + 'env> Tc<'env, T> {
         }
     }
 
-    /// Evaluate an atom with the current mode, performing at least a single
-    /// step of normalisation.
+    /// Normalise the given atom.
     pub fn normalise_node<N: Copy>(&self, atom: N) -> Result<N, NormaliseSignal>
     where
         Visitor: Map<N>,
@@ -76,8 +86,8 @@ impl<'env, T: TcEnv + 'env> Tc<'env, T> {
         }
     }
 
-    /// Same as `eval`, but also sets the `evaluated` flag in the given
-    /// `EvalState`.
+    /// Same as `normalise_node`, but with a given evaluation state,
+    /// recording the normalisation.
     pub fn normalise_node_and_record<N: Copy>(
         &self,
         atom: N,
@@ -95,8 +105,7 @@ impl<'env, T: TcEnv + 'env> Tc<'env, T> {
         }
     }
 
-    /// Evaluate an atom in full, even if it has no effects, and including
-    /// impure function calls.
+    /// Normalise a node in `NormalisationMode::Full`.
     pub fn normalise_node_fully<N: Copy>(&self, atom: N) -> Result<N, NormaliseSignal>
     where
         Visitor: Map<N>,
@@ -104,7 +113,8 @@ impl<'env, T: TcEnv + 'env> Tc<'env, T> {
         self.normalisation_opts.mode.enter(NormalisationMode::Full, || self.normalise_node(atom))
     }
 
-    /// Same as `eval_nested`, but with a given evaluation state.
+    /// Same as `normalise_node`, but only occurs if the atom is not nested or
+    /// if the normalisation mode is `NormalisationMode::Full`.
     pub fn normalise_nested_node_and_record<N: Copy>(
         &self,
         atom: N,
@@ -119,9 +129,8 @@ impl<'env, T: TcEnv + 'env> Tc<'env, T> {
         }
     }
 
-    /// Evaluate an atom, performing at least a single step of normalisation.
-    ///
-    /// Returns `None` if the atom is already normalised.
+    /// Normalise the given atom, if applicable, or return `None` if already
+    /// normalised.
     pub fn potentially_normalise_node<N>(&self, atom: N) -> NormaliseResult<N>
     where
         Visitor: Map<N>,
@@ -168,10 +177,7 @@ impl<'env, T: TcEnv + 'env> Tc<'env, T> {
         }
     }
 
-    /// Evaluate an atom once, for use with `Visitor`'s `Map`.
-    ///
-    /// Invariant: if `self.atom_has_effects(atom)`, then `self.eval_once(atom)
-    /// != ctrl_continue()`.
+    /// Normalise an atom once, for use with `Visitor`'s `Map`.
     fn normalise_atom_once(&self, atom: Atom, nested: bool) -> NormaliseResult<ControlFlow<Atom>> {
         if nested && self.normalisation_opts.mode.get() == NormalisationMode::Weak {
             // If we're in weak mode, we don't want to evaluate nested atoms
@@ -182,8 +188,8 @@ impl<'env, T: TcEnv + 'env> Tc<'env, T> {
             Atom::Term(term) => {
                 normalisation_result_control_flow_into(self.try_normalise_node(term))
             }
-            Atom::FnDef(_) => already_normalised(), /* @@Temporary: can be removed soon when */
-            // FnDefIds are no longer a thing.
+            // @@Temporary: can be removed soon when FnDefIds are no longer a thing.
+            Atom::FnDef(_) => already_normalised(),
             Atom::Pat(pat) => normalisation_result_control_flow_into(self.try_normalise_node(pat)),
             Atom::Lit(lit) => normalisation_result_control_flow_into(self.try_normalise_node(lit)),
         }

--- a/compiler/hash-typecheck/src/utils/purity.rs
+++ b/compiler/hash-typecheck/src/utils/purity.rs
@@ -1,3 +1,4 @@
+//! Utilities for checking if a term has effects, or if it is pure.
 use std::ops::ControlFlow;
 
 use hash_storage::store::statics::StoreId;
@@ -11,6 +12,16 @@ use hash_utils::log::info;
 use crate::{env::TcEnv, tc::Tc};
 
 impl<E: TcEnv> Tc<'_, E> {
+    /// Check if the given term has effects.
+    ///
+    /// Something is considered an effect if:
+    /// - It mutates a variable,
+    /// - It calls a function that is not pure,
+    /// - It performs some imperative control-flow like a loop,
+    /// - It operates on references.
+    // @@Formalise: this is still a very vague notion of "effect", ideally we
+    // want to have a very formal set of rules for this so that we don't lead into
+    // inconsistencies with pure function evaluation.
     pub fn has_effects<N>(&self, node: N) -> Option<bool>
     where
         Visitor: Visit<N>,
@@ -22,6 +33,8 @@ impl<E: TcEnv> Tc<'_, E> {
         has_effects
     }
 
+    /// Check if the given atom has effects, for use with TIR `Visitor`'s `Map`
+    /// trait.
     fn atom_has_effects_once(
         &self,
         visitor: &Visitor,

--- a/compiler/hash-typecheck/src/utils/substitution.rs
+++ b/compiler/hash-typecheck/src/utils/substitution.rs
@@ -1,11 +1,10 @@
 //! Operations to substitute variables in types and terms.
-
 use std::{collections::HashSet, ops::ControlFlow};
 
 use hash_storage::store::{statics::StoreId, TrivialSequenceStoreKey};
 use hash_tir::{
     atom_info::ItemInAtomInfo,
-    context::{ContextMember, HasContext},
+    context::HasContext,
     sub::Sub,
     tir::{
         AccessTerm, ArgsId, Hole, NodeId, ParamId, ParamIndex, ParamsId, Pat, SymbolId, Term,
@@ -13,10 +12,11 @@ use hash_tir::{
     },
     visitor::{Atom, Map, Visit, Visitor},
 };
-use hash_utils::log::warn;
 
 use crate::{env::TcEnv, tc::Tc};
 
+/// A wrapper around the typechecker, with its own TIR `Visitor`,
+/// which can be used to substitute variables in types and terms.
 pub struct Substituter<'a, T: TcEnv> {
     tc: &'a Tc<'a, T>,
     traversing_utils: Visitor,
@@ -33,236 +33,9 @@ impl<'a, T: TcEnv> Substituter<'a, T> {
         Self { tc: checker, traversing_utils: Visitor::new() }
     }
 
-    fn params_contain_vars(
-        &self,
-        params: ParamsId,
-        var_matches: &HashSet<SymbolId>,
-        can_apply: &mut bool,
-    ) -> HashSet<SymbolId> {
-        let mut seen = var_matches.clone();
-        for param in params.iter() {
-            let param = param.value();
-            if self.contains_vars(param.ty, &seen) {
-                *can_apply = true;
-                return seen;
-            }
-            seen.remove(&param.name);
-            if let Some(default) = param.default {
-                if self.contains_vars(default, &seen) {
-                    *can_apply = true;
-                    return seen;
-                }
-            }
-        }
-        seen
-    }
-
-    fn apply_sub_to_params_and_get_shadowed(&self, params: ParamsId, sub: &Sub) -> Sub {
-        let mut shadowed_sub = sub.clone();
-        for param in params.iter() {
-            let param = param.value();
-            self.apply_sub_in_place(param.ty, &shadowed_sub);
-            shadowed_sub.remove(param.name);
-            if let Some(default) = param.default {
-                self.apply_sub_in_place(default, &shadowed_sub);
-            }
-        }
-        shadowed_sub
-    }
-
-    /// Apply the given substitution to the given atom, modifying it in place.
-    ///
-    /// Returns `ControlFlow::Break(())` if the atom was modified, and
-    /// `ControlFlow::Continue(())` otherwise to recurse deeper.
-    pub fn apply_sub_to_atom_in_place_once(&self, atom: Atom, sub: &Sub) -> ControlFlow<()> {
-        // Apply to type as well if applicable
-        match atom {
-            Atom::Term(term) => {
-                if let Some(ty) = self.tc.try_get_inferred_ty(term) {
-                    self.apply_sub_in_place(ty, sub);
-                }
-            }
-            Atom::Pat(pat) => {
-                if let Some(ty) = self.tc.try_get_inferred_ty(pat) {
-                    self.apply_sub_in_place(ty, sub);
-                }
-            }
-            Atom::Lit(_) | Atom::FnDef(_) => {}
-        }
-        match atom {
-            Atom::Term(term) => match *term.value() {
-                Term::Hole(Hole(symbol)) | Term::Var(VarTerm { symbol }) => {
-                    match sub.get_sub_for(symbol) {
-                        Some(subbed_term) => {
-                            let subbed_term_val = subbed_term.value();
-                            term.set(subbed_term_val);
-                            ControlFlow::Break(())
-                        }
-                        None => ControlFlow::Continue(()),
-                    }
-                }
-                Ty::TupleTy(tuple_ty) => {
-                    let _ = self.apply_sub_to_params_and_get_shadowed(tuple_ty.data, sub);
-                    ControlFlow::Break(())
-                }
-                Ty::FnTy(fn_ty) => {
-                    let shadowed_sub = self.apply_sub_to_params_and_get_shadowed(fn_ty.params, sub);
-                    self.apply_sub_in_place(fn_ty.return_ty, &shadowed_sub);
-                    ControlFlow::Break(())
-                }
-                _ => ControlFlow::Continue(()),
-            },
-            Atom::FnDef(fn_def_id) => {
-                let fn_def = fn_def_id.value();
-                let fn_ty = fn_def.ty;
-                let shadowed_sub = self.apply_sub_to_params_and_get_shadowed(fn_ty.params, sub);
-                self.apply_sub_in_place(fn_ty.return_ty, &shadowed_sub);
-                self.apply_sub_in_place(fn_def.body, &shadowed_sub);
-                ControlFlow::Break(())
-            }
-            Atom::Pat(_) => ControlFlow::Continue(()),
-            Atom::Lit(_) => ControlFlow::Break(()),
-        }
-    }
-
-    /// Whether the given substitution can be appliedto the given atom,
-    ///
-    /// i.e. if the atom contains a variable or hole that is in the
-    /// substitution.
-    pub fn atom_contains_vars_once(
-        &self,
-        atom: Atom,
-        var_matches: &HashSet<SymbolId>,
-        can_apply: &mut bool,
-    ) -> ControlFlow<()> {
-        let var_matches = &var_matches;
-        match atom {
-            Atom::Term(term) => match *term.value() {
-                Term::Hole(Hole(symbol)) | Term::Var(VarTerm { symbol })
-                    if var_matches.contains(&symbol) =>
-                {
-                    *can_apply = true;
-                    ControlFlow::Break(())
-                }
-                Ty::TupleTy(tuple_ty) => {
-                    let _ = self.params_contain_vars(tuple_ty.data, var_matches, can_apply);
-                    ControlFlow::Break(())
-                }
-                Ty::FnTy(fn_ty) => {
-                    let seen = self.params_contain_vars(fn_ty.params, var_matches, can_apply);
-                    if self.contains_vars(fn_ty.return_ty, &seen) {
-                        *can_apply = true;
-                        return ControlFlow::Break(());
-                    }
-                    ControlFlow::Break(())
-                }
-                _ => ControlFlow::Continue(()),
-            },
-            Atom::FnDef(fn_def_id) => {
-                let fn_def = fn_def_id.value();
-                let fn_ty = fn_def.ty;
-                let seen = self.params_contain_vars(fn_ty.params, var_matches, can_apply);
-                if self.contains_vars(fn_ty.return_ty, &seen) {
-                    *can_apply = true;
-                    return ControlFlow::Break(());
-                }
-                if self.contains_vars(fn_def.body, &seen) {
-                    *can_apply = true;
-                    return ControlFlow::Break(());
-                }
-                ControlFlow::Break(())
-            }
-            Atom::Pat(_) => ControlFlow::Continue(()),
-            Atom::Lit(_) => ControlFlow::Break(()),
-        }
-    }
-
-    /// Whether the given substitution can be appliedto the given atom,
-    ///
-    /// i.e. if the atom contains a variable or hole that is in the
-    /// substitution.
-    pub fn can_apply_sub_to_atom_once(
-        &self,
-        atom: Atom,
-        sub: &Sub,
-        can_apply: &mut bool,
-    ) -> ControlFlow<()> {
-        let domain: HashSet<SymbolId> = sub.domain().collect();
-        self.atom_contains_vars_once(atom, &domain, can_apply)
-    }
-
-    pub fn contains_vars<N>(&self, atom: N, filter: &HashSet<SymbolId>) -> bool
-    where
-        Visitor: Visit<N>,
-    {
-        let mut can_apply = false;
-        self.traversing_utils
-            .visit(atom, &mut |atom| self.atom_contains_vars_once(atom, filter, &mut can_apply));
-        can_apply
-    }
-
-    pub fn can_apply_sub<N>(&self, atom: N, sub: &Sub) -> bool
-    where
-        Visitor: Visit<N>,
-    {
-        let mut can_apply = false;
-        self.traversing_utils
-            .visit(atom, &mut |atom| self.can_apply_sub_to_atom_once(atom, sub, &mut can_apply));
-        can_apply
-    }
-
-    pub fn apply_sub_in_place<U>(&self, item: U, sub: &Sub)
-    where
-        Visitor: Visit<U>,
-    {
-        self.traversing_utils
-            .visit(item, &mut |atom| self.apply_sub_to_atom_in_place_once(atom, sub));
-    }
-
-    pub fn apply_sub_from_context<U>(&self, item: U)
-    where
-        Visitor: Visit<U>,
-    {
-        let atom = item;
-        let sub = self.create_sub_from_current_scope();
-        self.apply_sub_in_place(atom, &sub);
-    }
-
-    /// Determines whether the given atom contains a hole.
-    ///
-    /// If a hole is found, `ControlFlow::Break(())` is returned. Otherwise,
-    /// `ControlFlow::Continue(())` is returned. `has_holes` is updated
-    /// accordingly.
-    pub fn atom_has_holes_once(&self, atom: Atom, has_holes: &mut Option<Atom>) -> ControlFlow<()> {
-        match atom {
-            Atom::Term(term) => match *term.value() {
-                Term::Hole(_) => {
-                    *has_holes = Some(atom);
-                    ControlFlow::Break(())
-                }
-                Term::Ctor(ctor_term) => {
-                    if let Some(atom) = self.has_holes(ctor_term.ctor_args) {
-                        *has_holes = Some(atom);
-                    }
-                    ControlFlow::Break(())
-                }
-                _ => ControlFlow::Continue(()),
-            },
-            Atom::Pat(pat) => match *pat.value() {
-                Pat::Ctor(ctor_pat) => {
-                    if let Some(atom) = self.has_holes(ctor_pat.ctor_pat_args) {
-                        *has_holes = Some(atom);
-                    }
-                    ControlFlow::Break(())
-                }
-                _ => ControlFlow::Continue(()),
-            },
-            Atom::FnDef(_) => ControlFlow::Continue(()),
-            Atom::Lit(_) => ControlFlow::Break(()),
-        }
-    }
-
     /// Determines whether the given TIR node contains one or more holes.
+    ///
+    /// If so, it returns the atom which contains the hole.
     pub fn has_holes<U>(&self, item: U) -> Option<Atom>
     where
         Visitor: Visit<U>,
@@ -273,7 +46,43 @@ impl<'a, T: TcEnv> Substituter<'a, T> {
         has_holes
     }
 
-    /// Create a substitution from the current scope members.
+    /// Whether the given atom contains any of the variables in `filter`.
+    pub fn contains_vars<N>(&self, atom: N, filter: &HashSet<SymbolId>) -> bool
+    where
+        Visitor: Visit<N>,
+    {
+        let mut can_apply = false;
+        self.traversing_utils
+            .visit(atom, &mut |atom| self.atom_contains_vars_once(atom, filter, &mut can_apply));
+        can_apply
+    }
+
+    /// Apply the given substitution to the given atom, modifying it in place.
+    pub fn apply_sub_in_place<U>(&self, item: U, sub: &Sub)
+    where
+        Visitor: Visit<U>,
+    {
+        self.traversing_utils
+            .visit(item, &mut |atom| self.apply_sub_to_atom_in_place_once(atom, sub));
+    }
+
+    /// Apply the substitition carried by the ambient context, to the given
+    /// atom.
+    ///
+    /// This is done so that the atom can escape the context without any
+    /// lingering references to its local scope.
+    // @@Formalise: we should specify exactly how this works using formal inference
+    // rules, and ensure that this is met by this algorithm.
+    pub fn apply_sub_from_context<U>(&self, item: U)
+    where
+        Visitor: Visit<U>,
+    {
+        let atom = item;
+        let sub = self.create_sub_from_current_scope();
+        self.apply_sub_in_place(atom, &sub);
+    }
+
+    /// Get the set of unassigned variables in the current scope.
     pub fn get_unassigned_vars_in_current_scope(&self) -> HashSet<SymbolId> {
         let mut sub = HashSet::new();
         let current_scope_index = self.context().get_current_scope_index();
@@ -283,20 +92,6 @@ impl<'a, T: TcEnv> Substituter<'a, T> {
             }
         });
         sub
-    }
-
-    /// Create a substitution from the current scope members.
-    pub fn is_unassigned_var_in_current_scope(&self, var: SymbolId) -> bool {
-        let _current_scope_index = self.context().get_current_scope_index();
-        match self.context().get_current_scope_ref().get_decl(var) {
-            Some(var) => {
-                matches!(var, ContextMember { value: None, .. })
-            }
-            None => {
-                warn!("Not found var {} in current scope", var);
-                false
-            }
-        }
     }
 
     /// Create a substitution from the current scope members.
@@ -313,15 +108,7 @@ impl<'a, T: TcEnv> Substituter<'a, T> {
         sub
     }
 
-    pub fn apply_sub_to_sub_in_place(&self, origin: &Sub, target: &Sub) -> Sub {
-        let mut sub = Sub::identity();
-        for (var, value) in target.iter() {
-            let value = self.apply_sub(value, origin);
-            sub.insert(var, value);
-        }
-        sub
-    }
-
+    /// Apply a substitution to the given atom, returning a new atom.
     pub fn apply_sub<U: Copy>(&self, item: U, sub: &Sub) -> U
     where
         Visitor: Visit<U> + Map<U>,
@@ -329,15 +116,6 @@ impl<'a, T: TcEnv> Substituter<'a, T> {
         let copy = self.traversing_utils.copy(item);
         self.apply_sub_in_place(copy, sub);
         copy
-    }
-
-    /// Insert the given variable and value into the given substitution if
-    /// the value is not a variable with the same name.
-    pub fn insert_to_sub_if_needed(&self, sub: &mut Sub, name: SymbolId, value: TermId) {
-        let subbed_value = self.apply_sub(value, sub);
-        if !matches!(*subbed_value.value(), Term::Var(v) if v.symbol == name) {
-            sub.insert(name, subbed_value);
-        }
     }
 
     /// Create a substitution from the given arguments.
@@ -414,24 +192,204 @@ impl<'a, T: TcEnv> Substituter<'a, T> {
         shadowed_sub
     }
 
-    /// Reverse the given substitution.
+    /// Check whether the given `Params` contains any of the variables inside
+    /// `var_matches`.
     ///
-    /// Invariant: the substitution is injective.
-    pub fn reverse_sub(&self, sub: &Sub) -> Sub {
-        let mut reversed_sub = Sub::identity();
-        for (name, value) in sub.iter() {
-            match *value.value() {
-                Term::Var(v) => {
-                    reversed_sub.insert(v.symbol, Term::from(name, name.origin()));
-                }
-                Term::Hole(h) => {
-                    reversed_sub.insert(h.0, Term::from(name, name.origin()));
-                }
-                _ => {
-                    panic!("cannot reverse non-injective substitution");
+    /// This performs shadowing on the parameter names, so that any dependency
+    /// on previous parameters is not taken into account.
+    fn params_contain_vars(
+        &self,
+        params: ParamsId,
+        var_matches: &HashSet<SymbolId>,
+        can_apply: &mut bool,
+    ) -> HashSet<SymbolId> {
+        let mut seen = var_matches.clone();
+        for param in params.iter() {
+            let param = param.value();
+            if self.contains_vars(param.ty, &seen) {
+                *can_apply = true;
+                return seen;
+            }
+            seen.remove(&param.name);
+            if let Some(default) = param.default {
+                if self.contains_vars(default, &seen) {
+                    *can_apply = true;
+                    return seen;
                 }
             }
         }
-        reversed_sub
+        seen
+    }
+
+    /// Apply a given substitution to the parameters, appropriately accounting
+    /// for the parameter dependencies.
+    ///
+    /// For example, substitution `[a -> b]` in parameters `(a: A(a), b: B(a))`
+    /// will result in `(a: A(b), b: B(a))`, because the second `a` depends
+    /// on the first `a`, and not on the substitution source `a`. (This example
+    /// is a bit contrived because usually this naming conflict doesn't exist
+    /// due to uniqueness of symbols. It it still comes up when symbols have the
+    /// same ID due to recursion)
+    fn apply_sub_to_params_and_get_shadowed(&self, params: ParamsId, sub: &Sub) -> Sub {
+        let mut shadowed_sub = sub.clone();
+        for param in params.iter() {
+            let param = param.value();
+            self.apply_sub_in_place(param.ty, &shadowed_sub);
+            shadowed_sub.remove(param.name);
+            if let Some(default) = param.default {
+                self.apply_sub_in_place(default, &shadowed_sub);
+            }
+        }
+        shadowed_sub
+    }
+
+    /// Apply the given substitution to the given atom, modifying it in place.
+    ///
+    /// Returns `ControlFlow::Break(())` if the atom was modified, and
+    /// `ControlFlow::Continue(())` otherwise to recurse deeper.
+    fn apply_sub_to_atom_in_place_once(&self, atom: Atom, sub: &Sub) -> ControlFlow<()> {
+        // Apply to type as well if applicable
+        match atom {
+            Atom::Term(term) => {
+                if let Some(ty) = self.tc.try_get_inferred_ty(term) {
+                    self.apply_sub_in_place(ty, sub);
+                }
+            }
+            Atom::Pat(pat) => {
+                if let Some(ty) = self.tc.try_get_inferred_ty(pat) {
+                    self.apply_sub_in_place(ty, sub);
+                }
+            }
+            Atom::Lit(_) | Atom::FnDef(_) => {}
+        }
+        match atom {
+            Atom::Term(term) => match *term.value() {
+                Term::Hole(Hole(symbol)) | Term::Var(VarTerm { symbol }) => {
+                    match sub.get_sub_for(symbol) {
+                        Some(subbed_term) => {
+                            let subbed_term_val = subbed_term.value();
+                            term.set(subbed_term_val);
+                            ControlFlow::Break(())
+                        }
+                        None => ControlFlow::Continue(()),
+                    }
+                }
+                Ty::TupleTy(tuple_ty) => {
+                    let _ = self.apply_sub_to_params_and_get_shadowed(tuple_ty.data, sub);
+                    ControlFlow::Break(())
+                }
+                Ty::FnTy(fn_ty) => {
+                    let shadowed_sub = self.apply_sub_to_params_and_get_shadowed(fn_ty.params, sub);
+                    self.apply_sub_in_place(fn_ty.return_ty, &shadowed_sub);
+                    ControlFlow::Break(())
+                }
+                _ => ControlFlow::Continue(()),
+            },
+            Atom::FnDef(fn_def_id) => {
+                let fn_def = fn_def_id.value();
+                let fn_ty = fn_def.ty;
+                let shadowed_sub = self.apply_sub_to_params_and_get_shadowed(fn_ty.params, sub);
+                self.apply_sub_in_place(fn_ty.return_ty, &shadowed_sub);
+                self.apply_sub_in_place(fn_def.body, &shadowed_sub);
+                ControlFlow::Break(())
+            }
+            Atom::Pat(_) => ControlFlow::Continue(()),
+            Atom::Lit(_) => ControlFlow::Break(()),
+        }
+    }
+
+    /// Whether the given substitution can be appliedto the given atom,
+    ///
+    /// i.e. if the atom contains a variable or hole that is in the
+    /// substitution.
+    fn atom_contains_vars_once(
+        &self,
+        atom: Atom,
+        var_matches: &HashSet<SymbolId>,
+        can_apply: &mut bool,
+    ) -> ControlFlow<()> {
+        let var_matches = &var_matches;
+        match atom {
+            Atom::Term(term) => match *term.value() {
+                Term::Hole(Hole(symbol)) | Term::Var(VarTerm { symbol })
+                    if var_matches.contains(&symbol) =>
+                {
+                    *can_apply = true;
+                    ControlFlow::Break(())
+                }
+                Ty::TupleTy(tuple_ty) => {
+                    let _ = self.params_contain_vars(tuple_ty.data, var_matches, can_apply);
+                    ControlFlow::Break(())
+                }
+                Ty::FnTy(fn_ty) => {
+                    let seen = self.params_contain_vars(fn_ty.params, var_matches, can_apply);
+                    if self.contains_vars(fn_ty.return_ty, &seen) {
+                        *can_apply = true;
+                        return ControlFlow::Break(());
+                    }
+                    ControlFlow::Break(())
+                }
+                _ => ControlFlow::Continue(()),
+            },
+            Atom::FnDef(fn_def_id) => {
+                let fn_def = fn_def_id.value();
+                let fn_ty = fn_def.ty;
+                let seen = self.params_contain_vars(fn_ty.params, var_matches, can_apply);
+                if self.contains_vars(fn_ty.return_ty, &seen) {
+                    *can_apply = true;
+                    return ControlFlow::Break(());
+                }
+                if self.contains_vars(fn_def.body, &seen) {
+                    *can_apply = true;
+                    return ControlFlow::Break(());
+                }
+                ControlFlow::Break(())
+            }
+            Atom::Pat(_) => ControlFlow::Continue(()),
+            Atom::Lit(_) => ControlFlow::Break(()),
+        }
+    }
+
+    /// Determines whether the given atom contains a hole.
+    ///
+    /// If a hole is found, `ControlFlow::Break(())` is returned. Otherwise,
+    /// `ControlFlow::Continue(())` is returned. `has_holes` is updated
+    /// accordingly.
+    fn atom_has_holes_once(&self, atom: Atom, has_holes: &mut Option<Atom>) -> ControlFlow<()> {
+        match atom {
+            Atom::Term(term) => match *term.value() {
+                Term::Hole(_) => {
+                    *has_holes = Some(atom);
+                    ControlFlow::Break(())
+                }
+                Term::Ctor(ctor_term) => {
+                    if let Some(atom) = self.has_holes(ctor_term.ctor_args) {
+                        *has_holes = Some(atom);
+                    }
+                    ControlFlow::Break(())
+                }
+                _ => ControlFlow::Continue(()),
+            },
+            Atom::Pat(pat) => match *pat.value() {
+                Pat::Ctor(ctor_pat) => {
+                    if let Some(atom) = self.has_holes(ctor_pat.ctor_pat_args) {
+                        *has_holes = Some(atom);
+                    }
+                    ControlFlow::Break(())
+                }
+                _ => ControlFlow::Continue(()),
+            },
+            Atom::FnDef(_) => ControlFlow::Continue(()),
+            Atom::Lit(_) => ControlFlow::Break(()),
+        }
+    }
+
+    /// Insert the given variable and value into the given substitution if
+    /// the value is not a variable with the same name.
+    fn insert_to_sub_if_needed(&self, sub: &mut Sub, name: SymbolId, value: TermId) {
+        let subbed_value = self.apply_sub(value, sub);
+        if !matches!(*subbed_value.value(), Term::Var(v) if v.symbol == name) {
+            sub.insert(name, subbed_value);
+        }
     }
 }


### PR DESCRIPTION
This PR adds some documentation to the typechecking. Specifically it tackles the `lib`, `env`, `traits`, `tc` and `utils` modules. Next up, I will add docs to `operations` and `errors`

This also renames some items to a better suited name, and removes unused code.