### PR TITLE
storage: shrink direct sequence element ids from `16bytes` to `12bytes`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,6 +678,7 @@ version = "0.1.0"
 dependencies = [
  "fixedbitset",
  "hash-ir",
+ "hash-source",
  "hash-storage",
  "hash-target",
  "hash-utils",

--- a/compiler/hash-ast-expand/src/attr.rs
+++ b/compiler/hash-ast-expand/src/attr.rs
@@ -147,7 +147,7 @@ impl AstExpander<'_> {
                     let target = if let Some(name) = arg.name.as_ref() {
                         ParamIndex::Name(name.ident)
                     } else {
-                        ParamIndex::Position(index)
+                        ParamIndex::pos(index)
                     };
 
                     let expected_ty = attr_ty.ty_of_param(target);

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -1993,7 +1993,7 @@ define_tree! {
         NamedField(Identifier),
 
         /// The numeric value of the index that's being accessed
-        NumericField(usize),
+        NumericField(u32),
     }
 
     /// A property access expression.

--- a/compiler/hash-attrs/src/attr.rs
+++ b/compiler/hash-attrs/src/attr.rs
@@ -123,7 +123,7 @@ impl From<ParamIndex> for AttrArgIdx {
     fn from(index: ParamIndex) -> Self {
         match index {
             ParamIndex::Name(name) => AttrArgIdx::Name(name),
-            ParamIndex::Position(index) => AttrArgIdx::Position(index as u32),
+            ParamIndex::Position(index) => AttrArgIdx::Position(index),
         }
     }
 }

--- a/compiler/hash-exhaustiveness/src/construct.rs
+++ b/compiler/hash-exhaustiveness/src/construct.rs
@@ -113,7 +113,7 @@ impl<E: ExhaustivenessEnv> ExhaustivenessChecker<'_, E> {
                         };
 
                         let ctor_id = data_def.borrow().ctors.assert_defined();
-                        CtorDefId(ctor_id.elements(), variant_idx).borrow().params.len()
+                        CtorDefId::new(ctor_id.elements(), variant_idx).borrow().params.len()
                     }
                     Ty::TupleTy(TupleTy { data }) => data.len(),
                     ty => panic!("Unexpected type `{ty:?}` when computing arity"),

--- a/compiler/hash-exhaustiveness/src/deconstruct.rs
+++ b/compiler/hash-exhaustiveness/src/deconstruct.rs
@@ -214,7 +214,7 @@ impl<E: ExhaustivenessEnv> fmt::Debug for ExhaustivenessFmtCtx<'_, Deconstructed
                         // currently active.
                         if let DeconstructedCtor::Variant(index) = ctor {
                             let ctors = data_def.borrow().ctors.assert_defined();
-                            let ctor_name = CtorDefId(ctors.elements(), *index).borrow().name;
+                            let ctor_name = CtorDefId::new(ctors.elements(), *index).borrow().name;
                             write!(f, "::{ctor_name}")?;
                         }
                     }

--- a/compiler/hash-exhaustiveness/src/fields.rs
+++ b/compiler/hash-exhaustiveness/src/fields.rs
@@ -93,7 +93,7 @@ impl<E: ExhaustivenessEnv> ExhaustivenessChecker<'_, E> {
                             panic!("expected a non-primitive data type")
                         };
 
-                        let ctor = CtorDefId(variants_id.elements(), variant_idx).borrow();
+                        let ctor = CtorDefId::new(variants_id.elements(), variant_idx).borrow();
                         let tys = ctor
                             .params
                             .elements()

--- a/compiler/hash-exhaustiveness/src/lower.rs
+++ b/compiler/hash-exhaustiveness/src/lower.rs
@@ -153,7 +153,7 @@ impl<E: HasTarget> ExhaustivenessChecker<'_, E> {
 
                 let CtorDefId(ctor_defs, index) = ctor;
                 let ctor = if index != 0 || ctor_defs.len() > 1 {
-                    DeconstructedCtor::Variant(ctor.1)
+                    DeconstructedCtor::Variant(ctor.1 as usize)
                 } else {
                     DeconstructedCtor::Single
                 };
