### PR TITLE
Fix import resolution logic

### DIFF
--- a/compiler/hash-ast-desugaring/src/lib.rs
+++ b/compiler/hash-ast-desugaring/src/lib.rs
@@ -82,8 +82,8 @@ impl<Ctx: AstDesugaringCtxQuery> CompilerStage<Ctx> for AstDesugaringPass {
 
             // Iterate over all of the modules and add the expressions
             // to the queue so it can be distributed over the threads
-            for (id, module) in node_map.iter_mut_modules().enumerate() {
-                let source_id = SourceId::new_module(id as u32);
+            for (id, module) in node_map.iter_mut_modules() {
+                let source_id = SourceId::from(*id);
                 let stage_info = source_stage_info.get(source_id);
 
                 // Skip any modules that have already been de-sugared

--- a/compiler/hash-ast-expand/src/lib.rs
+++ b/compiler/hash-ast-expand/src/lib.rs
@@ -88,8 +88,8 @@ impl<Ctx: AstExpansionCtxQuery> CompilerStage<Ctx> for AstExpansionPass {
                 expander.emit_diagnostics_to(&sender);
             }
 
-            for (id, module) in node_map.iter_modules().enumerate() {
-                let source_id = SourceId::new_module(id as u32);
+            for (id, module) in node_map.iter_modules() {
+                let source_id = SourceId::from(*id);
                 let stage_info = source_stage_info.get(source_id);
 
                 // Skip any modules that have already been de-sugared

--- a/compiler/hash-ast-utils/src/tree.rs
+++ b/compiler/hash-ast-utils/src/tree.rs
@@ -276,7 +276,13 @@ impl AstVisitor for AstTreePrinter {
         &self,
         node: ast::AstNodeRef<ast::Import>,
     ) -> Result<Self::ImportRet, Self::Error> {
-        Ok(TreeNode::leaf(labelled("import", node.path.to_str(), "\"")))
+        Ok(TreeNode::branch(
+            "import",
+            vec![
+                TreeNode::leaf(labelled("import", node.path.to_str(), "\"")),
+                TreeNode::leaf(labelled("source", format!("{:?}", node.source), "")),
+            ],
+        ))
     }
 
     type ImportExprRet = TreeNode;

--- a/compiler/hash-ast/src/node_map.rs
+++ b/compiler/hash-ast/src/node_map.rs
@@ -2,8 +2,11 @@
 //! This is used to ensure that the same node is not parsed and to retrieve
 //! nodes in later compilation stages.
 use std::{
+    collections::{
+        hash_map::{Iter, IterMut},
+        HashMap,
+    },
     path::{Path, PathBuf},
-    slice::{Iter, IterMut},
 };
 
 use hash_source::{InteractiveId, ModuleId, SourceId};
@@ -112,8 +115,11 @@ pub enum SourceRef<'i> {
 /// parsed within the current [Workspace].
 #[derive(Debug, Default)]
 pub struct NodeMap {
-    /// All [Module] nodes that have been parsed.
-    modules: IndexVec<ModuleId, ModuleEntry>,
+    /// All [Module] nodes that have been parsed. We use a [HashMap] here since the 
+    /// order of the parsed modules will not be guaranteed, hence we have to insert by 
+    /// the [ModuleId] that is reserved during parsing.
+    modules: HashMap<ModuleId, ModuleEntry>,
+
     /// All [InteractiveBlock] nodes that have been parsed.
     interactive_blocks: IndexVec<InteractiveId, InteractiveBlock>,
 }
@@ -133,7 +139,7 @@ pub trait HasNodeMap {
 impl NodeMap {
     /// Create a new [NodeMap]
     pub fn new() -> Self {
-        Self { modules: index_vec![], interactive_blocks: index_vec![] }
+        Self { modules: HashMap::new(), interactive_blocks: index_vec![] }
     }
 
     /// Add a [InteractiveBlock] to the [NodeMap]
@@ -142,8 +148,8 @@ impl NodeMap {
     }
 
     /// Add a [Module] to the [NodeMap]
-    pub fn add_module(&mut self, module: ModuleEntry) {
-        self.modules.push(module);
+    pub fn add_module(&mut self, id: ModuleId, module: ModuleEntry) {
+        self.modules.insert(id, module);
     }
 
     /// Get a [SourceRef] by [SourceId].
@@ -170,22 +176,22 @@ impl NodeMap {
     /// Get a mutable reference to an [Module], panics if the [SourceId]
     /// has no backing [Module].
     pub fn get_module(&self, id: ModuleId) -> &ModuleEntry {
-        self.modules.get(id).unwrap()
+        self.modules.get(&id).unwrap()
     }
 
     /// Get a reference to an [Module], panics if the [SourceId]
     /// has no backing [Module].
     pub fn get_module_mut(&mut self, id: ModuleId) -> &mut ModuleEntry {
-        self.modules.get_mut(id).unwrap()
+        self.modules.get_mut(&id).unwrap()
     }
 
     /// /// Create an [Iter] over the currently stores modules within [NodeMap]
-    pub fn iter_modules(&self) -> Iter<ModuleEntry> {
+    pub fn iter_modules(&self) -> Iter<ModuleId, ModuleEntry> {
         self.modules.iter()
     }
 
     /// Create an [IterMut] over the currently stores modules within [NodeMap].
-    pub fn iter_mut_modules(&mut self) -> IterMut<ModuleEntry> {
+    pub fn iter_mut_modules(&mut self) -> IterMut<ModuleId, ModuleEntry> {
         self.modules.iter_mut()
     }
 }

--- a/compiler/hash-ast/src/node_map.rs
+++ b/compiler/hash-ast/src/node_map.rs
@@ -115,9 +115,9 @@ pub enum SourceRef<'i> {
 /// parsed within the current [Workspace].
 #[derive(Debug, Default)]
 pub struct NodeMap {
-    /// All [Module] nodes that have been parsed. We use a [HashMap] here since the 
-    /// order of the parsed modules will not be guaranteed, hence we have to insert by 
-    /// the [ModuleId] that is reserved during parsing.
+    /// All [Module] nodes that have been parsed. We use a [HashMap] here since
+    /// the order of the parsed modules will not be guaranteed, hence we
+    /// have to insert by the [ModuleId] that is reserved during parsing.
     modules: HashMap<ModuleId, ModuleEntry>,
 
     /// All [InteractiveBlock] nodes that have been parsed.

--- a/compiler/hash-parser/src/lib.rs
+++ b/compiler/hash-parser/src/lib.rs
@@ -109,7 +109,7 @@ impl<Ctx: ParserCtxQuery> CompilerStage<Ctx> for Parser {
                         self.merge_metrics(timings);
 
                         let path = SourceMapUtils::map(id, |source| source.path().to_path_buf());
-                        node_map.add_module(ModuleEntry::new(path, node));
+                        node_map.add_module(id, ModuleEntry::new(path, node));
                     }
                     ParserAction::MergeSpans { spans } => scope.spawn(move |_| {
                         SpanMap::add_local_map(spans);

--- a/compiler/hash-pipeline/src/workspace.rs
+++ b/compiler/hash-pipeline/src/workspace.rs
@@ -318,7 +318,7 @@ impl Workspace {
             dump_ast(node.into(), mode, character_set, writer)?;
         }
 
-        for module in self.node_map.iter_modules() {
+        for (_, module) in self.node_map.iter_modules() {
             dump_ast(module.node_ref().into(), mode, character_set, writer)?;
         }
 

--- a/compiler/hash-semantics/src/passes/discovery/mod.rs
+++ b/compiler/hash-semantics/src/passes/discovery/mod.rs
@@ -30,9 +30,6 @@ pub struct DiscoveryPass<'env, E: SemanticEnv> {
     /// currently inside.
     def_state: DefDiscoveryState,
 
-    /// The current source being discovered.
-    source: SourceId,
-
     /// The AST info for the current analysis session.
     ast_info: &'env AstInfo,
 }
@@ -53,7 +50,12 @@ impl<E: SemanticEnv> AnalysisPass for DiscoveryPass<'_, E> {
         self.visit_body_block(node)
     }
 
-    fn pass_module(&self, _: SourceId, node: ast::AstNodeRef<ast::Module>) -> SemanticResult<()> {
+    fn pass_module(
+        &self,
+        source: SourceId,
+        node: ast::AstNodeRef<ast::Module>,
+    ) -> SemanticResult<()> {
+        debug_assert_eq!(source, node.span().id);
         self.visit_module(node)
     }
 
@@ -68,13 +70,12 @@ impl<E: SemanticEnv> AnalysisPass for DiscoveryPass<'_, E> {
 }
 
 impl<'env, E: SemanticEnv> DiscoveryPass<'env, E> {
-    pub fn new(env: &'env E, ast_info: &'env AstInfo, source: SourceId) -> Self {
+    pub fn new(env: &'env E, ast_info: &'env AstInfo) -> Self {
         Self {
             env,
             name_hint: LightState::new(None),
             def_state: DefDiscoveryState::new(),
             ast_info,
-            source,
         }
     }
 

--- a/compiler/hash-semantics/src/passes/discovery/visitor.rs
+++ b/compiler/hash-semantics/src/passes/discovery/visitor.rs
@@ -140,7 +140,7 @@ impl<E: SemanticEnv> ast::AstVisitor for DiscoveryPass<'_, E> {
         &self,
         node: ast::AstNodeRef<ast::Module>,
     ) -> Result<Self::ModuleRet, Self::Error> {
-        let mod_def_id = self.create_or_get_module_mod_def(self.source.into());
+        let mod_def_id = self.create_or_get_module_mod_def(node.span().id.into());
 
         // Traverse the module
         self.enter_def(node, mod_def_id, || walk::walk_module(self, node))?;
@@ -448,7 +448,7 @@ impl<E: SemanticEnv> ast::AstVisitor for DiscoveryPass<'_, E> {
 
     type ImportRet = ();
     fn visit_import(&self, node: AstNodeRef<ast::Import>) -> Result<Self::ImportRet, Self::Error> {
-        DiscoveryPass::new(self.env, self.ast_info, node.source).pass_source(node.source)?;
+        DiscoveryPass::new(self.env, self.ast_info).pass_source(node.source)?;
         Ok(())
     }
 }

--- a/compiler/hash-semantics/src/passes/mod.rs
+++ b/compiler/hash-semantics/src/passes/mod.rs
@@ -30,7 +30,7 @@ impl<'env, E: SemanticEnv> Analyser<'env, E> {
         let ast_info = AstInfo::new();
 
         // Discover all definitions in the source.
-        DiscoveryPass::new(self.env, &ast_info, source).pass_source(source)?;
+        DiscoveryPass::new(self.env, &ast_info).pass_source(source)?;
 
         // Resolve all symbols in the source and create TIR terms.
         ResolutionPass::new(self.env, &ast_info).pass_source(source)?;

--- a/compiler/hash-untyped-semantics/src/lib.rs
+++ b/compiler/hash-untyped-semantics/src/lib.rs
@@ -73,8 +73,8 @@ impl<Ctx: UntypedSemanticAnalysisCtxQuery> CompilerStage<Ctx> for UntypedSemanti
 
             // Iterate over all of the modules and add the expressions
             // to the queue so it can be distributed over the threads
-            for (id, module) in node_map.iter_modules().enumerate() {
-                let source_id = SourceId::new_module(id as u32);
+            for (id, module) in node_map.iter_modules() {
+                let source_id = SourceId::from(*id);
                 let stage_info = source_stage_info.get(source_id);
 
                 // Skip any modules that have already been checked


### PR DESCRIPTION
This fixes issue #980 and other similar issues where given that multiple imports are being simultaneously parsed, the insertion order of the modules in `NodeMap` is not correctly preserved when using a `Vec`. This comes from the fact that the parser generates the corresponding `ModuleId`. To respect the order of insertion, we use a map between the generated `ModuleId` and the parsed `Module`s.

fixes #980
fixes #982