### PR TITLE
lower: fix Graphviz output and settings

### DIFF
--- a/compiler/hash-ir-utils/src/graphviz.rs
+++ b/compiler/hash-ir-utils/src/graphviz.rs
@@ -240,12 +240,17 @@ struct IrBlockWriter<'ir> {
 impl fmt::Display for IrBlockWriter<'_> {
     fn fmt(&self, w: &mut fmt::Formatter<'_>) -> fmt::Result {
         // Now we write the first row, which is the basic block header
-        let block_id = format!("{:?}", self.id.raw());
+        let prefix = if let Some(index) = self.options.use_subgraph {
+            format!("c{index}_")
+        } else {
+            "".to_string()
+        };
+        let id = format!("{prefix}{:?}", self.id);
 
         // First write the table, and the header of the table
         write!(
             w,
-            r#"  {block_id} [shape="none", label=<<table border="0" cellborder="1" cellspacing="0">"#
+            r#"  {id} [shape="none", label=<<table border="0" cellborder="1" cellspacing="0">"#
         )?;
 
         write!(

--- a/compiler/hash-lower/src/optimise/mod.rs
+++ b/compiler/hash-lower/src/optimise/mod.rs
@@ -54,6 +54,7 @@ impl<'ir> Optimiser<'ir> {
             passes: vec![
                 Box::new(simplify_graph::SimplifyGraphPass),
                 Box::new(cleanup_locals::CleanupLocalPass),
+                Box::new(simplify_graph::SimplifyGraphPass),
             ],
             metrics: CellStageMetrics::default(),
         }

--- a/compiler/hash-pipeline/src/settings.rs
+++ b/compiler/hash-pipeline/src/settings.rs
@@ -547,9 +547,9 @@ impl Default for LoweringSettings {
 
 impl MergeConfig for LoweringSettings {
     fn merge_config(&mut self, config: &Self) {
-        self.dump |= config.dump;
+        self.dump = config.dump;
         self.dump_mode = config.dump_mode;
-        self.checked_operations |= config.checked_operations;
+        self.checked_operations = config.checked_operations;
     }
 }
 

--- a/compiler/hash-pipeline/src/settings.rs
+++ b/compiler/hash-pipeline/src/settings.rs
@@ -183,7 +183,9 @@ impl MergeConfig for CompilerSettings {
 impl CompilerSettings {
     /// Create a new [CompilerSettings].
     pub fn new() -> Self {
-        Self::default()
+        let mut s = Self::default();
+        s.post_init();
+        s
     }
 
     /// Create a new [CompilerSettings] from the command-line arguments.
@@ -207,7 +209,17 @@ impl CompilerSettings {
             },
         )?;
 
+        settings.post_init();
         Ok(settings)
+    }
+
+    /// Run any post-init adjustments that must happen after the settings.
+    ///
+    /// Add some kind of utility to guarantee a `PostInit` trait that can be
+    /// implemented by the settings.
+    #[inline]
+    fn post_init(&mut self) {
+        self.apply_optimisation_level(self.optimisation_level);
     }
 
     /// Get the entry point filename from the [CompilerSettings]. If

--- a/tests/cases/lowering/early_returns.stdout
+++ b/tests/cases/lowering/early_returns.stdout
@@ -16,69 +16,61 @@ boo := (_1: i32, _2: i32) -> i32 {
 
     bb0 {
         _3 = Eq(_1, const 0_i32);
-        switch(_3) [false -> bb1, otherwise -> bb2];
+        switch(_3) [false -> bb3, otherwise -> bb1];
     }
 
     bb1 {
-        goto -> bb4;
+        _0 = const 1_i32;
+        goto -> bb2;
     }
 
     bb2 {
-        _0 = const 1_i32;
-        goto -> bb3;
-    }
-
-    bb3 {
         return;
     }
 
-    bb4 {
+    bb3 {
         _5 = Gt(_1, const 10_i32);
-        switch(_5) [false -> bb7, otherwise -> bb6];
+        switch(_5) [false -> bb5, otherwise -> bb4];
+    }
+
+    bb4 {
+        _4 = const true;
+        goto -> bb6;
     }
 
     bb5 {
-        goto -> bb11;
+        _6 = Gt(_2, const 10_i32);
+        _4 = _6;
+        goto -> bb6;
     }
 
     bb6 {
-        _4 = const true;
-        goto -> bb8;
+        switch(_4) [false -> bb9, otherwise -> bb7];
     }
 
     bb7 {
-        _6 = Gt(_2, const 10_i32);
-        _4 = _6;
+        _0 = const 2_i32;
         goto -> bb8;
     }
 
     bb8 {
-        switch(_4) [false -> bb5, otherwise -> bb9];
-    }
-
-    bb9 {
-        _0 = const 2_i32;
-        goto -> bb10;
-    }
-
-    bb10 {
         return;
     }
 
+    bb9 {
+        _7 = foo(_1) -> bb10;
+    }
+
+    bb10 {
+        _8 = foo(_2) -> bb11;
+    }
+
     bb11 {
-        _7 = foo(_1) -> bb12;
+        _9 = CheckedAdd(_7, _8);
+        assert((_9.1), false, "attempt to compute `_7 + _8`, which would overflow") -> bb12;
     }
 
     bb12 {
-        _8 = foo(_2) -> bb13;
-    }
-
-    bb13 {
-        _9 = CheckedAdd(_7, _8);
-        assert((_9.1), false, "attempt to compute `_7 + _8`, which would overflow") -> bb14;
-    }
-
-    bb14 {
         _0 = (_9.0);
         return;
     }
@@ -98,51 +90,43 @@ foo := (_1: i32) -> i32 {
 
     bb0 {
         _2 = Eq(_1, const 0_i32);
-        switch(_2) [false -> bb1, otherwise -> bb2];
+        switch(_2) [false -> bb3, otherwise -> bb1];
     }
 
     bb1 {
-        goto -> bb4;
+        _0 = const 3_i32;
+        goto -> bb2;
     }
 
     bb2 {
-        _0 = const 3_i32;
-        goto -> bb3;
+        return;
     }
 
     bb3 {
-        return;
+        _3 = Gt(_1, const 10_i32);
+        switch(_3) [false -> bb6, otherwise -> bb4];
     }
 
     bb4 {
-        _3 = Gt(_1, const 10_i32);
-        switch(_3) [false -> bb5, otherwise -> bb6];
+        _0 = const 4_i32;
+        goto -> bb5;
     }
 
     bb5 {
-        goto -> bb8;
-    }
-
-    bb6 {
-        _0 = const 4_i32;
-        goto -> bb7;
-    }
-
-    bb7 {
         return;
     }
 
-    bb8 {
+    bb6 {
         _5 = CheckedAdd(_1, const 1_i32);
-        assert((_5.1), false, "attempt to compute `_1 + const 1_i32`, which would overflow") -> bb9;
+        assert((_5.1), false, "attempt to compute `_1 + const 1_i32`, which would overflow") -> bb7;
     }
 
-    bb9 {
+    bb7 {
         _4 = (_5.0);
-        _0 = boo(_1, _4) -> bb10;
+        _0 = boo(_1, _4) -> bb8;
     }
 
-    bb10 {
+    bb8 {
         return;
     }
 }

--- a/tests/cases/lowering/nested_loops.stdout
+++ b/tests/cases/lowering/nested_loops.stdout
@@ -32,40 +32,32 @@ main := () -> () {
     }
 
     bb4 {
-        goto -> bb5;
+        _5 = CheckedAdd(_1, const 1_i32);
+        assert((_5.1), false, "attempt to compute `_1 + const 1_i32`, which would overflow") -> bb5;
     }
 
     bb5 {
-        _5 = CheckedAdd(_1, const 1_i32);
-        assert((_5.1), false, "attempt to compute `_1 + const 1_i32`, which would overflow") -> bb6;
+        _4 = (_5.0);
+        goto -> bb6;
     }
 
     bb6 {
-        _4 = (_5.0);
-        goto -> bb7;
+        _6 = LtEq(const 0_i32, _4);
+        switch(_6) [false -> bb8, otherwise -> bb7];
     }
 
     bb7 {
-        _6 = LtEq(const 0_i32, _4);
-        switch(_6) [false -> bb9, otherwise -> bb8];
+        _7 = LtEq(_4, const 3_i32);
+        switch(_7) [false -> bb8, otherwise -> bb6];
     }
 
     bb8 {
-        _7 = LtEq(_4, const 3_i32);
-        switch(_7) [false -> bb9, otherwise -> bb7];
+        switch(_4) [4_i32 -> bb1, otherwise -> bb9];
     }
 
     bb9 {
-        switch(_4) [4_i32 -> bb1, otherwise -> bb10];
-    }
-
-    bb10 {
         _8 = CheckedSub(_4, const 1_i32);
-        assert((_8.1), false, "attempt to compute `_4 - const 1_i32`, which would overflow") -> bb11;
-    }
-
-    bb11 {
-        goto -> bb7;
+        assert((_8.1), false, "attempt to compute `_4 - const 1_i32`, which would overflow") -> bb6;
     }
 }
 


### PR DESCRIPTION
## Description

This PR fixes a few issues with the lowering settings being propagated and with the graphviz
output format which unexpectedly changed the block ids.

Finally, the `SimplifyGraphPass` is now run before and after the `CleanupLocalPass` to ensure that now-empty blocks are also removed
after the lowering.

## Commits

- **pipeline: run post-init hooks after settings initialisation**
- **pipeline: `LoweringSettings` merge should inherit rhs values**
- **lower: fix graphviz block ids**
- **lower: run `SimplifyGraphPass` pre & post `CleanupLocalPass`**