@@ -245,7 +245,7 @@ impl<E: HasTarget> ExhaustivenessChecker<'_, E> {
                                     DeconstructedCtor::Variant(idx) => *idx,
                                     _ => unreachable!()
                                 };
-                                let ctor = CtorDefId(ctor_def_id.elements(), variant_idx);
+                                let ctor = CtorDefId::new(ctor_def_id.elements(), variant_idx);
                                 let (pats, spread) = self.construct_pat_args(fields, ctor.borrow().params);
 
                                 Pat::Ctor(CtorPat { ctor, ctor_pat_args: pats, ctor_pat_args_spread: spread, data_args: args })
@@ -297,7 +297,7 @@ impl<E: HasTarget> ExhaustivenessChecker<'_, E> {
             .map(|(index, p)| {
                 Node::at(
                     PatArg {
-                        target: ParamId(params.elements(), index).as_param_index(),
+                        target: ParamId::new(params.elements(), index).as_param_index(),
                         pat: self.construct_pat(p).into(),
                     },
                     NodeOrigin::Generated,

--- a/compiler/hash-ir/src/ty.rs
+++ b/compiler/hash-ir/src/ty.rs
@@ -274,11 +274,11 @@ impl IrTy {
     /// Make a tuple type, i.e. `(T1, T2, T3, ...)`
     pub fn tuple(tys: &[IrTyId]) -> IrTy {
         let variants = index_vec![AdtVariant::singleton(
-            0usize.into(),
+            Identifier::num(0),
             tys.iter()
                 .copied()
                 .enumerate()
-                .map(|(idx, ty)| AdtField { name: idx.into(), ty })
+                .map(|(idx, ty)| AdtField { name: Identifier::num(idx), ty })
                 .collect(),
         )];
         let adt = Adt::new_with_flags("tuple".into(), variants, AdtFlags::TUPLE);
@@ -966,10 +966,10 @@ impl Adt {
     ///
     /// - We determine the "minimum" size of the discriminant by using the
     ///   rules:
-    ///  
+    ///
     ///    - If the ADT is a C-like type, then we use the minimum size specified
     ///      by the target, i.e. `c_style_enum_min_size` in the data layout.
-    ///   
+    ///
     ///    - default to using a `u8`.
     ///
     /// - Using the minimum, we then determine the "fit" of the discriminant by

--- a/compiler/hash-layout/Cargo.toml
+++ b/compiler/hash-layout/Cargo.toml
@@ -13,4 +13,5 @@ fixedbitset = "0.4.2"
 hash-ir = { path = "../hash-ir" }
 hash-storage = { path = "../hash-storage" }
 hash-target = { path = "../hash-target" }
+hash-source = { path = "../hash-source" }
 hash-utils = { path = "../hash-utils" }

--- a/compiler/hash-layout/src/write.rs
+++ b/compiler/hash-layout/src/write.rs
@@ -19,6 +19,7 @@
 use std::{fmt, iter};
 
 use hash_ir::ty::{IrTy, VariantIdx};
+use hash_source::identifier::Identifier;
 use hash_storage::store::statics::StoreId;
 use hash_target::{
     abi::AbiRepresentation, data_layout::HasDataLayout, primitives::IntTy, size::Size,
@@ -691,12 +692,12 @@ impl<'l> LayoutWriter<'l> {
                         })
                     }
                     (AbiRepresentation::Scalar(scalar), _) => {
-                        vec![(0usize.into(), format!("{scalar}"))]
+                        vec![(Identifier::num(0), format!("{scalar}"))]
                     }
                     (AbiRepresentation::Pair(scalar_1, scalar_2), _) => {
                         vec![
-                            (0usize.into(), format!("{scalar_1}")),
-                            (1usize.into(), format!("{scalar_2}")),
+                            (Identifier::num(0), format!("{scalar_1}")),
+                            (Identifier::num(1), format!("{scalar_2}")),
                         ]
                     }
                     _ => unreachable!(),

--- a/compiler/hash-lower/src/build/into.rs
+++ b/compiler/hash-lower/src/build/into.rs
@@ -60,7 +60,7 @@ impl<'tcx> BodyBuilder<'tcx> {
                     .map(|element| {
                         let name = match element.target {
                             ParamIndex::Name(name) => name,
-                            ParamIndex::Position(pos) => pos.into(),
+                            ParamIndex::Position(pos) => Identifier::num(pos),
                         };
 
                         (name, element.value)
@@ -88,7 +88,7 @@ impl<'tcx> BodyBuilder<'tcx> {
                         .iter()
                         .copied()
                         .enumerate()
-                        .map(|(index, element)| (index.into(), element))
+                        .map(|(index, element)| (Identifier::num(index), element))
                         .collect_vec(),
                     ArrayTerm::Repeated(operand, repeat) => {
                         // @@Semantics: When we need to deal with data drops, what do we do in the
@@ -449,7 +449,7 @@ impl<'tcx> BodyBuilder<'tcx> {
 
         let aggregate_kind = adt_id.map(|adt| {
             if adt.flags.is_enum() || adt.flags.is_union() {
-                AggregateKind::Enum(adt_id, VariantIdx::from_usize(ctor.1))
+                AggregateKind::Enum(adt_id, VariantIdx::from_raw(ctor.1))
             } else {
                 debug_assert!(adt.flags.is_struct());
                 AggregateKind::Struct(adt_id)
@@ -477,7 +477,7 @@ impl<'tcx> BodyBuilder<'tcx> {
             .map(|arg| {
                 let name = match arg.target {
                     ParamIndex::Name(name) => name,
-                    ParamIndex::Position(pos) => pos.into(),
+                    ParamIndex::Position(pos) => Identifier::num(pos),
                 };
 
                 (name, arg.value)

--- a/compiler/hash-lower/src/build/matches/candidate.rs
+++ b/compiler/hash-lower/src/build/matches/candidate.rs
@@ -442,7 +442,7 @@ impl<'tcx> BodyBuilder<'tcx> {
                     // and thus we use the index of the pattern in the argument.
                     let index = match arg.target {
                         ParamIndex::Name(name) => variant.field_idx(name).unwrap(),
-                        ParamIndex::Position(index) => index,
+                        ParamIndex::Position(index) => index as usize,
                     };
 
                     let place = place.clone_project(PlaceProjection::Field(index));

--- a/compiler/hash-lower/src/build/matches/test.rs
+++ b/compiler/hash-lower/src/build/matches/test.rs
@@ -294,7 +294,7 @@ impl<'tcx> BodyBuilder<'tcx> {
                         return None;
                     }
 
-                    Some(VariantIdx::from_usize(ctor.1))
+                    Some(VariantIdx::from_raw(ctor.1))
                 })?;
 
                 self.candidate_after_variant_switch(
@@ -517,7 +517,7 @@ impl<'tcx> BodyBuilder<'tcx> {
                     .map(|arg| {
                         let field_index = match arg.target {
                             ParamIndex::Name(name) => variant.field_idx(name).unwrap(),
-                            ParamIndex::Position(index) => index,
+                            ParamIndex::Position(index) => index as usize,
                         };
 
                         let place =
@@ -819,7 +819,7 @@ impl<'tcx> BodyBuilder<'tcx> {
         // the variants...
         match *match_pair.pat.value() {
             Pat::Ctor(CtorPat { ctor, .. }) => {
-                variants.insert(ctor.1);
+                variants.insert(ctor.1 as usize);
                 true
             }
 

--- a/compiler/hash-lower/src/build/place.rs
+++ b/compiler/hash-lower/src/build/place.rs
@@ -186,7 +186,7 @@ impl<'tcx> BodyBuilder<'tcx> {
                         // whole vector trying to find the field with the same name.
                         variant.fields.iter().position(|field| field.name == name).unwrap()
                     }
-                    ParamIndex::Position(index) => index,
+                    ParamIndex::Position(index) => index as usize,
                 }
             } else {
                 unreachable!("attempt to access a field of a non-struct or tuple type")

--- a/compiler/hash-lower/src/lower_ty.rs
+++ b/compiler/hash-lower/src/lower_ty.rs
@@ -13,6 +13,7 @@ use hash_ir::{
     TyCacheEntry,
 };
 use hash_reporting::macros::panic_on_span;
+use hash_source::identifier::Identifier;
 use hash_storage::store::{
     statics::{SingleStoreValue, StoreId},
     SequenceStoreKey,
@@ -116,7 +117,7 @@ impl<'ir> BuilderCtx<'ir> {
                     .iter()
                     .map(|field| self.ty_id_from_tir_ty(field.ty))
                     .enumerate()
-                    .map(|(index, ty)| AdtField { name: index.into(), ty })
+                    .map(|(index, ty)| AdtField { name: Identifier::num(index), ty })
                     .collect();
                 let variant = AdtVariant::singleton("0".into(), fields);
 
@@ -340,7 +341,7 @@ impl<'ir> BuilderCtx<'ir> {
                     .iter()
                     .enumerate()
                     .map(|(index, field)| AdtField {
-                        name: field.name.borrow().name.unwrap_or(index.into()),
+                        name: field.name.borrow().name.unwrap_or_else(|| Identifier::num(index)),
                         ty: self.ty_id_from_tir_ty(field.ty),
                     })
                     .collect_vec();

--- a/compiler/hash-parser/src/parser/expr.rs
+++ b/compiler/hash-parser/src/parser/expr.rs
@@ -663,7 +663,7 @@ impl<'s> AstGen<'s> {
                 }
 
                 self.skip_fast(token.kind); // `int` literal
-                let value = self.source.hunk(token.span).parse::<usize>().map_err(|_| {
+                let value = self.source.hunk(token.span).parse::<u32>().map_err(|_| {
                     self.make_err(
                         ParseErrorKind::InvalidPropertyAccess,
                         ExpectedItem::empty(),

--- a/compiler/hash-semantics/src/passes/discovery/defs.rs
+++ b/compiler/hash-semantics/src/passes/discovery/defs.rs
@@ -240,7 +240,7 @@ impl<'env, E: SemanticEnv + 'env> DiscoveryPass<'env, E> {
                         {
                             ast_info.mod_members().insert(
                                 *node_id,
-                                ModMemberId(mod_members.elements(), mod_member_index),
+                                ModMemberId::new(mod_members.elements(), mod_member_index),
                             );
                         }
                     }
@@ -273,9 +273,10 @@ impl<'env, E: SemanticEnv + 'env> DiscoveryPass<'env, E> {
                         for ((node_id, _), data_ctor_index) in
                             members.iter().zip(ctors.to_index_range())
                         {
-                            ast_info
-                                .ctor_defs()
-                                .insert(*node_id, CtorDefId(ctors.elements(), data_ctor_index));
+                            ast_info.ctor_defs().insert(
+                                *node_id,
+                                CtorDefId::new(ctors.elements(), data_ctor_index),
+                            );
                         }
                     }
                 })

--- a/compiler/hash-semantics/src/passes/discovery/params.rs
+++ b/compiler/hash-semantics/src/passes/discovery/params.rs
@@ -21,7 +21,7 @@ impl<'env, E: SemanticEnv> DiscoveryPass<'env, E> {
                         Some(name) => {
                             ParamIndex::Name(name.ident).into_symbol(NodeOrigin::Given(name.id()))
                         }
-                        None => ParamIndex::Position(i).into_symbol(NodeOrigin::Given(param.id())),
+                        None => ParamIndex::pos(i).into_symbol(NodeOrigin::Given(param.id())),
                     }),
                     NodeOrigin::Given(param.id()),
                 )
@@ -30,7 +30,7 @@ impl<'env, E: SemanticEnv> DiscoveryPass<'env, E> {
         );
 
         for (i, param) in params.iter().enumerate() {
-            self.ast_info.params().insert(param.id(), ParamId(params_id.elements(), i));
+            self.ast_info.params().insert(param.id(), ParamId::new(params_id.elements(), i));
         }
 
         params_id

--- a/compiler/hash-semantics/src/passes/resolution/exprs.rs
+++ b/compiler/hash-semantics/src/passes/resolution/exprs.rs
@@ -70,7 +70,7 @@ impl<E: SemanticEnv> ResolutionPass<'_, E> {
                             .name
                             .as_ref()
                             .map(|name| ParamIndex::Name(name.ident))
-                            .unwrap_or_else(|| ParamIndex::Position(i)),
+                            .unwrap_or_else(|| ParamIndex::pos(i)),
                         value: self.make_term_from_ast_expr(arg.value.ast_ref())?,
                     },
                     NodeOrigin::Given(arg.id()),
@@ -96,7 +96,7 @@ impl<E: SemanticEnv> ResolutionPass<'_, E> {
                             .name
                             .as_ref()
                             .map(|name| ParamIndex::Name(name.ident))
-                            .unwrap_or_else(|| ParamIndex::Position(i)),
+                            .unwrap_or_else(|| ParamIndex::pos(i)),
                         value: self.make_term_from_ast_expr(arg.value.ast_ref())?,
                     },
                     NodeOrigin::Given(arg.id()),

--- a/compiler/hash-semantics/src/passes/resolution/pats.rs
+++ b/compiler/hash-semantics/src/passes/resolution/pats.rs
@@ -45,7 +45,7 @@ impl<E: SemanticEnv> ResolutionPass<'_, E> {
                     PatArg {
                         target: match arg.name.as_ref() {
                             Some(name) => ParamIndex::Name(name.ident),
-                            None => ParamIndex::Position(i),
+                            None => ParamIndex::pos(i),
                         },
                         pat: PatOrCapture::Pat(self.make_pat_from_ast_pat(arg.pat.ast_ref())?),
                     },

--- a/compiler/hash-semantics/src/passes/resolution/scoping.rs
+++ b/compiler/hash-semantics/src/passes/resolution/scoping.rs
@@ -201,7 +201,7 @@ impl<'env, E: SemanticEnv + 'env> Scoping<'env, E> {
     pub(super) fn add_data_params_and_ctors(&self, data_def_id: DataDefId) {
         let params = data_def_id.borrow().params;
         for i in params.to_index_range() {
-            self.add_param_binding(ParamId(params.elements(), i));
+            self.add_param_binding(ParamId::new(params.elements(), i));
         }
         // Add all the constructors
         match data_def_id.borrow().ctors {

--- a/compiler/hash-semantics/src/passes/resolution/tys.rs
+++ b/compiler/hash-semantics/src/passes/resolution/tys.rs
@@ -46,7 +46,7 @@ impl<E: SemanticEnv> ResolutionPass<'_, E> {
                             .name
                             .as_ref()
                             .map(|name| ParamIndex::Name(name.ident))
-                            .unwrap_or_else(|| ParamIndex::Position(i)),
+                            .unwrap_or_else(|| ParamIndex::pos(i)),
                         value: self.make_ty_from_ast_ty(arg.ty.ast_ref())?,
                     },
                     NodeOrigin::Given(arg.id()),

--- a/compiler/hash-source/src/identifier.rs
+++ b/compiler/hash-source/src/identifier.rs
@@ -10,7 +10,8 @@ use hash_storage::{
     string::BrickString,
 };
 use hash_utils::{
-    counter, dashmap::DashMap, fnv::FnvBuildHasher, fxhash::FxBuildHasher, lazy_static::lazy_static,
+    counter, dashmap::DashMap, fnv::FnvBuildHasher, fxhash::FxBuildHasher,
+    lazy_static::lazy_static, num_traits::PrimInt,
 };
 
 counter! {
@@ -37,6 +38,15 @@ impl Identifier {
     /// Get the identifier as a static string.
     pub fn as_str(&self) -> &'static str {
         IDENTIFIER_MAP.get_ident(*self)
+    }
+
+    /// Create an [Identifier] from a numeric type.
+    ///
+    /// This will convert the numeric using the [fmt::Display]
+    /// implementation, and finally create a new identifier for
+    /// it.
+    pub fn num<N: PrimInt + ToString>(value: N) -> Self {
+        IDENTIFIER_MAP.create_ident(value.to_string().as_str())
     }
 }
 
@@ -66,12 +76,6 @@ impl From<&str> for Identifier {
 impl From<String> for Identifier {
     fn from(name: String) -> Self {
         IDENTIFIER_MAP.create_ident(name.as_str())
-    }
-}
-
-impl From<usize> for Identifier {
-    fn from(id: usize) -> Self {
-        IDENTIFIER_MAP.create_ident(id.to_string().as_str())
     }
 }
 

--- a/compiler/hash-storage/src/store/sequence/mod.rs
+++ b/compiler/hash-storage/src/store/sequence/mod.rs
@@ -152,7 +152,9 @@ macro_rules! new_sequence_store_key_direct {
 
         impl $el_name {
             pub fn new(a: $name, b: usize) -> Self {
-                Self(a, b as u32)
+                let index = b as u32;
+                debug_assert!(index < a.len);
+                Self(a, index)
             }
         }
 

--- a/compiler/hash-storage/src/store/sequence/mod.rs
+++ b/compiler/hash-storage/src/store/sequence/mod.rs
@@ -148,17 +148,23 @@ macro_rules! new_sequence_store_key_direct {
         }
 
         #[derive(PartialEq, Eq, Clone, Copy, Hash, $($($extra_el_derives),*)?)]
-        $visibility struct $el_name(pub $name, pub usize);
+        $visibility struct $el_name(pub $name, pub u32);
+
+        impl $el_name {
+            pub fn new(a: $name, b: usize) -> Self {
+                Self(a, b as u32)
+            }
+        }
 
         impl From<$el_name> for ($name, usize) {
             fn from(value: $el_name) -> Self {
-                (value.0, value.1)
+                (value.0, value.1 as usize)
             }
         }
 
         impl From<($name, usize)> for $el_name {
             fn from(value: ($name, usize)) -> Self {
-                Self(value.0, value.1)
+                Self(value.0, value.1 as u32)
             }
         }
 

--- a/compiler/hash-storage/src/store/statics.rs
+++ b/compiler/hash-storage/src/store/statics.rs
@@ -543,17 +543,17 @@ macro_rules! static_sequence_store_direct {
 
             fn map<R>(self, f: impl FnOnce(&Self::ValueRef) -> R) -> R {
                 use $crate::store::SequenceStore;
-                $store_source.$store_name().map_fast(self.0, |v| f(&v[self.1]))
+                $store_source.$store_name().map_fast(self.0, |v| f(&v[self.1 as usize]))
             }
 
             fn modify<R>(self, f: impl FnOnce(&mut Self::ValueRef) -> R) -> R {
                 use $crate::store::SequenceStore;
-                $store_source.$store_name().modify_fast(self.0, |v| f(&mut v[self.1]))
+                $store_source.$store_name().modify_fast(self.0, |v| f(&mut v[self.1 as usize]))
             }
 
             fn set(self, value: Self::Value) {
                 use $crate::store::SequenceStore;
-                $store_source.$store_name().set_at_index(self.0, self.1, value);
+                $store_source.$store_name().set_at_index(self.0, self.1 as usize, value);
             }
         }
     };

--- a/compiler/hash-tir/src/stores.rs
+++ b/compiler/hash-tir/src/stores.rs
@@ -281,7 +281,7 @@ macro_rules! tir_node_sequence_store_direct {
         impl From<($id, usize)> for $el_id {
             fn from(value: ($id, usize)) -> Self {
                 use hash_storage::store::statics::StoreId;
-                $el_id(value.0.value().data, value.1)
+                $el_id::new(value.0.value().data, value.1)
             }
         }
     };

--- a/compiler/hash-tir/src/tir/args.rs
+++ b/compiler/hash-tir/src/tir/args.rs
@@ -54,7 +54,7 @@ impl Arg {
                     .map(|(i, param)| {
                         Node::at(
                             Arg {
-                                target: ParamIndex::Position(i),
+                                target: ParamIndex::pos(i),
                                 value: Term::var(param.value().name),
                             },
                             param.origin(),
@@ -77,7 +77,7 @@ impl Arg {
                 args.into_iter()
                     .enumerate()
                     .map(|(i, arg)| {
-                        Node::at(Arg { target: ParamIndex::Position(i), value: arg }, arg.origin())
+                        Node::at(Arg { target: ParamIndex::pos(i), value: arg }, arg.origin())
                     })
                     .collect_vec(),
             ),
@@ -99,7 +99,7 @@ impl Arg {
                     .map(|(i, param)| {
                         Node::at(
                             Arg {
-                                target: ParamIndex::Position(i),
+                                target: ParamIndex::pos(i),
                                 value: Term::hole(param.origin().inferred()),
                             },
                             param.origin().inferred(),
@@ -240,8 +240,8 @@ impl SequenceStoreKey for SomeArgsId {
 impl From<(SomeArgsId, usize)> for SomeArgId {
     fn from(value: (SomeArgsId, usize)) -> Self {
         match value.0 {
-            SomeArgsId::PatArgs(id) => SomeArgId::PatArg(PatArgId(id.elements(), value.1)),
-            SomeArgsId::Args(id) => SomeArgId::Arg(ArgId(id.elements(), value.1)),
+            SomeArgsId::PatArgs(id) => SomeArgId::PatArg(PatArgId::new(id.elements(), value.1)),
+            SomeArgsId::Args(id) => SomeArgId::Arg(ArgId::new(id.elements(), value.1)),
         }
     }
 }

--- a/compiler/hash-tir/src/tir/params/mod.rs
+++ b/compiler/hash-tir/src/tir/params/mod.rs
@@ -119,7 +119,7 @@ impl ParamsId {
                     None
                 }
             }),
-            ParamIndex::Position(pos) => Some(pos),
+            ParamIndex::Position(pos) => Some(pos as usize),
         }
     }
 }
@@ -131,8 +131,9 @@ impl ParamsId {
 pub enum ParamIndex {
     /// A named parameter, like `foo(value=3)`.
     Name(Identifier),
+
     /// A positional parameter, like `dot(x, y)`.
-    Position(usize),
+    Position(u32),
 }
 
 impl From<ParamId> for ParamIndex {
@@ -149,6 +150,11 @@ impl ParamIndex {
             ParamIndex::Name(name) => SymbolId::from_name(*name, origin),
             ParamIndex::Position(_) => SymbolId::fresh(origin),
         }
+    }
+
+    /// Create a new [ParamIndex::Position].
+    pub fn pos(item: usize) -> Self {
+        Self::Position(item as u32)
     }
 }
 
@@ -240,7 +246,7 @@ impl ParamsId {
                 .value()
                 .iter()
                 .find(|param| matches!(param.borrow().name.borrow().name, Some(n) if n == name)),
-            ParamIndex::Position(pos) => self.elements().at(pos),
+            ParamIndex::Position(pos) => self.elements().at(pos as usize),
         }
     }
 

--- a/compiler/hash-tir/src/tir/params/utils.rs
+++ b/compiler/hash-tir/src/tir/params/utils.rs
@@ -368,12 +368,12 @@ pub fn validate_and_reorder_args_against_params(
         match arg.target {
             // Invariant: all positional arguments are before named
             ParamIndex::Position(j_received) => {
-                assert!(j_received == j);
+                assert!(j_received as usize == j);
 
                 result[j] = Some(Node::at(
                     Arg {
                         // Add the name if present
-                        target: (ParamId(params_id.elements(), j).as_param_index()),
+                        target: (ParamId::new(params_id.elements(), j).as_param_index()),
                         value: arg.value,
                     },
                     arg.origin,
@@ -394,8 +394,8 @@ pub fn validate_and_reorder_args_against_params(
                             // Duplicate argument name, must be from positional
                             assert!(j != i);
                             error_state.add_error(ParamError::DuplicateArg {
-                                first: ArgId(args_id.elements(), i).into(),
-                                second: ArgId(args_id.elements(), j).into(),
+                                first: ArgId::new(args_id.elements(), i).into(),
+                                second: ArgId::new(args_id.elements(), j).into(),
                             });
                         } else {
                             // Found an uncrossed parameter, add it to the result
@@ -425,7 +425,7 @@ pub fn validate_and_reorder_args_against_params(
     // Populate default values and catch missing arguments
     for i in params_id.to_index_range() {
         if result[i].is_none() {
-            let param_id = ParamId(params_id.elements(), i);
+            let param_id = ParamId::new(params_id.elements(), i);
             let param = param_id.borrow();
             let default = param.default;
 
@@ -494,7 +494,7 @@ pub fn validate_and_reorder_pat_args_against_params(
         match arg.target {
             // Invariant: all positional arguments are before named
             ParamIndex::Position(j_received) => {
-                assert!(j_received == j);
+                assert!(j_received as usize == j);
 
                 // If the previous argument was a spread, this is an error
                 if let Some(spread) = spread
@@ -509,7 +509,7 @@ pub fn validate_and_reorder_pat_args_against_params(
                 result[j] = Some(Node::at(
                     PatArg {
                         // Add the name if present
-                        target: (ParamId(params_id.elements(), j)).as_param_index(),
+                        target: (ParamId::new(params_id.elements(), j)).as_param_index(),
                         pat: arg.pat,
                     },
                     arg.origin,
@@ -530,8 +530,8 @@ pub fn validate_and_reorder_pat_args_against_params(
                             // Duplicate argument name, must be from positional
                             assert!(j != i);
                             error_state.add_error(ParamError::DuplicateArg {
-                                first: PatArgId(args_id.elements(), i).into(),
-                                second: PatArgId(args_id.elements(), j).into(),
+                                first: PatArgId::new(args_id.elements(), i).into(),
+                                second: PatArgId::new(args_id.elements(), j).into(),
                             });
                         } else {
                             // Found an uncrossed parameter, add it to the result
@@ -561,7 +561,7 @@ pub fn validate_and_reorder_pat_args_against_params(
     // Populate missing arguments with captures
     for i in params_id.to_index_range() {
         if result[i].is_none() {
-            let param_id = ParamId(params_id.elements(), i);
+            let param_id = ParamId::new(params_id.elements(), i);
             if spread.is_some() {
                 result[i] = Some(Node::at(
                     PatArg {

--- a/compiler/hash-tir/src/visitor.rs
+++ b/compiler/hash-tir/src/visitor.rs
@@ -810,7 +810,7 @@ impl Visit<DataDefId> for Visitor {
             DataDefCtors::Defined(data_def_ctors_id) => {
                 // Traverse the constructors
                 for ctor_idx in data_def_ctors_id.value().to_index_range() {
-                    self.try_visit(CtorDefId(data_def_ctors_id.elements(), ctor_idx), f)?;
+                    self.try_visit(CtorDefId::new(data_def_ctors_id.elements(), ctor_idx), f)?;
                 }
                 Ok(())
             }

--- a/compiler/hash-utils/src/lib.rs
+++ b/compiler/hash-utils/src/lib.rs
@@ -37,6 +37,7 @@ pub use indexmap;
 pub use itertools;
 pub use lazy_static;
 pub use log;
+pub use num_traits;
 pub use parking_lot;
 pub use rayon;
 pub use smallvec;


### PR DESCRIPTION
Any thoughts on how to remove a bunch of type casts everywhere?