### PR TITLE
Allow for disabling compilation of LLVM backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,6 +554,7 @@ version = "0.1.0"
 dependencies = [
  "hash-codegen",
  "hash-codegen-llvm",
+ "hash-codegen-vm",
  "hash-ir",
  "hash-pipeline",
  "hash-reporting",
@@ -580,16 +581,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hash-codegen-bytecode"
-version = "0.1.0"
-dependencies = [
- "hash-codegen",
- "hash-ir",
- "hash-source",
- "hash-utils",
-]
-
-[[package]]
 name = "hash-codegen-llvm"
 version = "0.1.0"
 dependencies = [
@@ -603,6 +594,17 @@ dependencies = [
  "hash-utils",
  "inkwell",
  "llvm-sys",
+]
+
+[[package]]
+name = "hash-codegen-vm"
+version = "0.1.0"
+dependencies = [
+ "hash-codegen",
+ "hash-ir",
+ "hash-pipeline",
+ "hash-source",
+ "hash-utils",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,6 +745,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash-messaging"
+version = "0.1.0"
+dependencies = [
+ "hash-utils",
+]
+
+[[package]]
 name = "hash-parser"
 version = "0.1.0"
 dependencies = [

--- a/compiler/hash-backend/Cargo.toml
+++ b/compiler/hash-backend/Cargo.toml
@@ -16,3 +16,6 @@ hash-reporting = { path = "../hash-reporting" }
 hash-source = { path = "../hash-source" }
 hash-target = { path = "../hash-target" }
 hash-utils = { path = "../hash-utils" }
+
+[features]
+llvm = []

--- a/compiler/hash-backend/Cargo.toml
+++ b/compiler/hash-backend/Cargo.toml
@@ -10,6 +10,7 @@ doctest = false
 [dependencies]
 hash-codegen = { path = "../hash-codegen" }
 hash-codegen-llvm = { path = "../hash-codegen-llvm" }
+hash-codegen-vm = { path = "../hash-codegen-vm" }
 hash-ir = { path = "../hash-ir" }
 hash-pipeline = { path = "../hash-pipeline" }
 hash-reporting = { path = "../hash-reporting" }

--- a/compiler/hash-backend/src/lib.rs
+++ b/compiler/hash-backend/src/lib.rs
@@ -13,6 +13,8 @@ use hash_pipeline::{
 };
 use hash_source::SourceId;
 
+type Backend<'b> = Box<dyn CompilerBackend<'b> + 'b>;
+
 /// The Hash compiler code generation stage. This stage is responsible for
 /// converting the generated Hash IR into machine code using a specific backend.
 #[derive(Default)]
@@ -58,6 +60,7 @@ impl<Ctx: BackendCtxQuery> CompilerStage<Ctx> for CodeGenPass {
 
         // Create a new instance of a backend, and then run it...
         let mut backend = match settings.codegen_settings.backend {
+            #[cfg(feature = "llvm")]
             CodeGenBackend::LLVM => create_llvm_backend(ctx.data(), &mut self.metrics),
             CodeGenBackend::VM => unimplemented!(),
         };
@@ -67,9 +70,7 @@ impl<Ctx: BackendCtxQuery> CompilerStage<Ctx> for CodeGenPass {
 }
 
 /// Create a new instance of the [hash_codegen_llvm::LLVMBackend].
-pub fn create_llvm_backend<'b>(
-    ctx: BackendCtx<'b>,
-    metrics: &'b mut StageMetrics,
-) -> Box<dyn CompilerBackend<'b> + 'b> {
+#[cfg(feature = "llvm")]
+pub fn create_llvm_backend<'b>(ctx: BackendCtx<'b>, metrics: &'b mut StageMetrics) -> Backend<'b> {
     Box::new(hash_codegen_llvm::LLVMBackend::new(ctx, metrics))
 }

--- a/compiler/hash-backend/src/lib.rs
+++ b/compiler/hash-backend/src/lib.rs
@@ -62,7 +62,7 @@ impl<Ctx: BackendCtxQuery> CompilerStage<Ctx> for CodeGenPass {
         let mut backend = match settings.codegen_settings.backend {
             #[cfg(feature = "llvm")]
             CodeGenBackend::LLVM => create_llvm_backend(ctx.data(), &mut self.metrics),
-            CodeGenBackend::VM => unimplemented!(),
+            CodeGenBackend::VM => create_vm_backend(ctx.data(), &mut self.metrics),
         };
 
         backend.run()
@@ -73,4 +73,9 @@ impl<Ctx: BackendCtxQuery> CompilerStage<Ctx> for CodeGenPass {
 #[cfg(feature = "llvm")]
 pub fn create_llvm_backend<'b>(ctx: BackendCtx<'b>, metrics: &'b mut StageMetrics) -> Backend<'b> {
     Box::new(hash_codegen_llvm::LLVMBackend::new(ctx, metrics))
+}
+
+/// Create a new instance of the [hash_codegen_vm::VMBackend].
+pub fn create_vm_backend<'b>(ctx: BackendCtx<'b>, metrics: &'b mut StageMetrics) -> Backend<'b> {
+    Box::new(hash_codegen_vm::VMBackend::new(ctx, metrics))
 }

--- a/compiler/hash-codegen-bytecode/src/lib.rs
+++ b/compiler/hash-codegen-bytecode/src/lib.rs
@@ -1,3 +1,0 @@
-//! Hash compiler bytecode code generation crate. This crate contains
-//! all of the logic of transforming generated Hash IR into Hash Bytecode
-//! so that it can be processed by the Hash VM.

--- a/compiler/hash-codegen-vm/Cargo.toml
+++ b/compiler/hash-codegen-vm/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "hash-codegen-bytecode"
+name = "hash-codegen-vm"
 version = "0.1.0"
 authors = ["The Hash Language authors"]
 edition = "2021"
@@ -10,5 +10,6 @@ doctest = false
 [dependencies]
 hash-codegen = {path = "../hash-codegen" }
 hash-ir = {path = "../hash-ir" }
+hash-pipeline = { path = "../hash-pipeline" }
 hash-source = {path = "../hash-source" }
 hash-utils = {path = "../hash-utils" }

--- a/compiler/hash-codegen-vm/src/lib.rs
+++ b/compiler/hash-codegen-vm/src/lib.rs
@@ -1,0 +1,76 @@
+//! Hash compiler bytecode code generation crate. This crate contains
+//! all of the logic of transforming generated Hash IR into Hash Bytecode
+//! so that it can be processed by the Hash VM.
+#![allow(unused)]
+
+use hash_codegen::{
+    backend::{BackendCtx, CodeGenStorage, CompilerBackend},
+    repr::LayoutStorage,
+};
+use hash_ir::IrStorage;
+use hash_pipeline::{
+    interface::{CompilerOutputStream, CompilerResult},
+    settings::CompilerSettings,
+    workspace::Workspace,
+};
+use hash_utils::profiling::{HasMutMetrics, StageMetrics};
+
+pub struct VMBackend<'b> {
+    /// The stream to use for printing out the results
+    /// of the lowering operation.
+    stdout: CompilerOutputStream,
+
+    /// The current compiler workspace, which is where the results of the
+    /// linking and bytecode emission will be stored.
+    workspace: &'b mut Workspace,
+
+    /// The compiler settings associated with the current
+    /// session.
+    settings: &'b CompilerSettings,
+
+    /// The IR storage that is used to store the lowered IR, and all metadata
+    /// about the IR.
+    ir_storage: &'b IrStorage,
+
+    /// The codegen storage, stores information about objects that were
+    /// generated during code generation.
+    codegen_storage: &'b CodeGenStorage,
+
+    /// All of the information about the layouts of types
+    /// in the current session.
+    layouts: &'b LayoutStorage,
+
+    /// All of the metrics that are collected when running the LLVM
+    /// backend. This contains a map of `stages` to the time it took
+    /// to run the stage.
+    metrics: &'b mut StageMetrics,
+}
+
+impl<'b> HasMutMetrics for VMBackend<'b> {
+    fn metrics(&mut self) -> &mut StageMetrics {
+        self.metrics
+    }
+}
+
+impl<'b> VMBackend<'b> {
+    /// Create a new LLVM Backend from the given [BackendCtx].
+    pub fn new(ctx: BackendCtx<'b>, metrics: &'b mut StageMetrics) -> Self {
+        let BackendCtx {
+            workspace,
+            icx: ir_storage,
+            codegen_storage,
+            lcx: layouts,
+            settings,
+            stdout,
+            ..
+        } = ctx;
+
+        Self { settings, workspace, ir_storage, codegen_storage, layouts, stdout, metrics }
+    }
+}
+
+impl<'b> CompilerBackend<'b> for VMBackend<'b> {
+    fn run(&mut self) -> CompilerResult<()> {
+        todo!()
+    }
+}

--- a/compiler/hash-codegen/src/lower/terminator.rs
+++ b/compiler/hash-codegen/src/lower/terminator.rs
@@ -11,7 +11,7 @@
 
 use hash_abi::{ArgAbi, FnAbiId, PassMode};
 use hash_ir::{intrinsics::Intrinsic, ir, lang_items::LangItem, ty::COMMON_REPR_TYS};
-use hash_pipeline::settings::{CodeGenBackend, OptimisationLevel};
+use hash_pipeline::settings::OptimisationLevel;
 use hash_source::constant::AllocId;
 use hash_storage::store::{statics::StoreId, Store};
 use hash_target::abi::{AbiRepresentation, ValidScalarRange};
@@ -551,7 +551,7 @@ impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
         } else if targets_iter.len() == 2
             && self.body.blocks()[targets.otherwise()].is_empty_and_unreachable()
             && self.ctx.settings().optimisation_level == OptimisationLevel::Debug
-            && self.ctx.settings().codegen_settings().backend == CodeGenBackend::LLVM
+            && self.ctx.settings().codegen_settings().backend.is_llvm()
         {
             let (value, target_1) = targets_iter.next().unwrap();
             let (_, target_2) = targets_iter.next().unwrap();

--- a/compiler/hash-driver/Cargo.toml
+++ b/compiler/hash-driver/Cargo.toml
@@ -30,3 +30,6 @@ hash-lower = { path = "../hash-lower" }
 hash-parser = { path = "../hash-parser" }
 hash-semantics = { path = "../hash-semantics" }
 hash-untyped-semantics = { path = "../hash-untyped-semantics" }
+
+[features]
+llvm = ["hash-backend/llvm"]

--- a/compiler/hash-messaging/Cargo.toml
+++ b/compiler/hash-messaging/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "hash-messaging"
+version = "0.1.0"
+authors = ["The Hash Language authors"]
+edition = "2021"
+
+[lib]
+doctest = false
+
+[dependencies]
+hash-utils = {path = "../hash-utils" }

--- a/compiler/hash-messaging/src/lib.rs
+++ b/compiler/hash-messaging/src/lib.rs
@@ -1,0 +1,1 @@
+//! Defines compiler messages that are passed in and out of the compiler.

--- a/compiler/hash-pipeline/Cargo.toml
+++ b/compiler/hash-pipeline/Cargo.toml
@@ -18,3 +18,7 @@ hash-reporting = { path = "../hash-reporting" }
 hash-source = { path = "../hash-source" }
 hash-target = { path = "../hash-target" }
 hash-utils = { path = "../hash-utils" }
+
+
+[features]
+llvm = []

--- a/compiler/hash-pipeline/build.rs
+++ b/compiler/hash-pipeline/build.rs
@@ -1,5 +1,5 @@
-//! Build file for the `hash-pipeline` crate. This simply inlines the
-//! executable version into the executable.
+//! Build file for the `hash-pipeline` crate. This simply inlines needed
+//! metadata about the standard library and the compiler itself.
 
 use std::path::PathBuf;
 
@@ -7,9 +7,36 @@ use std::path::PathBuf;
 /// where the standard library is located at.
 static BUILD_DIR: &str = env!("CARGO_MANIFEST_DIR");
 
-/// This is run at compile time to compute some meta data about the produced
-/// executable
 fn main() {
+    inline_stdlib_info();
+    inline_compuler_info();
+}
+
+/// Compute the path to the standard library and inline it into the build of
+/// the compiler.
+///
+/// @@Future: We probably shouldn't do this because it will depend on each
+/// installed system where the standard library is located. We should probably
+/// define a "install" process that will copy the compiler and unpack the
+/// standard library into a known location.
+fn inline_stdlib_info() {
     let stdlib_path: PathBuf = [BUILD_DIR, "..", "..", "stdlib"].iter().collect();
     println!("cargo:rustc-env=STDLIB_PATH={}", stdlib_path.as_path().to_str().unwrap());
+}
+
+/// Compute the version of the compiler and inline it into the build of the
+/// compiler. The version incluces the version of the `hash` crate, and the git
+/// revision hash of the compiler itself.
+fn inline_compuler_info() {
+    let git_hash = String::from_utf8(
+        std::process::Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .output()
+            .expect("Failed to get git hash")
+            .stdout,
+    )
+    .unwrap();
+
+    let version = format!("{}-{}", env!("CARGO_PKG_VERSION"), git_hash);
+    println!("cargo:rustc-env=COMPILER_VERSION={}", version);
 }

--- a/compiler/hash-pipeline/src/settings.rs
+++ b/compiler/hash-pipeline/src/settings.rs
@@ -21,7 +21,7 @@ use crate::{error::PipelineError, fs::resolve_path};
 /// Various settings that are present on the compiler pipeline when initially
 /// launching.
 #[derive(Parser, Debug, Clone)]
-#[command(name = "hashc", version, about = "", author)]
+#[command(name = "hashc", version = env!("COMPILER_VERSION"), about = "", author)]
 pub struct CompilerSettings {
     /// An optionally specified entry point for the compiler.
     ///

--- a/compiler/hash-pipeline/src/settings.rs
+++ b/compiler/hash-pipeline/src/settings.rs
@@ -472,7 +472,7 @@ pub struct CodeGenSettings {
     /// be that some functions/expressions are evaluated at compile-time via the
     /// Hash VM which may mean that the code generation backend for that one
     /// might differ from the overall code generation backend.
-    #[arg(long="backend", default_value_t = CodeGenBackend::LLVM)]
+    #[arg(long="backend", default_value_t = CodeGenBackend::default())]
     pub backend: CodeGenBackend,
 
     /// An optionally specified path to a file that should be used to
@@ -537,21 +537,49 @@ impl Default for CodeGenSettings {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum CodeGenBackend {
     /// The LLVM backend is target for code generation.
+    #[cfg(feature = "llvm")]
     LLVM,
 
     /// The Hash VM interpreter is being targeted.
     VM,
 }
 
+impl CodeGenBackend {
+    /// Check if the code generation backend is the LLVM backend.
+    #[cfg(feature = "llvm")]
+    pub fn is_llvm(&self) -> bool {
+        matches!(self, Self::LLVM)
+    }
+
+    #[cfg(not(feature = "llvm"))]
+    pub fn is_llvm(&self) -> bool {
+        false
+    }
+
+    /// Check if the code generation backend is the Hash VM backend.
+    pub fn is_vm(&self) -> bool {
+        matches!(self, Self::VM)
+    }
+}
+
+#[cfg(feature = "llvm")]
 impl Default for CodeGenBackend {
     fn default() -> Self {
         Self::LLVM
     }
 }
 
+#[cfg(not(feature = "llvm"))]
+impl Default for CodeGenBackend {
+    fn default() -> Self {
+        Self::VM
+    }
+}
+
 impl fmt::Display for CodeGenBackend {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            #[cfg(feature = "llvm")]
             Self::LLVM => write!(f, "llvm"),
             Self::VM => write!(f, "vm"),
         }

--- a/compiler/hash/Cargo.toml
+++ b/compiler/hash/Cargo.toml
@@ -22,10 +22,10 @@ hash-target = { path = "../hash-target" }
 hash-utils = { path = "../hash-utils" }
 
 [features]
-profile-with-tracy = ["profiling/profile-with-tracy"]
+tracy = ["profiling/profile-with-tracy"]
+llvm = ["hash-pipeline/llvm", "hash-driver/llvm"]
 
-# Enable this flag to run tracy profiling
-# default = ["profile-with-tracy"]
+default = ["llvm"]
 
 [dev-dependencies.cargo-husky]
 version = "1.5"


### PR DESCRIPTION
- **messaging: add `hash_messaging` crate**
- **fix fmt issue**
- **pipeline: add more verbose version of the compiler**
- **compiler: make compiling LLVM backend optional**
- **codegen(vm): rename crate to `vm` from `bytecode` and add basic impl**


Relates to https://github.com/hash-org/hashc/issues/976
