### PR TITLE
Fix string comparison code generation

### DIFF
--- a/compiler/hash-codegen/src/lower/rvalue.rs
+++ b/compiler/hash-codegen/src/lower/rvalue.rs
@@ -156,7 +156,7 @@ impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
                     return;
                 }
 
-                // Optimisation for immediates, we can use llvm.memset.p0i8.* to
+                // Optimisation for immediate, we can use llvm.memset.p0i8.* to
                 // initialise the memory.
                 if let OperandValue::Immediate(val) = op.value {
                     let zero = builder.const_usize(0);

--- a/compiler/hash-lower/src/build/ty.rs
+++ b/compiler/hash-lower/src/build/ty.rs
@@ -11,7 +11,7 @@ use hash_const_eval::{
     Const, ConstKind,
 };
 use hash_ir::{
-    ir::Scalar,
+    ir::{BodyInfo, Scalar},
     ty::{ReprTy, ReprTyId},
 };
 use hash_storage::store::{statics::StoreId, TrivialSequenceStoreKey};
@@ -182,6 +182,11 @@ impl<'tcx> BodyBuilder<'tcx> {
             }
             _ => FnCallTermKind::Call,
         }
+    }
+
+    /// Get a [BodyInfo] from the current [BodyBuilder] state.
+    pub fn body_info(&self) -> BodyInfo<'_> {
+        BodyInfo { locals: &self.locals, projections: &self.projections }
     }
 
     /// Convert the [LitPat] into a [Const] and return the value of the constant

--- a/compiler/hash-reporting/src/report.rs
+++ b/compiler/hash-reporting/src/report.rs
@@ -255,7 +255,7 @@ impl Report {
         )))
     }
 
-    /// Add a [`ReportNoteKind::Empty`] note with the given message to the
+    /// Add a [`ReportNoteKind::Raw`] note with the given message to the
     /// [Report].
     pub fn add_empty(&mut self, message: impl ToString) -> &mut Self {
         self.add_element(ReportElement::Note(ReportNote::new(
@@ -273,7 +273,7 @@ impl Report {
         )))
     }
 
-    /// Add a code block at the given location to the [Report].
+    /// Add a code block at the given [Span] to the [Report].
     pub fn add_span(&mut self, location: Span) -> &mut Self {
         self.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(location, "")))
     }

--- a/compiler/hash-repr/src/ty.rs
+++ b/compiler/hash-repr/src/ty.rs
@@ -345,7 +345,7 @@ impl ReprTy {
                 | Self::Bool)
 
             // A reference to `str` is non-scalar since it is a fat pointer.
-            || matches!(self, Self::Ref(element, _, RefKind::Normal | RefKind::Raw) if element.is_str())
+            || matches!(self, Self::Ref(element, _, RefKind::Normal | RefKind::Raw) if !element.is_str())
     }
 
     /// Check if the type is an array.

--- a/tests/cases/lowering/strings_in_matches.stdout
+++ b/tests/cases/lowering/strings_in_matches.stdout
@@ -24,33 +24,39 @@ main := () -> () {
     }
 
     bb1 {
-        _3 = Eq(const "Alex", _1);
-        switch(_3) [false -> bb3, otherwise -> bb2];
+        _2 = str_eq(_1, const "Alex") -> bb2;
     }
 
     bb2 {
-        _0 = println(const "Hi Alex!") -> bb7;
+        switch(_2) [false -> bb4, otherwise -> bb3];
     }
 
     bb3 {
-        _2 = Eq(const "John", _1);
-        switch(_2) [false -> bb5, otherwise -> bb4];
+        _0 = println(const "Hi Alex!") -> bb9;
     }
 
     bb4 {
-        _0 = println(const "Hi John!") -> bb7;
+        _3 = str_eq(_1, const "John") -> bb5;
     }
 
     bb5 {
-        _4 = _1;
-        _5 = print(const "Hi! It's nice to meet you ") -> bb6;
+        switch(_3) [false -> bb7, otherwise -> bb6];
     }
 
     bb6 {
-        _0 = println(_4) -> bb7;
+        _0 = println(const "Hi John!") -> bb9;
     }
 
     bb7 {
+        _4 = _1;
+        _5 = print(const "Hi! It's nice to meet you ") -> bb8;
+    }
+
+    bb8 {
+        _0 = println(_4) -> bb9;
+    }
+
+    bb9 {
         return;
     }
 }


### PR DESCRIPTION
## Description

This patch fixes a bug with code generation not generating the required code for 
string comparisons in some cases. This resulted into odd behaviour when writing 
code like:

```rust
foo := () => "hello"

main := () => {
  if "hello" == foo() {
     println("yes!")
  }
}
```

The existing implementation tried to compare by `ptr` which inevitably failed
due to the `str`s having different base addresses.

This now properly invokes `str_eq` in all string comparison cases, and ensures 
that string comparisons behave as expected.

## Commits 
- **lower/reporting: fix comment typos**
- **reporting: convert `note_on_span!` into function**
- **repr: fix invalid `ReprTy::is_scalar` implementation**
- **lower: correctly handle string comparisons**
- **lower: re-factor `non_scalar_compare` to use `build_non_scalar_binary_compare`**
- **tests: re-generate `strings_in_matches` stdout**
