### PR TITLE
lower: add metrics to optimisation passes

### DIFF
--- a/compiler/hash-codegen-llvm/src/translation/abi.rs
+++ b/compiler/hash-codegen-llvm/src/translation/abi.rs
@@ -54,10 +54,6 @@ impl<'b, 'm> AbiBuilderMethods<'b> for LLVMBuilder<'_, 'b, 'm> {
 }
 
 pub trait ExtendedArgAbiMethods<'m> {
-    /// Get the type of the memory location that is backing
-    /// the given [ArgAbi].
-    fn get_memory_ty(&self, ctx: &CodeGenCtx<'_, 'm>) -> AnyTypeEnum<'m>;
-
     /// Store the given [AnyValueEnum] into the given [PlaceRef].
     fn store(
         &self,
@@ -119,10 +115,6 @@ impl<'m> ExtendedArgAbiMethods<'m> for ArgAbi {
                 self.store(builder, arg, destination)
             }
         }
-    }
-
-    fn get_memory_ty(&self, ctx: &CodeGenCtx<'_, 'm>) -> AnyTypeEnum<'m> {
-        self.info.llvm_ty(ctx)
     }
 }
 

--- a/compiler/hash-link/src/linker/mod.rs
+++ b/compiler/hash-link/src/linker/mod.rs
@@ -1,6 +1,7 @@
 //! Defines a generic linker interface and functions that create
 //! an instance of a [Linker] with the provided compiler settings
 //! and target options.
+#![allow(dead_code)] // @@Temporary: remove when all linker methods are used.
 
 use std::{
     ffi::{OsStr, OsString},

--- a/compiler/hash-lower/src/lib.rs
+++ b/compiler/hash-lower/src/lib.rs
@@ -204,7 +204,7 @@ impl<Ctx: LoweringCtxQuery> CompilerStage<Ctx> for IrOptimiser {
         let bodies = &mut icx.bodies;
         let body_data = &icx.ctx;
 
-        self.time_item("optimise", |_| {
+        self.time_item("optimise", |this| {
             // @@Todo: think about making optimisation passes in parallel...
             // pool.scope(|scope| {
             //     for body in &mut icx.generated_bodies {
@@ -218,6 +218,10 @@ impl<Ctx: LoweringCtxQuery> CompilerStage<Ctx> for IrOptimiser {
             for body in bodies.iter_mut() {
                 let optimiser = Optimiser::new(body_data, settings);
                 optimiser.optimise(body);
+
+                // Collect metrics on the stages.
+                let metrics = optimiser.into_metrics().into();
+                this.metrics().merge(&metrics);
             }
         });
 

--- a/compiler/hash-lower/src/optimise/cleanup_locals.rs
+++ b/compiler/hash-lower/src/optimise/cleanup_locals.rs
@@ -29,7 +29,7 @@ pub struct CleanupLocalPass;
 
 impl IrOptimisationPass for CleanupLocalPass {
     fn name(&self) -> &'static str {
-        "cleanup_locals"
+        "optimise::cleanup_locals"
     }
 
     /// Pass [CleanupLocalPass] is always enabled since it performs

--- a/compiler/hash-lower/src/optimise/simplify_graph.rs
+++ b/compiler/hash-lower/src/optimise/simplify_graph.rs
@@ -94,7 +94,7 @@ pub struct SimplifyGraphPass;
 
 impl IrOptimisationPass for SimplifyGraphPass {
     fn name(&self) -> &'static str {
-        "simplify-graph"
+        "optimise::simplify_graph"
     }
 
     fn enabled(&self, settings: &CompilerSettings) -> bool {


### PR DESCRIPTION
This PR adds metrics to the optimisation passes that occur during lowering. This has two effects:
- we can no more accurately monitor and keep track of certain performance bottlenecks during IR optimisation.
- stop clippy from complaining about `IrOptimisationPass:name()` not being used.

Also:
- allow dead code in linker implementation (that will be used in the future for libraries)
- remove some dead code in `hash-codegen` and respective backends
