### PR TITLE
ir: Make projections local to a `Body`

### DIFF
--- a/compiler/hash-codegen-llvm/src/lib.rs
+++ b/compiler/hash-codegen-llvm/src/lib.rs
@@ -251,12 +251,12 @@ impl<'b, 'm> LLVMBackend<'b> {
         // We perform an initial pass where we pre-define everything so that
         // we can get place all of the symbols in the symbol table first.
         for body in self.ir_storage.bodies.iter() {
-            if matches!(body.info().source(), BodySource::Const) {
+            if matches!(body.metadata().source(), BodySource::Const) {
                 continue;
             }
 
             // Get the instance of the function.
-            let instance = body.info().ty().borrow().as_instance();
+            let instance = body.metadata().ty().borrow().as_instance();
 
             // So, we create the mangled symbol name, and then call `predefine()` which
             // should create the function ABI from the instance, with the correct
@@ -281,12 +281,12 @@ impl<'b, 'm> LLVMBackend<'b> {
         for body in ir.bodies.iter() {
             // We don't need to generate anything for constants since they
             // should have already been dealt with...
-            if matches!(body.info().source(), BodySource::Const) {
+            if matches!(body.metadata().source(), BodySource::Const) {
                 continue;
             }
 
             // Get the instance of the function.
-            let instance = body.info().ty().borrow().as_instance();
+            let instance = body.metadata().ty().borrow().as_instance();
 
             // @@ErrorHandling: we should be able to handle the error here
             codegen_ir_body::<LLVMBuilder>(instance, body, ctx).unwrap();
@@ -294,7 +294,7 @@ impl<'b, 'm> LLVMBackend<'b> {
             // Check if we should dump the generated LLVM IR
             if instance.borrow().has_attr(attrs::DUMP_LLVM_IR) {
                 let mut stdout = self.stdout.clone();
-                let func = FunctionPrinter::new(body.info.name(), ctx.get_fn(instance));
+                let func = FunctionPrinter::new(body.meta.name(), ctx.get_fn(instance));
 
                 stream_writeln!(stdout, "{}", Report::from(func));
             }

--- a/compiler/hash-codegen/src/lower/locals.rs
+++ b/compiler/hash-codegen/src/lower/locals.rs
@@ -9,7 +9,7 @@ use fixedbitset::FixedBitSet;
 use hash_ir::{
     ir::{self, IrRef, Local, PlaceProjection, START_BLOCK},
     traversal,
-    visitor::{ImmutablePlaceCtx, IrVisitorMut, MutablePlaceCtx, PlaceCtx, VisitorCtx},
+    visitor::{ImmutablePlaceCtx, IrVisitorCtx, IrVisitorMut, MutablePlaceCtx, PlaceCtx},
 };
 use hash_layout::TyInfo;
 use hash_storage::store::SequenceStoreKey;
@@ -207,7 +207,7 @@ impl<'ir, 'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> IrVisitorMut<'ir>
         &mut self,
         place: &ir::Place,
         value: &ir::RValue,
-        ctx: &VisitorCtx<'_>,
+        ctx: &IrVisitorCtx<'_>,
     ) {
         if let Some(local) = place.as_local() {
             self.assign(local, ctx.location);
@@ -229,7 +229,7 @@ impl<'ir, 'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> IrVisitorMut<'ir>
         self.visit_rvalue(value, ctx);
     }
 
-    fn visit_place(&mut self, place: &ir::Place, place_ctx: PlaceCtx, ctx: &VisitorCtx<'_>) {
+    fn visit_place(&mut self, place: &ir::Place, place_ctx: PlaceCtx, ctx: &IrVisitorCtx<'_>) {
         if place.projections.is_empty() {
             return self.visit_local(place.local, place_ctx, ctx.location);
         }

--- a/compiler/hash-codegen/src/lower/locals.rs
+++ b/compiler/hash-codegen/src/lower/locals.rs
@@ -9,7 +9,7 @@ use fixedbitset::FixedBitSet;
 use hash_ir::{
     ir::{self, IrRef, Local, PlaceProjection, START_BLOCK},
     traversal,
-    visitor::{ImmutablePlaceContext, IrVisitorMut, MutablePlaceContext, PlaceContext},
+    visitor::{ImmutablePlaceCtx, IrVisitorMut, MutablePlaceCtx, PlaceCtx, VisitorCtx},
 };
 use hash_layout::TyInfo;
 use hash_storage::store::SequenceStoreKey;
@@ -207,11 +207,10 @@ impl<'ir, 'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> IrVisitorMut<'ir>
         &mut self,
         place: &ir::Place,
         value: &ir::RValue,
-        reference: IrRef,
-        info: &ir::BodyInfo,
+        ctx: &VisitorCtx<'_>,
     ) {
         if let Some(local) = place.as_local() {
-            self.assign(local, reference);
+            self.assign(local, ctx.location);
 
             // Short-circuit: if the RValue doesn't create an operand, i.e. an
             // aggregate value or a repeated value, then we can immediately
@@ -224,26 +223,15 @@ impl<'ir, 'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> IrVisitorMut<'ir>
         } else {
             // we need to go the long way since projections might affect
             // the kind of memory that is used.
-            self.visit_place(
-                place,
-                PlaceContext::Mutable(MutablePlaceContext::Store),
-                reference,
-                info,
-            );
+            self.visit_place(place, PlaceCtx::Mutable(MutablePlaceCtx::Store), ctx);
         }
 
-        self.visit_rvalue(value, reference, info);
+        self.visit_rvalue(value, ctx);
     }
 
-    fn visit_place(
-        &mut self,
-        place: &ir::Place,
-        ctx: PlaceContext,
-        reference: IrRef,
-        info: &ir::BodyInfo,
-    ) {
+    fn visit_place(&mut self, place: &ir::Place, place_ctx: PlaceCtx, ctx: &VisitorCtx<'_>) {
         if place.projections.is_empty() {
-            return self.visit_local(place.local, ctx, reference);
+            return self.visit_local(place.local, place_ctx, ctx.location);
         }
 
         // If the place base type is a ZST then we can short-circuit
@@ -255,10 +243,10 @@ impl<'ir, 'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> IrVisitorMut<'ir>
             return;
         }
 
-        let mut base_ctx = if ctx.is_mutating() {
-            PlaceContext::Mutable(MutablePlaceContext::Projection)
+        let mut base_ctx = if place_ctx.is_mutating() {
+            PlaceCtx::Mutable(MutablePlaceCtx::Projection)
         } else {
-            PlaceContext::Immutable(ImmutablePlaceContext::Projection)
+            PlaceCtx::Immutable(ImmutablePlaceCtx::Projection)
         };
 
         // ##Hack: in order to preserve the order of the traversal, we
@@ -267,7 +255,7 @@ impl<'ir, 'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> IrVisitorMut<'ir>
         let mut index_locals = vec![];
 
         // loop over the projections in reverse order
-        for projection in info.projections.borrow(place.projections).iter().rev() {
+        for projection in ctx.info.projections.borrow(place.projections).iter().rev() {
             // @@Todo: if the projection yields a ZST, then we can
             // also short-circuit here.
 
@@ -276,9 +264,9 @@ impl<'ir, 'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> IrVisitorMut<'ir>
             // we use the `ctx` as the base context since this
             // is still an operand.
             match projection {
-                PlaceProjection::Field(_) if ctx.is_operand() => {
+                PlaceProjection::Field(_) if place_ctx.is_operand() => {
                     if self.fn_builder.ctx.is_backend_immediate(base_layout) {
-                        base_ctx = ctx;
+                        base_ctx = place_ctx;
                     }
                 }
                 PlaceProjection::Index(local) => {
@@ -294,32 +282,28 @@ impl<'ir, 'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> IrVisitorMut<'ir>
 
         // Once we have determined the base context, we can now visit
         // the local.
-        self.visit_local(place.local, base_ctx, reference);
+        self.visit_local(place.local, base_ctx, ctx.location);
 
         // now traverse the index locals, we set the `ctx` as being
         // an operand since they are always just being read in this
         // context.
         for local in index_locals {
-            self.visit_local(
-                local,
-                PlaceContext::Immutable(ImmutablePlaceContext::Operand),
-                reference,
-            );
+            self.visit_local(local, PlaceCtx::Immutable(ImmutablePlaceCtx::Operand), ctx.location);
         }
     }
 
-    fn visit_local(&mut self, local: Local, ctx: PlaceContext, reference: IrRef) {
+    fn visit_local(&mut self, local: Local, ctx: PlaceCtx, reference: IrRef) {
         match ctx {
             // If it is being used as a destination for a value, then treat
             // it as an assignment
-            PlaceContext::Mutable(MutablePlaceContext::Call) => {
+            PlaceCtx::Mutable(MutablePlaceCtx::Call) => {
                 self.assign(local, reference);
             }
 
             // Don't do anything for meta context.
-            PlaceContext::Meta(_) => {}
+            PlaceCtx::Meta(_) => {}
 
-            PlaceContext::Immutable(ImmutablePlaceContext::Operand) => {
+            PlaceCtx::Immutable(ImmutablePlaceCtx::Operand) => {
                 match &mut self.locals[local] {
                     // @@Investigate: do we need to deal with in any way here?
                     LocalMemoryKind::Unused => {}
@@ -337,16 +321,14 @@ impl<'ir, 'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> IrVisitorMut<'ir>
             }
 
             // Everything else is a memory value.
-            PlaceContext::Mutable(
-                MutablePlaceContext::Store
-                | MutablePlaceContext::Projection
-                | MutablePlaceContext::Ref
-                | MutablePlaceContext::Discriminant,
+            PlaceCtx::Mutable(
+                MutablePlaceCtx::Store
+                | MutablePlaceCtx::Projection
+                | MutablePlaceCtx::Ref
+                | MutablePlaceCtx::Discriminant,
             )
-            | PlaceContext::Immutable(
-                ImmutablePlaceContext::Inspect
-                | ImmutablePlaceContext::Ref
-                | ImmutablePlaceContext::Projection,
+            | PlaceCtx::Immutable(
+                ImmutablePlaceCtx::Inspect | ImmutablePlaceCtx::Ref | ImmutablePlaceCtx::Projection,
             ) => {
                 self.locals[local] = LocalMemoryKind::Memory;
             }

--- a/compiler/hash-codegen/src/lower/mod.rs
+++ b/compiler/hash-codegen/src/lower/mod.rs
@@ -118,7 +118,7 @@ impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
             fn_abi,
             function: func,
             block_map,
-            locals: IndexVec::with_capacity(body.declarations.len()),
+            locals: IndexVec::with_capacity(body.locals.len()),
         }
     }
 }
@@ -165,7 +165,7 @@ pub fn codegen_ir_body<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>>(
 
         let mut allocate = |local: Local| {
             // we need to get the type and layout from the local
-            let decl = &fn_builder.body.declarations[local];
+            let decl = &fn_builder.body.locals[local];
             let info = fn_builder.ctx.layout_of(decl.ty);
 
             if local == ir::RETURN_PLACE && is_return_indirect {

--- a/compiler/hash-codegen/src/lower/operands.rs
+++ b/compiler/hash-codegen/src/lower/operands.rs
@@ -427,7 +427,7 @@ impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
     }
 
     /// Generate code for consuming an "operand", i.e. generate code that
-    /// resolves the references [Place] and the load it from memory as
+    /// resolves the references [ir::Place] and the load it from memory as
     /// a [OperandRef].
     pub(super) fn codegen_consume_operand(
         &mut self,
@@ -463,7 +463,7 @@ impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
     ) -> Option<OperandRef<Builder::Value>> {
         match self.locals[place.local] {
             LocalRef::Operand(Some(mut operand)) => {
-                for projection in place.projections.borrow().iter() {
+                for projection in self.body.projections().borrow(place.projections) {
                     match *projection {
                         ir::PlaceProjection::Field(index) => {
                             operand = operand.extract_field(builder, index);

--- a/compiler/hash-codegen/src/lower/rvalue.rs
+++ b/compiler/hash-codegen/src/lower/rvalue.rs
@@ -225,7 +225,7 @@ impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
 
     /// Compute the type of an [RValue].
     pub fn ty_of_rvalue(&self, value: &RValue) -> IrTyId {
-        value.ty(&self.body.declarations)
+        value.ty(&self.body.aux())
     }
 
     /// Emit code for a [ir::RValue] that will return an [OperandRef].

--- a/compiler/hash-ir-utils/src/graphviz.rs
+++ b/compiler/hash-ir-utils/src/graphviz.rs
@@ -76,14 +76,14 @@ impl<'ir> IrGraphWriter<'ir> {
         // Now we write the `label` of the graph which is essentially the type of
         // the function and any local declarations that have been defined within the
         // body.
-        let mut declarations = self.body.declarations.iter();
+        let mut declarations = self.body.locals.iter();
 
         // return_type declaration, this is always located at `0`
         let return_ty_decl = declarations.next().unwrap();
 
-        match self.body.info().source() {
+        match self.body.metadata().source() {
             BodySource::Item => {
-                write!(w, "  label=<{}(", self.body.info().name,)?;
+                write!(w, "  label=<{}(", self.body.metadata().name,)?;
 
                 // Write the arguments of the function
                 for (i, param) in declarations.take(self.body.arg_count).enumerate() {
@@ -103,13 +103,13 @@ impl<'ir> IrGraphWriter<'ir> {
                 )?;
             }
             BodySource::Const => {
-                let header = format!("{}", self.body.info().ty());
+                let header = format!("{}", self.body.metadata().ty());
 
                 // @@Todo: maybe figure out a better format for this?
                 write!(
                     w,
                     "  label=<{}{}{}",
-                    self.body.info().name,
+                    self.body.metadata().name,
                     encode_text(&header),
                     LINE_SEPARATOR
                 )?;
@@ -118,7 +118,7 @@ impl<'ir> IrGraphWriter<'ir> {
 
         // Now we can emit the local declarations that have been defined within the
         // body...
-        let declarations = self.body.declarations.iter_enumerated();
+        let declarations = self.body.locals.iter_enumerated();
         let offset = 1 + self.body.arg_count;
 
         for (local, decl) in declarations.skip(offset) {
@@ -161,7 +161,7 @@ impl<'ir> IrGraphWriter<'ir> {
                         )?;
                     }
                     TerminatorKind::Switch { targets, value } => {
-                        let target_ty = value.ty(&self.body.declarations);
+                        let target_ty = value.ty(&self.body.aux());
 
                         // Add all of the table cases
                         for (value, target) in targets.iter() {
@@ -254,7 +254,7 @@ impl<'ir> IrGraphWriter<'ir> {
             write!(
                 w,
                 r#"<tr><td align="left" balign="left">{}</td></tr>"#,
-                encode_text(&format!("{}", statement.with_edges(self.body, self.lc, false)))
+                encode_text(&format!("{}", statement.with_edges(self.body.aux(), self.lc, false)))
             )?;
         }
 
@@ -263,7 +263,7 @@ impl<'ir> IrGraphWriter<'ir> {
             write!(
                 w,
                 r#"<tr><td align="left">{}</td></tr>"#,
-                encode_text(&format!("{}", terminator.with_edges(self.body, self.lc, false)))
+                encode_text(&format!("{}", terminator.with_edges(self.body.aux(), self.lc, false)))
             )?;
         }
 

--- a/compiler/hash-ir/src/lib.rs
+++ b/compiler/hash-ir/src/lib.rs
@@ -33,7 +33,7 @@ use hash_tir::{
 };
 use hash_utils::fxhash::FxHashMap;
 use intrinsics::Intrinsics;
-use ir::{Body, ProjectionStore};
+use ir::Body;
 use lang_items::LangItems;
 use ty::{AdtStore, InstanceId, InstanceStore, IrTyId, IrTyListStore, IrTyStore};
 
@@ -158,7 +158,6 @@ stores!(
     tys: IrTyStore,
     ty_list: IrTyListStore,
     instances: InstanceStore,
-    projections: ProjectionStore,
     allocations: Allocations
 );
 

--- a/compiler/hash-ir/src/ty.rs
+++ b/compiler/hash-ir/src/ty.rs
@@ -42,7 +42,7 @@ use hash_utils::{
 };
 
 use crate::{
-    ir::{LocalDecls, Place, PlaceProjection},
+    ir::{BodyInfo, Place, PlaceProjection},
     ir_stores,
 };
 
@@ -758,11 +758,11 @@ impl PlaceTy {
     }
 
     /// Create a [PlaceTy] from a [Place].
-    pub fn from_place(place: Place, locals: &LocalDecls) -> Self {
+    pub fn from_place(place: Place, info: &BodyInfo) -> Self {
         // get the type of the local from the body.
-        let mut base = PlaceTy { ty: locals[place.local].ty, index: None };
+        let mut base = PlaceTy { ty: info.locals[place.local].ty, index: None };
 
-        for projection in place.projections.borrow().iter() {
+        for projection in info.projections.borrow(place.projections).iter() {
             base = base.apply_projection(*projection);
         }
 

--- a/compiler/hash-lower/src/build/into.rs
+++ b/compiler/hash-lower/src/build/into.rs
@@ -651,7 +651,8 @@ impl<'tcx> BodyBuilder<'tcx> {
         self.control_flow_graph.push_assign(block, array_ptr, Operand::Place(ptr).into(), origin);
 
         // 2). Write data to allocation.
-        self.aggregate_into_dest(array_ptr.deref(), block, aggregate_kind, args, origin);
+        let dest = array_ptr.deref(&mut self.projections);
+        self.aggregate_into_dest(dest, block, aggregate_kind, args, origin);
 
         // 3).
         //

--- a/compiler/hash-lower/src/build/matches/candidate.rs
+++ b/compiler/hash-lower/src/build/matches/candidate.rs
@@ -281,7 +281,7 @@ impl<'tcx> BodyBuilder<'tcx> {
                     } else {
                         Mutability::Immutable
                     },
-                    source: pair.place.into_place(),
+                    source: pair.place.into_place(&mut self.projections),
                     name,
 
                     // @@Todo: introduce a way of specifying what the binding

--- a/compiler/hash-lower/src/build/matches/declarations.rs
+++ b/compiler/hash-lower/src/build/matches/declarations.rs
@@ -22,7 +22,7 @@ impl<'tcx> BodyBuilder<'tcx> {
     /// via the name of the local and the scope that it is in.
     pub(crate) fn push_local(&mut self, key: SymbolId, decl: LocalDecl) -> Local {
         let is_named = decl.name.is_some();
-        let index = self.declarations.push(decl);
+        let index = self.locals.push(decl);
 
         // If the declaration has a name i.e. not an auxiliary local, then
         // we can push it into the `declaration_map`.

--- a/compiler/hash-lower/src/build/matches/test.rs
+++ b/compiler/hash-lower/src/build/matches/test.rs
@@ -542,7 +542,7 @@ impl<'tcx> BodyBuilder<'tcx> {
         make_target_blocks: impl FnOnce(&mut Self) -> Vec<BasicBlock>,
     ) {
         // Build the place from the provided place builder
-        let place = place_builder.clone().into_place();
+        let place = place_builder.clone().into_place(&mut self.projections);
         let span = test.origin;
 
         match test.kind {

--- a/compiler/hash-lower/src/build/place.rs
+++ b/compiler/hash-lower/src/build/place.rs
@@ -1,7 +1,7 @@
 //! Utilities for dealing with [Place]s when building up Hash IR.
 
 use hash_ir::{
-    ir::{BasicBlock, Local, Place, PlaceProjection, ProjectionId},
+    ir::{BasicBlock, Local, Place, PlaceProjection, Projections},
     ty::{IrTyId, Mutability, VariantIdx},
 };
 use hash_storage::store::statics::StoreId;
@@ -64,8 +64,8 @@ impl PlaceBuilder {
     }
 
     /// Build the [Place] from the [PlaceBuilder].
-    pub(crate) fn into_place(self) -> Place {
-        Place { local: self.base, projections: ProjectionId::seq(self.projections) }
+    pub(crate) fn into_place(self, store: &mut Projections) -> Place {
+        Place { local: self.base, projections: store.create_from_iter(self.projections) }
     }
 }
 
@@ -83,7 +83,7 @@ impl<'tcx> BodyBuilder<'tcx> {
         mutability: Mutability,
     ) -> BlockAnd<Place> {
         let place_builder = unpack!(block = self.as_place_builder(block, term, mutability));
-        block.and(place_builder.into_place())
+        block.and(place_builder.into_place(&mut self.projections))
     }
 
     pub(crate) fn as_place_builder(

--- a/compiler/hash-lower/src/build/rvalue.rs
+++ b/compiler/hash-lower/src/build/rvalue.rs
@@ -234,8 +234,8 @@ impl<'tcx> BodyBuilder<'tcx> {
                 let temp = self.temp_place(ty);
                 let rvalue = RValue::CheckedBinaryOp(op, operands);
 
-                let result = temp.field(0);
-                let overflow = temp.field(1);
+                let result = temp.field(0, &mut self.projections);
+                let overflow = temp.field(1, &mut self.projections);
 
                 // Push an assignment to the tuple on the operation
                 self.control_flow_graph.push_assign(block, temp, rvalue, origin);

--- a/compiler/hash-lower/src/build/temp.rs
+++ b/compiler/hash-lower/src/build/temp.rs
@@ -20,7 +20,7 @@ impl<'tcx> BodyBuilder<'tcx> {
         let ty = self.ty_id_from_tir_term(term);
         let local = LocalDecl::new_auxiliary(ty, mutability);
 
-        let temp = self.declarations.push(local);
+        let temp = self.locals.push(local);
         let temp_place = Place::from_local(temp);
 
         unpack!(block = self.term_into_dest(temp_place, block, term));
@@ -31,6 +31,6 @@ impl<'tcx> BodyBuilder<'tcx> {
     pub(crate) fn temp_place(&mut self, ty: IrTyId) -> Place {
         let decl = LocalDecl::new_auxiliary(ty, Mutability::Immutable);
 
-        Place::from_local(self.declarations.push(decl))
+        Place::from_local(self.locals.push(decl))
     }
 }

--- a/compiler/hash-lower/src/build/utils.rs
+++ b/compiler/hash-lower/src/build/utils.rs
@@ -115,7 +115,7 @@ impl<'tcx> BodyBuilder<'tcx> {
             Some(tmp) => *tmp,
             None => {
                 let local = LocalDecl::new_auxiliary(COMMON_IR_TYS.unit, Mutability::Immutable);
-                let local_id = self.declarations.push(local);
+                let local_id = self.locals.push(local);
 
                 let place = Place::from_local(local_id);
                 self.tmp_place = Some(place);

--- a/compiler/hash-lower/src/lib.rs
+++ b/compiler/hash-lower/src/lib.rs
@@ -127,7 +127,7 @@ impl<Ctx: LoweringCtxQuery> CompilerStage<Ctx> for IrGen {
                 // This is the entry point, so we need to record that this
                 // is the entry point.
                 if let Some(def) = entry_point.def() && def == func {
-                    let instance = body.info.ty().borrow().as_instance();
+                    let instance = body.meta.ty().borrow().as_instance();
                     data.icx.entry_point.set(instance, entry_point.kind().unwrap());
                 }
 

--- a/compiler/hash-lower/src/optimise/cleanup_locals.rs
+++ b/compiler/hash-lower/src/optimise/cleanup_locals.rs
@@ -13,7 +13,7 @@ use hash_ir::{
         Body, BodyInfo, IrRef, Local, LocalDecl, Place, PlaceProjection, RValue, Statement,
         StatementKind, RETURN_PLACE,
     },
-    visitor::{walk_mut, IrVisitorMut, ModifyingIrVisitor, PlaceCtx, VisitorCtx},
+    visitor::{walk_mut, IrVisitorCtx, IrVisitorMut, ModifyingIrVisitor, PlaceCtx},
     IrCtx,
 };
 use hash_pipeline::settings::{CompilerSettings, OptimisationLevel};
@@ -171,7 +171,7 @@ impl LocalUseMap {
         // re-visit this particular statement since we've just removed it, use a
         // dummy reference since we don't care here.
         let mut visitor = LocalUseVisitor::new(self);
-        let ctx = VisitorCtx::new(IrRef::default(), info);
+        let ctx = IrVisitorCtx::new(IrRef::default(), info);
         visitor.visit_statement(statement, &ctx);
     }
 
@@ -224,7 +224,7 @@ impl<'ir> IrVisitorMut<'ir> for LocalUseVisitor<'ir> {
     /// Visit an assignment [Statement], we only visit the [RValue] part of the
     /// assignment fully, and only check the projections of the [Place] in case
     /// it is referenced within a [PlaceProjection::Index].
-    fn visit_assign_statement(&mut self, place: &Place, value: &RValue, ctx: &VisitorCtx<'_>) {
+    fn visit_assign_statement(&mut self, place: &Place, value: &RValue, ctx: &IrVisitorCtx<'_>) {
         for projection in ctx.info.projections.borrow(place.projections) {
             if let PlaceProjection::Index(index_local) = projection {
                 self.map.update_count_for(*index_local);

--- a/compiler/hash-storage/src/store/sequence/local.rs
+++ b/compiler/hash-storage/src/store/sequence/local.rs
@@ -1,0 +1,71 @@
+use std::marker::PhantomData;
+
+use super::SequenceStoreKey;
+
+/// An implementation of [SequenceStore] which doesn't require being shared
+/// across thread boundaries.
+pub struct LocalSequenceStore<Key, V> {
+    data: Vec<V>,
+    _phantom: PhantomData<Key>,
+}
+
+impl<Key, V> Default for LocalSequenceStore<Key, V> {
+    fn default() -> Self {
+        Self { data: Vec::new(), _phantom: PhantomData }
+    }
+}
+
+impl<Key: SequenceStoreKey, V: Clone> LocalSequenceStore<Key, V> {
+    pub fn new() -> Self {
+        Self { data: Vec::new(), _phantom: PhantomData }
+    }
+
+    /// Create a sequence of values inside the store from a slice, returning its
+    /// key.
+    pub fn create_from_slice(&mut self, values: &[V]) -> Key {
+        let starting_index = self.data.len();
+        self.data.extend_from_slice(values);
+        unsafe { Key::from_raw_parts(starting_index, values.len()) }
+    }
+
+    /// Create an empty sequence of values inside the store, returning its key.
+    pub fn create_empty(&self) -> Key {
+        unsafe { Key::from_raw_parts(self.data.len(), 0) }
+    }
+
+    /// Create a sequence of values inside the store from an iterator-like
+    /// object, returning its key.
+    ///
+    /// *Warning*: Do not call mutating store methods (`create_*` etc) in the
+    /// `values` iterator, otherwise there will be a panic. If you want to
+    /// do this, consider using [`Self::create_from_iter()`] instead.
+    pub fn create_from_iter(&mut self, values: impl IntoIterator<Item = V>) -> Key {
+        let starting_index = self.data.len();
+        self.data.extend(values);
+        unsafe { Key::from_raw_parts(starting_index, self.data.len() - starting_index) }
+    }
+
+    /// Get the value sequence for the given key as an owned vector.
+    pub fn get_vec(&self, key: Key) -> Vec<V> {
+        let (index, len) = key.to_index_and_len();
+        self.data[index..index + len].to_vec()
+    }
+
+    /// Borrow a collection of items.
+    pub fn borrow(&self, key: Key) -> &[V] {
+        let (index, len) = key.to_index_and_len();
+        &self.data[index..index + len]
+    }
+
+    /// Borrow a mutable collection of items.
+    pub fn borrow_mut(&mut self, key: Key) -> &mut [V] {
+        let (index, len) = key.to_index_and_len();
+        &mut self.data[index..index + len]
+    }
+
+    pub fn modify<T>(&mut self, key: Key, f: impl FnOnce(&mut [V]) -> T) -> T {
+        let (index, len) = key.to_index_and_len();
+        let value = unsafe { self.data.get_unchecked_mut(index..index + len) };
+        f(value)
+    }
+}

--- a/compiler/hash-storage/src/store/sequence/local.rs
+++ b/compiler/hash-storage/src/store/sequence/local.rs
@@ -1,3 +1,7 @@
+//! A sister implementatiojn of [SequenceStore] which doesn't require being
+//! shared across thread boundaries, and hence avoiding any synchronisation
+//! overhead.
+
 use std::marker::PhantomData;
 
 use super::SequenceStoreKey;
@@ -48,19 +52,19 @@ impl<Key: SequenceStoreKey, V: Clone> LocalSequenceStore<Key, V> {
     /// Get the value sequence for the given key as an owned vector.
     pub fn get_vec(&self, key: Key) -> Vec<V> {
         let (index, len) = key.to_index_and_len();
-        self.data[index..index + len].to_vec()
+        unsafe { self.data.get_unchecked(index..index + len) }.to_vec()
     }
 
     /// Borrow a collection of items.
     pub fn borrow(&self, key: Key) -> &[V] {
         let (index, len) = key.to_index_and_len();
-        &self.data[index..index + len]
+        unsafe { self.data.get_unchecked(index..index + len) }
     }
 
     /// Borrow a mutable collection of items.
     pub fn borrow_mut(&mut self, key: Key) -> &mut [V] {
         let (index, len) = key.to_index_and_len();
-        &mut self.data[index..index + len]
+        unsafe { self.data.get_unchecked_mut(index..index + len) }
     }
 
     pub fn modify<T>(&mut self, key: Key, f: impl FnOnce(&mut [V]) -> T) -> T {

--- a/compiler/hash-storage/src/store/sequence/mod.rs
+++ b/compiler/hash-storage/src/store/sequence/mod.rs
@@ -1,0 +1,183 @@
+//! Defines a [SequenceStore] and [SequenceStoreKey] for a given type. Such a
+//! store keeps a sequence of elements per entry, this is useful for interning
+//! a list of items as a single id.
+
+use std::{
+    iter::{repeat, Map, Repeat, Zip},
+    ops::Range,
+};
+
+pub mod local;
+pub mod shared;
+
+pub use local::*;
+pub use shared::*;
+
+pub type SequenceStoreKeyIter<T, K> = Map<Zip<Repeat<T>, Range<usize>>, fn((T, usize)) -> K>;
+
+/// Represents a key that can be used to index a [`SequenceStore`].
+pub trait SequenceStoreKey: Copy + Eq {
+    type ElementKey: Copy + Eq;
+
+    /// Turn the key into an index and a length.
+    fn to_index_and_len(self) -> (usize, usize);
+
+    /// Create a key from an index and a length.
+    ///
+    /// # Safety
+    /// - This will create a [SequenceStoreKey] without checking the boundaries
+    ///   in the [SequenceStore].
+    /// - This should generally not be used in client code.
+    unsafe fn from_raw_parts(index: usize, len: usize) -> Self;
+
+    /// Turn the key into an index range `0..len`.
+    ///
+    /// Can be used to iterate over the values of the key in conjunction with
+    /// [`SequenceStore::get_at_index()`].
+    fn to_index_range(self) -> Range<usize> {
+        0..self.len()
+    }
+
+    /// Get the length of the entry corresponding to the key.
+    fn len(self) -> usize {
+        let (_, len) = self.to_index_and_len();
+        len
+    }
+
+    /// Whether the sequence the key points to is empty.
+    fn is_empty(self) -> bool {
+        self.len() == 0
+    }
+
+    /// Get the index of the entry corresponding to the key.
+    fn entry_index(self) -> usize {
+        let (index, _) = self.to_index_and_len();
+        index
+    }
+
+    /// Get an empty key.
+    fn empty() -> Self {
+        unsafe { Self::from_raw_parts(0, 0) }
+    }
+}
+
+pub trait TrivialSequenceStoreKey: SequenceStoreKey {
+    type Iter: Iterator<Item = Self::ElementKey>;
+    /// Turn the key into a range `(key, 0)..(key, len)`.
+    fn iter(self) -> Self::Iter;
+
+    /// Get the key corresponding to the given index.
+    fn at(self, index: usize) -> Option<Self::ElementKey>;
+}
+
+impl<T: SequenceStoreKey> TrivialSequenceStoreKey for T
+where
+    T::ElementKey: From<(T, usize)>,
+{
+    type Iter = SequenceStoreKeyIter<T, T::ElementKey>;
+    fn iter(self) -> Self::Iter {
+        repeat(self).zip(self.to_index_range()).map(Self::ElementKey::from)
+    }
+
+    fn at(self, index: usize) -> Option<Self::ElementKey> {
+        if index < self.len() {
+            Some(Self::ElementKey::from((self, index)))
+        } else {
+            None
+        }
+    }
+}
+
+/// Create a new [`SequenceStoreKey`] with the given name.
+#[macro_export]
+macro_rules! new_sequence_store_key_indirect {
+    ($visibility:vis $name:ident, $el_name:ident $(, derives = $($extra_derives:ident),*)?) => {
+        #[derive(PartialEq, Eq, Clone, Copy, Hash, $($($extra_derives),*)?)]
+        $visibility struct $name {
+            index: u32,
+            len: u32,
+        }
+
+        impl $crate::store::SequenceStoreKey for $name {
+            type ElementKey = $el_name;
+
+            fn to_index_and_len(self) -> (usize, usize) {
+                (self.index.try_into().unwrap(), self.len.try_into().unwrap())
+            }
+
+            unsafe fn from_raw_parts(index: usize, len: usize) -> Self {
+                Self { index: index.try_into().unwrap(), len: len.try_into().unwrap() }
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! impl_debug_for_sequence_store_key {
+    ($name:ident) => {
+        impl std::fmt::Debug for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.debug_tuple(stringify!($name)).field(&self.index).field(&self.len).finish()
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! impl_debug_for_sequence_store_element_key {
+    ($name:ident) => {
+        impl std::fmt::Debug for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.debug_tuple(stringify!($name))
+                    .field(&(&self.0.index, &self.0.len))
+                    .field(&self.1)
+                    .finish()
+            }
+        }
+    };
+}
+
+/// Create a new [`SequenceStoreKey`] with the given name.
+#[macro_export]
+macro_rules! new_sequence_store_key_direct {
+    ($visibility:vis $name:ident, $el_name:ident $(, derives = [$($extra_derives:ident),*])?  $(, el_derives = [$($extra_el_derives:ident),*])?) => {
+        #[derive(PartialEq, Eq, Clone, Copy, Hash, $($($extra_derives),*)?)]
+        $visibility struct $name {
+            index: u32,
+            len: u32,
+        }
+
+        #[derive(PartialEq, Eq, Clone, Copy, Hash, $($($extra_el_derives),*)?)]
+        $visibility struct $el_name(pub $name, pub usize);
+
+        impl From<$el_name> for ($name, usize) {
+            fn from(value: $el_name) -> Self {
+                (value.0, value.1)
+            }
+        }
+
+        impl From<($name, usize)> for $el_name {
+            fn from(value: ($name, usize)) -> Self {
+                Self(value.0, value.1)
+            }
+        }
+
+        impl $crate::store::sequence::SequenceStoreKey for $name {
+            type ElementKey = $el_name;
+
+            fn to_index_and_len(self) -> (usize, usize) {
+                (self.index.try_into().unwrap(), self.len.try_into().unwrap())
+            }
+
+            unsafe fn from_raw_parts(index: usize, len: usize) -> Self {
+                Self { index: index.try_into().unwrap(), len: len.try_into().unwrap() }
+            }
+        }
+    };
+}
+
+#[cfg(test)]
+mod test_super {
+    // Ensuring macros expand correctly:
+    new_sequence_store_key_direct!(pub TestSeqK, TestKK);
+}

--- a/compiler/hash-storage/src/store/sequence/shared.rs
+++ b/compiler/hash-storage/src/store/sequence/shared.rs
@@ -1,179 +1,10 @@
-//! Defines a [SequenceStore] and [SequenceStoreKey] for a given type. Such a
-//! store keeps a sequence of elements per entry, this is useful for interning
-//! a list of items as a single id.
-
-use std::{
-    iter::{repeat, Map, Repeat, Zip},
-    marker::PhantomData,
-    ops::Range,
-};
+use std::marker::PhantomData;
 
 use parking_lot::{
     MappedRwLockReadGuard, MappedRwLockWriteGuard, RwLock, RwLockReadGuard, RwLockWriteGuard,
 };
 
-pub type SequenceStoreKeyIter<T, K> = Map<Zip<Repeat<T>, Range<usize>>, fn((T, usize)) -> K>;
-
-/// Represents a key that can be used to index a [`SequenceStore`].
-pub trait SequenceStoreKey: Copy + Eq {
-    type ElementKey: Copy + Eq;
-
-    /// Turn the key into an index and a length.
-    fn to_index_and_len(self) -> (usize, usize);
-
-    /// Create a key from an index and a length.
-    ///
-    /// # Safety
-    /// - This will create a [SequenceStoreKey] without checking the boundaries
-    ///   in the [SequenceStore].
-    /// - This should generally not be used in client code.
-    unsafe fn from_index_and_len_unchecked(index: usize, len: usize) -> Self;
-
-    /// Turn the key into an index range `0..len`.
-    ///
-    /// Can be used to iterate over the values of the key in conjunction with
-    /// [`SequenceStore::get_at_index()`].
-    fn to_index_range(self) -> Range<usize> {
-        0..self.len()
-    }
-
-    /// Get the length of the entry corresponding to the key.
-    fn len(self) -> usize {
-        let (_, len) = self.to_index_and_len();
-        len
-    }
-
-    /// Whether the sequence the key points to is empty.
-    fn is_empty(self) -> bool {
-        self.len() == 0
-    }
-
-    /// Get the index of the entry corresponding to the key.
-    fn entry_index(self) -> usize {
-        let (index, _) = self.to_index_and_len();
-        index
-    }
-
-    /// Get an empty key.
-    fn empty() -> Self {
-        unsafe { Self::from_index_and_len_unchecked(0, 0) }
-    }
-}
-
-pub trait TrivialSequenceStoreKey: SequenceStoreKey {
-    type Iter: Iterator<Item = Self::ElementKey>;
-    /// Turn the key into a range `(key, 0)..(key, len)`.
-    fn iter(self) -> Self::Iter;
-
-    /// Get the key corresponding to the given index.
-    fn at(self, index: usize) -> Option<Self::ElementKey>;
-}
-
-impl<T: SequenceStoreKey> TrivialSequenceStoreKey for T
-where
-    T::ElementKey: From<(T, usize)>,
-{
-    type Iter = SequenceStoreKeyIter<T, T::ElementKey>;
-    fn iter(self) -> Self::Iter {
-        repeat(self).zip(self.to_index_range()).map(Self::ElementKey::from)
-    }
-
-    fn at(self, index: usize) -> Option<Self::ElementKey> {
-        if index < self.len() {
-            Some(Self::ElementKey::from((self, index)))
-        } else {
-            None
-        }
-    }
-}
-
-/// Create a new [`SequenceStoreKey`] with the given name.
-#[macro_export]
-macro_rules! new_sequence_store_key_indirect {
-    ($visibility:vis $name:ident, $el_name:ident $(, derives = $($extra_derives:ident),*)?) => {
-        #[derive(PartialEq, Eq, Clone, Copy, Hash, $($($extra_derives),*)?)]
-        $visibility struct $name {
-            index: u32,
-            len: u32,
-        }
-
-        impl $crate::store::SequenceStoreKey for $name {
-            type ElementKey = $el_name;
-
-            fn to_index_and_len(self) -> (usize, usize) {
-                (self.index.try_into().unwrap(), self.len.try_into().unwrap())
-            }
-
-            unsafe fn from_index_and_len_unchecked(index: usize, len: usize) -> Self {
-                Self { index: index.try_into().unwrap(), len: len.try_into().unwrap() }
-            }
-        }
-    };
-}
-
-#[macro_export]
-macro_rules! impl_debug_for_sequence_store_key {
-    ($name:ident) => {
-        impl std::fmt::Debug for $name {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                f.debug_tuple(stringify!($name)).field(&self.index).field(&self.len).finish()
-            }
-        }
-    };
-}
-
-#[macro_export]
-macro_rules! impl_debug_for_sequence_store_element_key {
-    ($name:ident) => {
-        impl std::fmt::Debug for $name {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                f.debug_tuple(stringify!($name))
-                    .field(&(&self.0.index, &self.0.len))
-                    .field(&self.1)
-                    .finish()
-            }
-        }
-    };
-}
-
-/// Create a new [`SequenceStoreKey`] with the given name.
-#[macro_export]
-macro_rules! new_sequence_store_key_direct {
-    ($visibility:vis $name:ident, $el_name:ident $(, derives = [$($extra_derives:ident),*])?  $(, el_derives = [$($extra_el_derives:ident),*])?) => {
-        #[derive(PartialEq, Eq, Clone, Copy, Hash, $($($extra_derives),*)?)]
-        $visibility struct $name {
-            index: u32,
-            len: u32,
-        }
-
-        #[derive(PartialEq, Eq, Clone, Copy, Hash, $($($extra_el_derives),*)?)]
-        $visibility struct $el_name(pub $name, pub usize);
-
-        impl From<$el_name> for ($name, usize) {
-            fn from(value: $el_name) -> Self {
-                (value.0, value.1)
-            }
-        }
-
-        impl From<($name, usize)> for $el_name {
-            fn from(value: ($name, usize)) -> Self {
-                Self(value.0, value.1)
-            }
-        }
-
-        impl $crate::store::sequence::SequenceStoreKey for $name {
-            type ElementKey = $el_name;
-
-            fn to_index_and_len(self) -> (usize, usize) {
-                (self.index.try_into().unwrap(), self.len.try_into().unwrap())
-            }
-
-            unsafe fn from_index_and_len_unchecked(index: usize, len: usize) -> Self {
-                Self { index: index.try_into().unwrap(), len: len.try_into().unwrap() }
-            }
-        }
-    };
-}
+use super::SequenceStoreKey;
 
 /// The internal data of a store.
 pub type SequenceStoreInternalData<Value> = RwLock<Vec<Value>>;
@@ -205,13 +36,13 @@ pub trait SequenceStore<Key: SequenceStoreKey, Value: Clone> {
         let mut data = self.internal_data().write();
         let starting_index = data.len();
         data.extend_from_slice(values);
-        unsafe { Key::from_index_and_len_unchecked(starting_index, values.len()) }
+        unsafe { Key::from_raw_parts(starting_index, values.len()) }
     }
 
     /// Create an empty sequence of values inside the store, returning its key.
     fn create_empty(&self) -> Key {
         let starting_index = self.internal_data().read().len();
-        unsafe { Key::from_index_and_len_unchecked(starting_index, 0) }
+        unsafe { Key::from_raw_parts(starting_index, 0) }
     }
 
     /// Create a sequence of values inside the store from an iterator-like
@@ -224,7 +55,7 @@ pub trait SequenceStore<Key: SequenceStoreKey, Value: Clone> {
         let mut data = self.internal_data().write();
         let starting_index = data.len();
         data.extend(values);
-        unsafe { Key::from_index_and_len_unchecked(starting_index, data.len() - starting_index) }
+        unsafe { Key::from_raw_parts(starting_index, data.len() - starting_index) }
     }
 
     /// Create a sequence of values inside the store from an iterator-like
@@ -491,10 +322,4 @@ impl<K: SequenceStoreKey, V: Clone> SequenceStore<K, V> for DefaultSequenceStore
     fn internal_data(&self) -> &SequenceStoreInternalData<V> {
         &self.data
     }
-}
-
-#[cfg(test)]
-mod test_super {
-    // Ensuring macros expand correctly:
-    new_sequence_store_key_direct!(pub TestSeqK, TestKK);
 }

--- a/compiler/hash-tir/src/stores.rs
+++ b/compiler/hash-tir/src/stores.rs
@@ -267,7 +267,7 @@ macro_rules! tir_node_sequence_store_direct {
                 self.elements().to_index_and_len()
             }
 
-            unsafe fn from_index_and_len_unchecked(_: usize, _: usize) -> Self {
+            unsafe fn from_raw_parts(_: usize, _: usize) -> Self {
                 panic!(
                     "{} cannot be used to create a new sequence, use {} instead",
                     stringify!($id),
@@ -356,7 +356,7 @@ macro_rules! tir_node_sequence_store_indirect {
                 self.elements().to_index_and_len()
             }
 
-            unsafe fn from_index_and_len_unchecked(_: usize, _: usize) -> Self {
+            unsafe fn from_raw_parts(_: usize, _: usize) -> Self {
                 panic!(
                     "{} cannot be used to create a new sequence, use {} instead",
                     stringify!($id),

--- a/compiler/hash-tir/src/tir/args.rs
+++ b/compiler/hash-tir/src/tir/args.rs
@@ -232,7 +232,7 @@ impl SequenceStoreKey for SomeArgsId {
         }
     }
 
-    unsafe fn from_index_and_len_unchecked(_: usize, _: usize) -> Self {
+    unsafe fn from_raw_parts(_: usize, _: usize) -> Self {
         panic!("Creating SomeArgsId is not allowed")
     }
 }


### PR DESCRIPTION
This PR makes all of the projections that are applied to a body local to the `Body` rather than being externally stored in a static store. The implementation isn't as clean as I'd hoped it to be (especially in the visitor parts).

## Changes

- ir: localise `Projections` to each `Body`
- ir: cleanup `IrVisitorMut` with `VisitorCtx`
- ir: cleanup `ModiyfyingIrVisitor` with `IrVisitorCtxMut`

## Todo

- [x] Merge #1009 before reviewing this PR

closes #996 
