### PR TITLE
json messaging format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,6 +402,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "erased-serde"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24e2389d65ab4fab27dc2a5de7b191e1f6617d1f1c8855c0dc569c94a4cbb18d"
+dependencies = [
+ "serde",
+ "typeid",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1051,6 +1061,7 @@ dependencies = [
  "rayon",
  "schemars",
  "serde",
+ "serde_json",
  "smallvec",
  "stacker",
  "thin-vec",
@@ -1138,6 +1149,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -1260,6 +1272,10 @@ name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+dependencies = [
+ "serde",
+ "value-bag",
+]
 
 [[package]]
 name = "loom"
@@ -1783,6 +1799,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45a28f4c49489add4ce10783f7911893516f15afe45d015608d41faca6bc4d29"
 dependencies = [
  "dyn-clone",
+ "indexmap 1.9.3",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -1847,6 +1864,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "serde_fmt"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d4ddca14104cd60529e8c7f7ba71a2c8acd8f7f5cfcdc2faf97eeb7c3010a4"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1916,6 +1942,84 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "sval"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53eb957fbc79a55306d5d25d87daf3627bc3800681491cda0709eef36c748bfe"
+
+[[package]]
+name = "sval_buffer"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96e860aef60e9cbf37888d4953a13445abf523c534640d1f6174d310917c410d"
+dependencies = [
+ "sval",
+ "sval_ref",
+]
+
+[[package]]
+name = "sval_dynamic"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea3f2b07929a1127d204ed7cb3905049381708245727680e9139dac317ed556f"
+dependencies = [
+ "sval",
+]
+
+[[package]]
+name = "sval_fmt"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4e188677497de274a1367c4bda15bd2296de4070d91729aac8f0a09c1abf64d"
+dependencies = [
+ "itoa",
+ "ryu",
+ "sval",
+]
+
+[[package]]
+name = "sval_json"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f456c07dae652744781f2245d5e3b78e6a9ebad70790ac11eb15dbdbce5282"
+dependencies = [
+ "itoa",
+ "ryu",
+ "sval",
+]
+
+[[package]]
+name = "sval_nested"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "886feb24709f0476baaebbf9ac10671a50163caa7e439d7a7beb7f6d81d0a6fb"
+dependencies = [
+ "sval",
+ "sval_buffer",
+ "sval_ref",
+]
+
+[[package]]
+name = "sval_ref"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2e7fc517d778f44f8cb64140afa36010999565528d48985f55e64d45f369ce"
+dependencies = [
+ "sval",
+]
+
+[[package]]
+name = "sval_serde"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79bf66549a997ff35cd2114a27ac4b0c2843280f2cfa84b240d169ecaa0add46"
+dependencies = [
+ "serde",
+ "sval",
+ "sval_nested",
 ]
 
 [[package]]
@@ -2154,6 +2258,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typeid"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "059d83cc991e7a42fc37bd50941885db0888e34209f8cfd9aab07ddec03bc9cf"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2220,6 +2330,42 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "value-bag"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a84c137d37ab0142f0f2ddfe332651fdbf252e7b7dbb4e67b6c1f1b2e925101"
+dependencies = [
+ "value-bag-serde1",
+ "value-bag-sval2",
+]
+
+[[package]]
+name = "value-bag-serde1"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccacf50c5cb077a9abb723c5bcb5e0754c1a433f1e1de89edc328e2760b6328b"
+dependencies = [
+ "erased-serde",
+ "serde",
+ "serde_fmt",
+]
+
+[[package]]
+name = "value-bag-sval2"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1785bae486022dfb9703915d42287dcb284c1ee37bd1080eeba78cc04721285b"
+dependencies = [
+ "sval",
+ "sval_buffer",
+ "sval_dynamic",
+ "sval_fmt",
+ "sval_json",
+ "sval_ref",
+ "sval_serde",
+]
 
 [[package]]
 name = "version_check"

--- a/compiler/hash-ast-expand/src/attr.rs
+++ b/compiler/hash-ast-expand/src/attr.rs
@@ -71,6 +71,8 @@ impl AstExpander<'_> {
         if should_dump {
             let mode = self.settings.ast_settings.dump_mode;
             let character_set = self.settings.character_set;
+
+            // @@Messaging: provide a format for the AST to be dumped in!
             log::info!("{}", AstDump::new(subject, mode, character_set));
         }
     }

--- a/compiler/hash-codegen-llvm/src/lib.rs
+++ b/compiler/hash-codegen-llvm/src/lib.rs
@@ -173,6 +173,7 @@ impl<'b, 'm> LLVMBackend<'b> {
                 .write_to_file(module, FileType::Assembly, &asm_path)
                 .map_err(|err| CodeGenError::ModuleWriteFailed { reason: err })?;
 
+            // @@Messaging
             log::info!("wrote assembly file to `{}`", asm_path.to_string_lossy());
         }
 
@@ -270,6 +271,7 @@ impl<'b, 'm> LLVMBackend<'b> {
 
             // Check if we should dump the generated LLVM IR
             if instance.borrow().has_attr(attrs::DUMP_LLVM_IR) {
+                // @@Messaging
                 log::info!(
                     "LLVM IR for function {}\n{}",
                     body.meta.name(),

--- a/compiler/hash-driver/src/driver.rs
+++ b/compiler/hash-driver/src/driver.rs
@@ -83,7 +83,9 @@ impl<I: CompilerInterface> Driver<I> {
     /// Function to report the collected metrics on the stages within the
     /// compiler.
     fn report_metrics(&self) {
-        log::info!("compiler pipeline metrics:\n{}", AggregateMetricReporter::new(&self.metrics));
+        let metrics = &self.metrics;
+        let message = CompilerOutputMessage::Metrics(metrics);
+        log::info!(message; "compiler pipeline metrics:\n{}", AggregateMetricReporter::new(metrics));
     }
 
     fn run_stage(&mut self, entry_point: SourceId, index: usize) -> CompilerResult<()> {
@@ -233,6 +235,7 @@ impl<I: CompilerInterface> Driver<I> {
         // when it was instructed to terminate before all of the stages. For example, if
         // the compiler is just checking the source, then it will terminate early.
         if err_count != 0 || warn_count != 0 {
+            // @@Messaging
             log::info!(
                 "compiler terminated with {err_count} error(s), and {warn_count} warning(s)."
             );

--- a/compiler/hash-driver/src/lib.rs
+++ b/compiler/hash-driver/src/lib.rs
@@ -9,7 +9,6 @@
 //! keeping the crate dependency graph clean.
 #![feature(let_chains, thread_id_value)]
 pub mod driver;
-mod metrics;
 
 use std::collections::HashSet;
 

--- a/compiler/hash-error-codes/src/lib.rs
+++ b/compiler/hash-error-codes/src/lib.rs
@@ -2,10 +2,14 @@
 
 macro_rules! error_codes {
     ($($name:ident = $code:expr),* $(,)?) => (
-        use hash_utils::schemars::{self, JsonSchema};
+        use hash_utils::{
+            schemars::{self, JsonSchema},
+            serde::{self, Serialize},
+        };
 
         /// Error code macro is used to generate the [HashErrorCode] macro.
-        #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, JsonSchema)]
+        #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, JsonSchema, Serialize)]
+        #[serde(crate = "self::serde")]
         #[allow(dead_code)]
         pub enum HashErrorCode {
             $($name, )*

--- a/compiler/hash-lower/src/ctx.rs
+++ b/compiler/hash-lower/src/ctx.rs
@@ -133,6 +133,8 @@ impl<'ir> BuilderCtx<'ir> {
         let writer_config = LayoutWriterConfig::from_character_set(self.settings.character_set);
 
         // Print the layout
+        //
+        // @@Messaging: provide a format for the layout to be dumped in!
         log::info!(
             "{}",
             LayoutWriter::new_with_config(

--- a/compiler/hash-lower/src/lib.rs
+++ b/compiler/hash-lower/src/lib.rs
@@ -255,6 +255,8 @@ impl<Ctx: LoweringCtxQuery> CompilerStage<Ctx> for IrOptimiser {
             return;
         }
 
+        // @@Messaging: provide a format for the IR to be dumped in (which is public).
+
         if settings.lowering_settings.dump_mode == IrDumpMode::Graph {
             log::info!(
                 "dumping IR in graphviz format:\n{}",

--- a/compiler/hash-messaging/src/lib.rs
+++ b/compiler/hash-messaging/src/lib.rs
@@ -3,9 +3,13 @@
 pub mod listener;
 pub mod stream;
 
-use hash_pipeline::settings::CompilerSettings;
+use hash_pipeline::{metrics::Metrics, settings::CompilerSettings};
 use hash_reporting::report::Report;
-use hash_utils::schemars::{self, JsonSchema};
+use hash_utils::{
+    log::kv,
+    schemars::{self, JsonSchema},
+    serde::{self, Serialize},
+};
 
 /// The [CompilerMessagingFormat] specifies the message mode that the compiler
 /// will use to to emit and receive messages.
@@ -23,25 +27,39 @@ pub enum CompilerMessagingFormat {
     Normal,
 }
 
-#[derive(Debug, Clone, JsonSchema)]
-pub enum CompilerOutputMessage {
+#[derive(Clone, JsonSchema, Serialize)]
+#[serde(crate = "self::serde", rename_all = "camelCase")]
+pub enum CompilerOutputMessage<'a> {
     /// A message that is emitted by the compiler, this is any diagnostic.
-    Report(Report),
+    Report(&'a Report),
 
     /// The configuration of the compiler.
-    Settings(CompilerSettings),
+    Settings(&'a CompilerSettings),
+
+    /// Metrics that the compiler collected.
+    Metrics(&'a Metrics),
+
+    /// The current "linker line" that the compiler is using for
+    /// a particular workspace.
+    LinkerLine(&'a str),
 }
 
-#[derive(Debug, Clone, JsonSchema)]
+// ##Hack: needed for using `log::info!(...)` with `CompilerOutputMessage`.
+impl kv::ToValue for CompilerOutputMessage<'_> {
+    fn to_value(&self) -> kv::Value<'_> {
+        kv::Value::from_serde(self)
+    }
+}
+
+/// Any messages that the compiler can accept as an input.
+#[derive(Clone, JsonSchema)]
 pub enum CompilerInputMessage {}
 
-///
-///
 /// This is purely a utility struct to help with the JSON schema generation.
-#[derive(Debug, Clone, JsonSchema)]
-pub enum CompilerMessage {
+#[derive(Clone, JsonSchema)]
+pub enum CompilerMessage<'a> {
     /// A message that is emitted by the compiler, this is any diagnostic.
-    Output(CompilerOutputMessage),
+    Output(CompilerOutputMessage<'a>),
 
     /// A message that is sent to the compiler, this is any request.
     Input(CompilerInputMessage),

--- a/compiler/hash-messaging/src/lib.rs
+++ b/compiler/hash-messaging/src/lib.rs
@@ -11,22 +11,6 @@ use hash_utils::{
     serde::{self, Serialize},
 };
 
-/// The [CompilerMessagingFormat] specifies the message mode that the compiler
-/// will use to to emit and receive messages.
-#[derive(Debug, Clone)]
-pub enum CompilerMessagingFormat {
-    /// All messages that are emitted to and from the compiler will be in JSON
-    /// format according to the schema that represents [CompilerMessage].
-    Json,
-
-    /// Normal mode is the classic emission of messages as the compiler would
-    /// normally do, i.e. calling [fmt::Display] on provided [Report]s.
-    ///
-    /// @@Note: do we support listening to messages in this mode - this doesn't
-    /// really make sense?
-    Normal,
-}
-
 #[derive(Clone, JsonSchema, Serialize)]
 #[serde(crate = "self::serde", rename_all = "camelCase")]
 pub enum CompilerOutputMessage<'a> {

--- a/compiler/hash-pipeline/src/lib.rs
+++ b/compiler/hash-pipeline/src/lib.rs
@@ -4,5 +4,6 @@
 pub mod error;
 pub mod fs;
 pub mod interface;
+pub mod metrics;
 pub mod settings;
 pub mod workspace;

--- a/compiler/hash-pipeline/src/settings.rs
+++ b/compiler/hash-pipeline/src/settings.rs
@@ -13,6 +13,7 @@ use hash_ast_utils::dump::AstDumpMode;
 use hash_target::{HasTarget, Target, HOST_TARGET_TRIPLE};
 use hash_utils::{
     clap::{Args, Parser, ValueEnum},
+    logging::CompilerMessagingFormat,
     schemars::{self, JsonSchema},
     serde::{self, Deserialize, Serialize},
     tree_writing::CharacterSet,
@@ -68,6 +69,12 @@ pub struct CompilerSettings {
     #[arg(long = "timings", default_value_t = false)]
     #[serde(default)]
     pub show_timings: bool,
+
+    /// The format to use when outputting information about compilation, either
+    /// in JSON format or in the normal format.
+    #[arg(long, default_value_t = CompilerMessagingFormat::Normal)]
+    #[serde(default)]
+    pub messaging_format: CompilerMessagingFormat,
 
     /// Whether to output of each stage result.
     #[arg(long, default_value_t = false)]
@@ -362,6 +369,7 @@ impl Default for CompilerSettings {
             entry_point: None,
             output_directory: None,
             output_stage_results: false,
+            messaging_format: CompilerMessagingFormat::Normal,
             show_timings: false,
             skip_prelude: false,
             prelude_is_quiet: false,

--- a/compiler/hash-pipeline/src/workspace.rs
+++ b/compiler/hash-pipeline/src/workspace.rs
@@ -310,6 +310,7 @@ impl Workspace {
     /// Utility function used by AST-like stages in order to print the
     /// current [NodeMap].
     pub fn print_sources(&self, mode: AstDumpMode, character_set: CharacterSet) {
+        // @@Messaging: Provide a format for sending the AST as an output.
         log::info!("{}", WorkspaceAstDump::new(self, mode, character_set));
     }
 }

--- a/compiler/hash-reporting/src/report.rs
+++ b/compiler/hash-reporting/src/report.rs
@@ -9,6 +9,7 @@ use hash_source::{
 use hash_utils::{
     highlight::{highlight, Colour, Modifier},
     schemars::{self, JsonSchema},
+    serde::{self, Serialize},
 };
 
 /// A data type representing a comment/message on a specific span in a code
@@ -24,7 +25,8 @@ pub struct ReportCodeBlockInfo {
 
 /// Enumeration describing the kind of [Report]; either being a warning, info or
 /// an error.
-#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, JsonSchema)]
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, JsonSchema, Serialize)]
+#[serde(crate = "self::serde")]
 pub enum ReportKind {
     /// The report is an error.
     Error,
@@ -66,7 +68,8 @@ impl fmt::Display for ReportKind {
 
 /// The kind of [ReportNote], this is primarily used for rendering the label of
 /// the [ReportNote].
-#[derive(Debug, Clone, PartialEq, Eq, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, JsonSchema, Serialize)]
+#[serde(crate = "self::serde")]
 pub enum ReportNoteKind {
     /// A help message or a suggestion.
     Help,
@@ -106,9 +109,13 @@ impl fmt::Display for ReportNoteKind {
 
 /// Data type representing a report note which consists of a label and the
 /// message.
-#[derive(Debug, Clone, JsonSchema)]
+#[derive(Debug, Clone, JsonSchema, Serialize)]
+#[serde(crate = "self::serde")]
 pub struct ReportNote {
+    /// The severity of the note.
     pub label: ReportNoteKind,
+
+    /// The message associated with the note.
     pub message: String,
 }
 
@@ -121,11 +128,18 @@ impl ReportNote {
 /// Data structure representing an associated block of code with a report. The
 /// type contains the span of the block, the message associated with a block and
 /// optional [ReportCodeBlockInfo] which adds a message pointed to a code item.
-#[derive(Debug, Clone, JsonSchema)]
+#[derive(Debug, Clone, JsonSchema, Serialize)]
+#[serde(crate = "self::serde")]
 pub struct ReportCodeBlock {
+    /// The span of the code block.
     pub span: Span,
+
+    /// The message associated with the code block.
     pub code_message: String,
+
+    /// Internal information for formatting the report.
     #[schemars(skip)]
+    #[serde(skip)]
     pub(crate) info: OnceCell<ReportCodeBlockInfo>,
 }
 
@@ -142,9 +156,13 @@ impl ReportCodeBlock {
 
 /// Enumeration representing types of components of a [Report]. A [Report] can
 /// be made of either [ReportCodeBlock]s or [ReportNote]s.
-#[derive(Debug, Clone, JsonSchema)]
+#[derive(Debug, Clone, JsonSchema, Serialize)]
+#[serde(crate = "self::serde")]
 pub enum ReportElement {
+    /// A note with code block.
     CodeBlock(ReportCodeBlock),
+
+    /// A note on a report, without an associated [Span].
     Note(ReportNote),
 }
 
@@ -172,7 +190,8 @@ pub macro info {
 /// The report data type represents the entire report which might contain many
 /// [ReportElement]s. The report also contains a general [ReportKind] and a
 /// general message.
-#[derive(Debug, Clone, schemars::JsonSchema)]
+#[derive(Debug, Clone, Serialize, schemars::JsonSchema)]
+#[serde(crate = "self::serde")]
 pub struct Report {
     /// The general kind of the report.
     pub kind: ReportKind,

--- a/compiler/hash-source/src/lib.rs
+++ b/compiler/hash-source/src/lib.rs
@@ -20,6 +20,7 @@ use hash_utils::{
     parking_lot::RwLock,
     path::adjust_canonicalisation,
     schemars::{self, JsonSchema},
+    serde::{self, Serialize},
 };
 use location::{ByteRange, LineRanges, RowColRange, SpannedSource};
 use once_cell::sync::{Lazy, OnceCell};
@@ -59,7 +60,8 @@ define_index_type! {
 /// The first 31 bits are used to store the actual value of the
 /// [SourceId]. The last bit is used to denote whether this is a
 /// module or an interactive block.
-#[derive(Clone, Copy, Hash, PartialEq, Eq, JsonSchema)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, JsonSchema, Serialize)]
+#[serde(crate = "self::serde")]
 pub struct SourceId {
     /// The raw value of the identifier.
     _raw: u32,

--- a/compiler/hash-source/src/location.rs
+++ b/compiler/hash-source/src/location.rs
@@ -9,6 +9,7 @@ use hash_utils::{
     derive_more::Constructor,
     range_map::RangeMap,
     schemars::{self, JsonSchema},
+    serde::{self, Serialize},
 };
 use line_span::LineSpanExt;
 
@@ -18,7 +19,8 @@ use crate::{SourceId, SourceMapUtils};
 /// The range itself is considered to be inclusive, so ranges such as `0:0`
 /// would include the first byte of the source, and ranges like `0:1` would
 /// include the first two bytes of the source.
-#[derive(Debug, Eq, Hash, Clone, Copy, PartialEq, JsonSchema)]
+#[derive(Debug, Eq, Hash, Clone, Copy, PartialEq, JsonSchema, Serialize)]
+#[serde(crate = "self::serde")]
 pub struct ByteRange(u32, u32);
 
 impl ByteRange {
@@ -105,7 +107,8 @@ impl fmt::Display for ByteRange {
 /// `hash_reporting` crate. Ideally, data structures that need to store
 /// locations of various items should use [ByteRange] and then convert into
 /// [Span]s.
-#[derive(Debug, Clone, Copy, Constructor, PartialEq, Eq, Hash, JsonSchema)]
+#[derive(Debug, Clone, Copy, Constructor, PartialEq, Eq, Hash, JsonSchema, Serialize)]
+#[serde(crate = "self::serde")]
 pub struct Span {
     /// The associated [ByteRange] with the [Span].
     pub range: ByteRange,

--- a/compiler/hash-tir/src/context.rs
+++ b/compiler/hash-tir/src/context.rs
@@ -615,7 +615,7 @@ impl fmt::Display for Context {
                 for line in result.lines() {
                     writeln!(f, "  {line}")?;
                 }
-                Ok(())
+                Ok::<(), fmt::Error>(())
             })?;
         }
         Ok(())

--- a/compiler/hash-tir/src/dump.rs
+++ b/compiler/hash-tir/src/dump.rs
@@ -1,5 +1,7 @@
 use hash_utils::log;
 
+/// Function to emit a TIR dump, this is useful for debugging purposes.
 pub fn dump_tir(value: impl ToString) {
+    // @@Messaging: provide a format for the TIR to be dumped in (which is public).
     log::info!("TIR dump:\n{}", value.to_string());
 }

--- a/compiler/hash-utils/Cargo.toml
+++ b/compiler/hash-utils/Cargo.toml
@@ -19,18 +19,19 @@ fixedbitset = "0.4.2"
 fnv = "1.0.7"
 fxhash = "0.2.1"
 index_vec = "0.1.3"
-indexmap = "1.9"
+indexmap = { version = "1.9", features = ["serde-1"] } 
 itertools = "0.10.5"
 lazy_static = "1.4.0"
 libc = "0.2"
-log = "0.4"
+log = { version = "0.4", features = ["kv_unstable", "kv_serde"] }
 num-bigint = "0.4"
 num-traits = "0.2"
 once_cell = "1.17"
 parking_lot = "0.12"
 rayon = "1.5.0"
-schemars = "0.8.16"
+schemars = { version = "0.8.16", features = ["indexmap1"] }
 serde = { version = "1.0.202", features = ["derive"] }
+serde_json = "1.0.117"
 smallvec = "1.11.0"
 stacker = "0.1.15"
 thin-vec = "0.2.10"

--- a/compiler/hash-utils/src/logging.rs
+++ b/compiler/hash-utils/src/logging.rs
@@ -1,33 +1,79 @@
 //! Hash compiler logging utilities. This defines a simple logger with a
 //! style which should be used across the compiler to log and print messages.
 
-use std::io::Write;
+use std::{
+    collections::BTreeMap,
+    io::{self, Write},
+};
 
 use once_cell::sync::OnceCell;
 
 use crate::{
     highlight::{highlight, Colour, Modifier},
-    log::{Level, Log, Metadata, Record},
+    log::{
+        kv::{Error, Key, Value, Visitor},
+        Level, Log, Metadata, Record,
+    },
     stream::CompilerOutputStream,
     stream_writeln,
 };
 
+#[derive(Default, PartialEq, Eq, Clone, Copy, Debug)]
+pub enum LoggingFormat {
+    /// Use the default logging format.
+    #[default]
+    Default,
+
+    /// Use the JSON logging format.
+    Json,
+}
+
 /// The compiler logger that is used by the compiler for `log!` statements.
 ///
 /// This is also used to emit structured messages to the user.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct CompilerLogger {
     /// The output stream that the logger will write to.
     pub output_stream: OnceCell<CompilerOutputStream>,
 
     /// The error stream that the logger will write to.
     pub error_stream: OnceCell<CompilerOutputStream>,
+
+    /// The format to use when logging information.
+    logging_format: OnceCell<LoggingFormat>,
 }
 
 impl CompilerLogger {
     /// Create a new compiler logger.
     pub const fn new() -> Self {
-        Self { output_stream: OnceCell::new(), error_stream: OnceCell::new() }
+        Self {
+            output_stream: OnceCell::new(),
+            error_stream: OnceCell::new(),
+            logging_format: OnceCell::new(),
+        }
+    }
+
+    /// Create a new [CompilerLogger] with a JSON logging format.
+    pub fn with_json_format(&self) {
+        self.logging_format.set(LoggingFormat::Json).unwrap();
+    }
+
+    /// Log the given record in the JSON format.
+    fn log_json(&self, out: &mut dyn Write, record: &Record, _: String) -> io::Result<()> {
+        let kvs = record.key_values();
+        let mut visitor = LoggerVisitor::default();
+        kvs.visit(&mut visitor).unwrap();
+
+        writeln!(out, "{}", serde_json::to_string(&visitor.0).unwrap())
+    }
+
+    fn log_default(&self, out: &mut dyn Write, record: &Record, level_prefix: String) {
+        stream_writeln!(
+            out,
+            "{level_prefix}: {message}",
+            level_prefix = level_prefix,
+            message = record.args()
+        );
     }
 }
 
@@ -37,30 +83,41 @@ impl Log for CompilerLogger {
     }
 
     fn log(&self, record: &Record) {
-        if self.enabled(record.metadata()) {
-            // Custom colour formatting for the log level
-            let level_prefix = match record.level() {
-                Level::Error => highlight(Colour::Red | Modifier::Bold, "error"),
-                Level::Warn => highlight(Colour::Yellow | Modifier::Bold, "warn"),
-                Level::Info => highlight(Colour::Blue | Modifier::Bold, "info"),
-                Level::Debug => highlight(Colour::Blue | Modifier::Bold, "debug"),
-                Level::Trace => highlight(Colour::Magenta | Modifier::Bold, "trace"),
-            };
+        if !self.enabled(record.metadata()) {
+            return;
+        }
 
-            let mut out = if record.level() == Level::Error {
-                self.error_stream.get().unwrap().clone()
-            } else {
-                self.output_stream.get().unwrap().clone()
-            };
+        // Custom colour formatting for the log level
+        let level_prefix = match record.level() {
+            Level::Error => highlight(Colour::Red | Modifier::Bold, "error"),
+            Level::Warn => highlight(Colour::Yellow | Modifier::Bold, "warn"),
+            Level::Info => highlight(Colour::Blue | Modifier::Bold, "info"),
+            Level::Debug => highlight(Colour::Blue | Modifier::Bold, "debug"),
+            Level::Trace => highlight(Colour::Magenta | Modifier::Bold, "trace"),
+        };
 
-            stream_writeln!(
-                out,
-                "{level_prefix}: {message}",
-                level_prefix = level_prefix,
-                message = record.args()
-            );
+        let mut out = if record.level() == Level::Error {
+            self.error_stream.get().unwrap().clone()
+        } else {
+            self.output_stream.get().unwrap().clone()
+        };
+
+        if *self.logging_format.get().unwrap() == LoggingFormat::Json {
+            self.log_json(&mut out, record, level_prefix).unwrap();
+        } else {
+            self.log_default(&mut out, record, level_prefix);
         }
     }
 
     fn flush(&self) {}
+}
+
+#[derive(Default)]
+struct LoggerVisitor<'l>(BTreeMap<Key<'l>, Value<'l>>);
+
+impl<'l> Visitor<'l> for LoggerVisitor<'l> {
+    fn visit_pair(&mut self, key: Key<'l>, value: Value<'l>) -> Result<(), Error> {
+        self.0.insert(key, value);
+        Ok(())
+    }
 }

--- a/compiler/hash-utils/src/profiling.rs
+++ b/compiler/hash-utils/src/profiling.rs
@@ -10,8 +10,10 @@ use std::{
 use derive_more::Constructor;
 use indexmap::IndexMap;
 use log::{log_enabled, Level};
+use schemars::JsonSchema;
+use serde::Serialize;
 
-#[derive(Debug, Clone, Copy, Constructor)]
+#[derive(Debug, Clone, Copy, Constructor, Serialize, JsonSchema)]
 pub struct MetricEntry {
     /// The time taken for the operation to complete.
     pub duration: Duration,
@@ -62,7 +64,7 @@ impl AddAssign for MetricEntry {
 }
 
 /// A [StageMetrics] is a collection of timings for each section of a stage.
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, Serialize, JsonSchema)]
 pub struct StageMetrics {
     /// The collected timings for each section of the stage.
     pub metrics: IndexMap<&'static str, MetricEntry>,
@@ -73,6 +75,7 @@ pub struct StageMetrics {
     /// useless results in the sense that stage is capturing memory usage
     /// which it hasn't directly caused. In this case, we don't want to emit
     /// RSS metrics for these stages.
+    #[serde(skip)]
     pub report_rss: bool,
 }
 

--- a/compiler/hash/src/main.rs
+++ b/compiler/hash/src/main.rs
@@ -30,6 +30,11 @@ fn main() {
 
     let settings = utils::emit_on_fatal_error(error_stream(), CompilerSettings::from_cli);
 
+    // @@TODO: find a neater way of setting this, as in what if initialising the
+    // `settings` fails and we need to actually output in the `json` format
+    // right from the start.
+    COMPILER_LOGGER.set_messaging_format(settings.messaging_format);
+
     // if debug is specified, we want to log everything that is debug level...
     if settings.debug {
         log::set_max_level(log::LevelFilter::Debug);

--- a/tests/runner.rs
+++ b/tests/runner.rs
@@ -40,7 +40,10 @@ use hash_testing_internal::{
 };
 use hash_testing_macros::generate_tests;
 use hash_utils::{
-    log, logging::CompilerLogger, path::adjust_canonicalisation, stream::CompilerOutputStream,
+    log,
+    logging::{CompilerLogger, CompilerMessagingFormat},
+    path::adjust_canonicalisation,
+    stream::CompilerOutputStream,
 };
 use regex::Regex;
 
@@ -299,6 +302,7 @@ fn handle_test(test: TestingInput) {
 
     COMPILER_LOGGER.error_stream.set(error_stream()).unwrap();
     COMPILER_LOGGER.output_stream.set(output_stream()).unwrap();
+    COMPILER_LOGGER.set_messaging_format(CompilerMessagingFormat::Normal);
     log::set_logger(&COMPILER_LOGGER).unwrap_or_else(|_| panic!("couldn't initiate logger"));
     log::set_max_level(log::LevelFilter::Info);
 


### PR DESCRIPTION
- **pipeline: move `metrics` implementation out of `hash-driver`**
- **logging: add JSON output format**
- **driver: use new `Metrics` type for profiling**
- **messaging: use `CompilerOutputMessage` for `log::info!`s**
- **driver: add configuration for messaging format**
