### PR TITLE
Store `TargetDataLayout` on `Target`

### DIFF
--- a/compiler/hash-attrs/src/builtin.rs
+++ b/compiler/hash-attrs/src/builtin.rs
@@ -30,7 +30,7 @@ macro_rules! define_attr {
     ($table:expr, $name:ident, { ($($arg:ident : $ty:ident),*), $subject:expr }) => {
         let name: Identifier = stringify!($name).into();
 
-        let params = if ${count(arg)} == 0 {
+        let params = if ${count($arg)} == 0 {
             gen::params([])
         } else {
             gen::params([

--- a/compiler/hash-codegen-llvm/src/translation/builder.rs
+++ b/compiler/hash-codegen-llvm/src/translation/builder.rs
@@ -424,7 +424,7 @@ impl<'a, 'b, 'm> BlockBuilderMethods<'a, 'b> for LLVMBuilder<'a, 'b, 'm> {
 
         // For some reason there is no function to get the width
         // of a float type, so we have to use raw fn call yet again...
-        let intrinsic = match { unsafe { llvm::LLVMGetTypeKind(ty.as_type_ref()) } } {
+        let intrinsic = match unsafe { llvm::LLVMGetTypeKind(ty.as_type_ref()) } {
             llvm_sys::LLVMTypeKind::LLVMHalfTypeKind
             | llvm_sys::LLVMTypeKind::LLVMFloatTypeKind => "llvm.pow.f32",
             llvm_sys::LLVMTypeKind::LLVMDoubleTypeKind => "llvm.pow.f64",

--- a/compiler/hash-lower/src/build/utils.rs
+++ b/compiler/hash-lower/src/build/utils.rs
@@ -60,10 +60,7 @@ impl<'tcx> BodyBuilder<'tcx> {
         };
 
         // Now lookup the item in the libc module
-        let Some(fn_def) = libc_mod.borrow().get_mod_fn_member_by_ident(name) else {
-            return None;
-        };
-
+        let fn_def = libc_mod.borrow().get_mod_fn_member_by_ident(name)?;
         Some(self.ty_id_from_tir_fn_def(fn_def))
     }
 
@@ -73,9 +70,7 @@ impl<'tcx> BodyBuilder<'tcx> {
     /// N.B. This assumes that the items have no type arguments.
     pub(crate) fn lookup_prelude_item(&mut self, name: &str) -> Option<IrTyId> {
         // Now lookup the item in the libc module
-        let Some(member) = self.ctx.prelude.borrow().get_mod_member_by_ident(name) else {
-            return None;
-        };
+        let member = self.ctx.prelude.borrow().get_mod_member_by_ident(name)?;
 
         match member.value {
             ModMemberValue::Data(data_def) => {

--- a/compiler/hash-target/src/lib.rs
+++ b/compiler/hash-target/src/lib.rs
@@ -140,7 +140,7 @@ pub struct Target {
 
     /// The equivalent of `data_layout`, but parsed into a structural
     /// format.
-    target_data_layout: Option<TargetDataLayout>,
+    target_data_layout: TargetDataLayout,
 
     /// What endianess the target is.
     pub endian: Endian,
@@ -263,12 +263,12 @@ impl Target {
     /// @@Ugh: this is a shit API, we need to figure out how to unify a the
     /// target and target data layout items.
     pub fn data_layout(&self) -> &TargetDataLayout {
-        self.target_data_layout.as_ref().unwrap()
+        &self.target_data_layout
     }
 
-    /// Set the [TargetDataLayout] for the [Target].
+    /// Set the [TargetDataLayout] for the [Target].Ì
     pub fn set_data_layout(&mut self, dl: TargetDataLayout) {
-        self.target_data_layout = Some(dl);
+        self.target_data_layout = dl;
     }
 
     /// Produce a [TargetDataLayout] from the given [Target] layout
@@ -354,7 +354,7 @@ impl Default for Target {
             // value will be overridden for the platform specific data layout
             // string.
             data_layout: "e-m:e-i64:64-f80:128-n8:16:32:64-S128".into(),
-            target_data_layout: Some(TargetDataLayout::default()),
+            target_data_layout: TargetDataLayout::default(),
             pointer_bit_width,
 
             // Entry point options

--- a/compiler/hash-target/src/lib.rs
+++ b/compiler/hash-target/src/lib.rs
@@ -138,6 +138,10 @@ pub struct Target {
     /// The data layout of the architecture.
     pub data_layout: Cow<'static, str>,
 
+    /// The equivalent of `data_layout`, but parsed into a structural
+    /// format.
+    target_data_layout: Option<TargetDataLayout>,
+
     /// What endianess the target is.
     pub endian: Endian,
 
@@ -253,6 +257,20 @@ impl Target {
         load_target(triple)
     }
 
+    /// Get the [TargetDataLayout] that is associated with this [Target], if
+    /// there exists one.
+    ///
+    /// @@Ugh: this is a shit API, we need to figure out how to unify a the
+    /// target and target data layout items.
+    pub fn data_layout(&self) -> &TargetDataLayout {
+        self.target_data_layout.as_ref().unwrap()
+    }
+
+    /// Set the [TargetDataLayout] for the [Target].
+    pub fn set_data_layout(&mut self, dl: TargetDataLayout) {
+        self.target_data_layout = Some(dl);
+    }
+
     /// Produce a [TargetDataLayout] from the given [Target] layout
     /// string. If the layout contains any errors, this function will
     /// return the errors that were encountered.
@@ -336,6 +354,7 @@ impl Default for Target {
             // value will be overridden for the platform specific data layout
             // string.
             data_layout: "e-m:e-i64:64-f80:128-n8:16:32:64-S128".into(),
+            target_data_layout: Some(TargetDataLayout::default()),
             pointer_bit_width,
 
             // Entry point options

--- a/compiler/hash-tir/src/intrinsics/make.rs
+++ b/compiler/hash-tir/src/intrinsics/make.rs
@@ -586,7 +586,7 @@ macro_rules! make_primitives {
                                                         // ##Hack: count the number of characters
                                                         // in the stringified arguments to
                                                         // determine if there are any
-                                                        result_args: if ${count(ctor_arg)} > 0 {
+                                                        result_args: if ${count($ctor_arg)} > 0 {
                                                             Some(args([$($($ctor_arg,)*)?]))
                                                         } else {
                                                             None


### PR DESCRIPTION
- chore: fix clippy and macro-metavar compilation issues
- target: store `TargetDataLayout` on `Target`
