### PR TITLE
fix #1066

### DIFF
--- a/compiler/hash-codegen-llvm/src/translation/builder.rs
+++ b/compiler/hash-codegen-llvm/src/translation/builder.rs
@@ -672,7 +672,7 @@ impl<'a, 'b, 'm> BlockBuilderMethods<'a, 'b> for LLVMBuilder<'a, 'b, 'm> {
         let fn_ty = self.type_function(&[src_ty], dest_ty);
         let func = self.declare_c_fn(&name, UnnamedAddress::None, fn_ty).as_any_value_enum();
 
-        self.call(func.get_type(), func, &[value], None)
+        self.call(fn_ty, func, &[value], None)
     }
 
     fn fp_to_ui(&mut self, val: Self::Value, dest_ty: Self::Type) -> Self::Value {

--- a/compiler/hash/src/main.rs
+++ b/compiler/hash/src/main.rs
@@ -14,7 +14,7 @@ fn main() {
     log::set_logger(&COMPILER_LOGGER).unwrap_or_else(|_| panic!("couldn't initiate logger"));
 
     // Starting the Tracy client is necessary before any invoking any of its APIs
-    #[cfg(feature = "profile-with-tracy")]
+    #[cfg(feature = "tracy")]
     tracy_client::Client::start();
 
     // Register main thread with the profiler


### PR DESCRIPTION
~~Merge #1065 first~~

- **codegen(llvm): use `fn_ty` instead of `func.get_type()`**
- **hashc: use correct `tracy` feature name**

fix #1066 
