### PR TITLE
Upgrade dependencies, tooling, and fix handling of benign CLI exit messages 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
@@ -34,9 +34,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.15"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -49,43 +49,43 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.4"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.89"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
 
 [[package]]
 name = "arrayvec"
@@ -95,9 +95,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backtrace"
@@ -167,9 +167,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.21"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
+checksum = "27f657647bcff5394bf56c7317665bbf790a137a50eaaa5c6bfbb9e27a518f2d"
 dependencies = [
  "shlex",
 ]
@@ -209,9 +209,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.18"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0956a43b323ac1afaffc053ed5c4b7c1f1800bacd1683c353aabbb752515dd3"
+checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -219,9 +219,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.18"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d72166dd41634086d5803a47eb71ae740e61d84709c36f3c34110173db3961b"
+checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
 dependencies = [
  "anstream",
  "anstyle",
@@ -238,35 +238,35 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "const_format"
-version = "0.2.33"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c655d81ff1114fb0dcdea9225ea9f0cc712a6f8d189378e82bdf62a473a64b"
+checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
 dependencies = [
  "const_format_proc_macros",
 ]
 
 [[package]]
 name = "const_format_proc_macros"
-version = "0.2.33"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff1a44b93f47b1bac19a27932f5c591e43d1ba357ee4f61526c8a25603f0eb1"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -378,7 +378,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.77",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -417,19 +417,19 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
 
 [[package]]
 name = "fixedbitset"
@@ -467,9 +467,9 @@ dependencies = [
 
 [[package]]
 name = "generator"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb949699c3e4df3a183b1d2142cb24277057055ed23c68ed58894f76c517223"
+checksum = "cc6bd114ceda131d3b1d665eba35788690ad37f5916457286b32ab6fd3c438dd"
 dependencies = [
  "cfg-if",
  "libc",
@@ -480,9 +480,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "half"
@@ -1106,6 +1106,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
 name = "hashc"
 version = "0.1.0"
 dependencies = [
@@ -1176,12 +1182,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.5.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -1204,7 +1210,7 @@ source = "git+https://github.com/hash-org/inkwell.git?branch=master#f9e3a486c125
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1235,16 +1241,17 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1256,9 +1263,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
 
 [[package]]
 name = "line-span"
@@ -1326,7 +1333,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
 dependencies = [
  "cfg-if",
- "generator 0.8.3",
+ "generator 0.8.4",
  "scoped-tls",
  "tracing",
  "tracing-subscriber",
@@ -1384,7 +1391,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1438,18 +1445,18 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.4"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
+checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "oorandom"
@@ -1522,7 +1529,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1536,9 +1543,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "plotters"
@@ -1614,18 +1621,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "profiling"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d84d1d7a6ac92673717f9f6d1518374ef257669c24ebc5ac25d5033828be58"
+checksum = "afbdc74edc00b6f6a218ca6a5364d6226a259d4b8ea1af4a0ea063f27e179f4d"
 dependencies = [
  "profiling-procmacros",
  "tracy-client 0.17.4",
@@ -1633,19 +1640,19 @@ dependencies = [
 
 [[package]]
 name = "profiling-procmacros"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8021cf59c8ec9c432cfc2526ac6b8aa508ecaf29cd415f271b8406c1b851c3fd"
+checksum = "a65f2e60fbf1063868558d69c6beacf412dc755f9fc020f514b7955fc914fe30"
 dependencies = [
  "quote",
- "syn 2.0.77",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "psm"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa37f80ca58604976033fae9515a8a2989fc13797d953f7c04fb8fa36a11f205"
+checksum = "200b9ff220857e53e184257720a14553b2f4aa02577d2ed9842d45d4b9654810"
 dependencies = [
  "cc",
 ]
@@ -1702,23 +1709,23 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.4"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0884ad60e090bf1345b93da0a5de8923c93884cd03f40dfcfddd3b4bee661853"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -1732,13 +1739,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -1755,9 +1762,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "replace_with"
@@ -1782,9 +1789,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.37"
+version = "0.38.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
+checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
 dependencies = [
  "bitflags",
  "errno",
@@ -1795,9 +1802,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
 
 [[package]]
 name = "rusty-fork"
@@ -1848,7 +1855,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.77",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1871,22 +1878,22 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1897,7 +1904,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1911,9 +1918,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.128"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
 dependencies = [
  "itoa",
  "memchr",
@@ -1987,15 +1994,15 @@ dependencies = [
 
 [[package]]
 name = "sval"
-version = "2.13.1"
+version = "2.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf38d1fa2ce984086ea42fb856a9f374d94680a4f796831a7fc868d7f2af1b9"
+checksum = "f6dc0f9830c49db20e73273ffae9b5240f63c42e515af1da1fceefb69fceafd8"
 
 [[package]]
 name = "sval_buffer"
-version = "2.13.1"
+version = "2.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81682ff859964ca1d7cf3d3d0f9ec7204ea04c2c32acb8cc2cf68ecbd3127354"
+checksum = "429922f7ad43c0ef8fd7309e14d750e38899e32eb7e8da656ea169dd28ee212f"
 dependencies = [
  "sval",
  "sval_ref",
@@ -2003,18 +2010,18 @@ dependencies = [
 
 [[package]]
 name = "sval_dynamic"
-version = "2.13.1"
+version = "2.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a213b93bb4c6f4c9f9b17f2e740e077fd18746bbf7c80c72bbadcac68fa7ee4"
+checksum = "68f16ff5d839396c11a30019b659b0976348f3803db0626f736764c473b50ff4"
 dependencies = [
  "sval",
 ]
 
 [[package]]
 name = "sval_fmt"
-version = "2.13.1"
+version = "2.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6902c6d3fb52c89206fe0dc93546c0123f7d48b5997fd14e61c9e64ff0b63275"
+checksum = "c01c27a80b6151b0557f9ccbe89c11db571dc5f68113690c1e028d7e974bae94"
 dependencies = [
  "itoa",
  "ryu",
@@ -2023,9 +2030,9 @@ dependencies = [
 
 [[package]]
 name = "sval_json"
-version = "2.13.1"
+version = "2.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11a28041ea78cdc394b930ae6b897d36246dc240a29a6edf82d76562487fb0b4"
+checksum = "0deef63c70da622b2a8069d8600cf4b05396459e665862e7bdb290fd6cf3f155"
 dependencies = [
  "itoa",
  "ryu",
@@ -2034,9 +2041,9 @@ dependencies = [
 
 [[package]]
 name = "sval_nested"
-version = "2.13.1"
+version = "2.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "850346e4b0742a7f2fd2697d703ff80084d0b658f0f2e336d71b8a06abf9b68e"
+checksum = "a39ce5976ae1feb814c35d290cf7cf8cd4f045782fe1548d6bc32e21f6156e9f"
 dependencies = [
  "sval",
  "sval_buffer",
@@ -2045,18 +2052,18 @@ dependencies = [
 
 [[package]]
 name = "sval_ref"
-version = "2.13.1"
+version = "2.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824afd97a8919f28a35b0fdea979845cc2ae461a8a3aaa129455cb89c88bb77a"
+checksum = "bb7c6ee3751795a728bc9316a092023529ffea1783499afbc5c66f5fabebb1fa"
 dependencies = [
  "sval",
 ]
 
 [[package]]
 name = "sval_serde"
-version = "2.13.1"
+version = "2.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ada7520dd719ed672c786c7db7de4f5230f4d504b0821bd8305cd30ca442315"
+checksum = "2a5572d0321b68109a343634e3a5d576bf131b82180c6c442dee06349dfc652a"
 dependencies = [
  "serde",
  "sval",
@@ -2076,9 +2083,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2087,9 +2094,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.12.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -2117,22 +2124,22 @@ checksum = "a38c90d48152c236a3ab59271da4f4ae63d678c5d7ad6b7714d7cb9760be5e4b"
 
 [[package]]
 name = "thiserror"
-version = "1.0.64"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.64"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2182,16 +2189,16 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.7.0",
  "toml_datetime",
  "winnow",
 ]
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -2200,20 +2207,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
  "valuable",
@@ -2232,9 +2239,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -2267,7 +2274,7 @@ checksum = "746b078c6a09ebfd5594609049e07116735c304671eaab06ce749854d23435bc"
 dependencies = [
  "loom 0.7.2",
  "once_cell",
- "tracy-client-sys 0.24.1",
+ "tracy-client-sys 0.24.2",
 ]
 
 [[package]]
@@ -2281,11 +2288,12 @@ dependencies = [
 
 [[package]]
 name = "tracy-client-sys"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68613466112302fdbeabc5fa55f7d57462a0b247d5a6b7d7e09401fb471a144d"
+checksum = "3637e734239e12ab152cd269302500bd063f37624ee210cd04b4936ed671f3b1"
 dependencies = [
  "cc",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2307,9 +2315,9 @@ checksum = "0e13db2e0ccd5e14a544e8a246ba2312cd25223f616442d7f2cb0e3db614236e"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "unicode-linebreak"
@@ -2375,9 +2383,9 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "value-bag"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a84c137d37ab0142f0f2ddfe332651fdbf252e7b7dbb4e67b6c1f1b2e925101"
+checksum = "3ef4c4aa54d5d05a279399bfa921ec387b7aba77caf7a682ae8d86785b8fdad2"
 dependencies = [
  "value-bag-serde1",
  "value-bag-sval2",
@@ -2385,9 +2393,9 @@ dependencies = [
 
 [[package]]
 name = "value-bag-serde1"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccacf50c5cb077a9abb723c5bcb5e0754c1a433f1e1de89edc328e2760b6328b"
+checksum = "4bb773bd36fd59c7ca6e336c94454d9c66386416734817927ac93d81cb3c5b0b"
 dependencies = [
  "erased-serde",
  "serde",
@@ -2396,9 +2404,9 @@ dependencies = [
 
 [[package]]
 name = "value-bag-sval2"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1785bae486022dfb9703915d42287dcb284c1ee37bd1080eeba78cc04721285b"
+checksum = "53a916a702cac43a88694c97657d449775667bcd14b70419441d05b7fea4a83a"
 dependencies = [
  "sval",
  "sval_buffer",
@@ -2436,9 +2444,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2447,24 +2455,23 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.90",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2472,28 +2479,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.90",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
 
 [[package]]
 name = "web-sys"
-version = "0.3.70"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2589,7 +2596,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2600,7 +2607,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.90",
 ]
 
 [[package]]

--- a/compiler/hash-ast-utils/src/pretty/collection.rs
+++ b/compiler/hash-ast-utils/src/pretty/collection.rs
@@ -89,7 +89,7 @@ impl CollectionPrintingOptions {
     }
 }
 
-impl<'ast, T> AstPrettyPrinter<'ast, T>
+impl<T> AstPrettyPrinter<'_, T>
 where
     T: std::io::Write,
 {

--- a/compiler/hash-ast-utils/src/pretty/mod.rs
+++ b/compiler/hash-ast-utils/src/pretty/mod.rs
@@ -84,7 +84,7 @@ where
     }
 }
 
-impl<'ast, T> AstVisitorMutSelf for AstPrettyPrinter<'ast, T>
+impl<T> AstVisitorMutSelf for AstPrettyPrinter<'_, T>
 where
     T: std::io::Write,
 {

--- a/compiler/hash-ast-utils/src/pretty/tokens.rs
+++ b/compiler/hash-ast-utils/src/pretty/tokens.rs
@@ -5,7 +5,7 @@ use hash_token::{delimiter::Delimiter, Token, TokenKind};
 
 use super::{AstPrettyPrinter, FmtResult};
 
-impl<'ast, T> AstPrettyPrinter<'ast, T>
+impl<T> AstPrettyPrinter<'_, T>
 where
     T: std::io::Write,
 {

--- a/compiler/hash-ast-utils/src/tree.rs
+++ b/compiler/hash-ast-utils/src/tree.rs
@@ -417,7 +417,7 @@ impl AstVisitor for AstTreePrinter {
     ) -> Result<Self::RefTyRet, Self::Error> {
         let walk::RefTy { inner, mutability, .. } = walk::walk_ref_ty(self, node)?;
 
-        let label = if node.kind.as_ref().map_or(false, |t| *t.body() == ast::RefKind::Raw) {
+        let label = if node.kind.as_ref().is_some_and(|t| *t.body() == ast::RefKind::Raw) {
             "raw_ref"
         } else {
             "ref"

--- a/compiler/hash-attrs/src/attr.rs
+++ b/compiler/hash-attrs/src/attr.rs
@@ -232,7 +232,7 @@ impl AttrStore {
     /// Check whether a particular [AstNodeId] has a specific
     /// attribute.
     pub fn node_has_attr(&self, id: AstNodeId, attr: AttrId) -> bool {
-        self.0.borrow(id).map_or(false, |attrs| attrs.has_attr(attr))
+        self.0.borrow(id).is_some_and(|attrs| attrs.has_attr(attr))
     }
 
     /// Get an [Attr] by name, from a node.

--- a/compiler/hash-codegen-llvm/src/ctx.rs
+++ b/compiler/hash-codegen-llvm/src/ctx.rs
@@ -156,7 +156,7 @@ impl<'b, 'm> CodeGenCtx<'b, 'm> {
 }
 
 /// Implement the types for the [CodeGenCtx].
-impl<'b, 'm> BackendTypes for CodeGenCtx<'b, 'm> {
+impl<'m> BackendTypes for CodeGenCtx<'_, 'm> {
     type Value = llvm::values::AnyValueEnum<'m>;
 
     type Function = llvm::values::FunctionValue<'m>;

--- a/compiler/hash-codegen-llvm/src/lib.rs
+++ b/compiler/hash-codegen-llvm/src/lib.rs
@@ -78,7 +78,7 @@ pub struct LLVMBackend<'b> {
     metrics: &'b mut StageMetrics,
 }
 
-impl<'b> HasMutMetrics for LLVMBackend<'b> {
+impl HasMutMetrics for LLVMBackend<'_> {
     fn metrics(&mut self) -> &mut StageMetrics {
         self.metrics
     }

--- a/compiler/hash-codegen-llvm/src/translation/abi.rs
+++ b/compiler/hash-codegen-llvm/src/translation/abi.rs
@@ -24,7 +24,7 @@ use inkwell::{
 use super::{ty::ExtendedTyBuilderMethods, LLVMBuilder};
 use crate::{ctx::CodeGenCtx, misc::AttributeKind};
 
-impl<'b, 'm> AbiBuilderMethods<'b> for LLVMBuilder<'_, 'b, 'm> {
+impl<'b> AbiBuilderMethods<'b> for LLVMBuilder<'_, 'b, '_> {
     fn get_param(&mut self, index: usize) -> Self::Value {
         let func = self.basic_block().get_parent().unwrap();
         func.get_nth_param(index as u32).unwrap().into()

--- a/compiler/hash-codegen-llvm/src/translation/builder.rs
+++ b/compiler/hash-codegen-llvm/src/translation/builder.rs
@@ -59,7 +59,7 @@ pub fn instruction_from_any_value(value: AnyValueEnum<'_>) -> InstructionValue<'
     value.as_instruction_value().unwrap()
 }
 
-impl<'a, 'b, 'm> LLVMBuilder<'a, 'b, 'm> {
+impl<'m> LLVMBuilder<'_, '_, 'm> {
     /// Create a PHI node in the current block.
     fn phi(
         &mut self,
@@ -128,7 +128,7 @@ impl<'a, 'b, 'm> LLVMBuilder<'a, 'b, 'm> {
     }
 }
 
-impl<'a, 'b, 'm> BlockBuilderMethods<'a, 'b> for LLVMBuilder<'a, 'b, 'm> {
+impl<'a, 'b> BlockBuilderMethods<'a, 'b> for LLVMBuilder<'a, 'b, '_> {
     fn ctx(&self) -> &Self::CodegenCtx {
         self.ctx
     }

--- a/compiler/hash-codegen-llvm/src/translation/constants.rs
+++ b/compiler/hash-codegen-llvm/src/translation/constants.rs
@@ -17,7 +17,7 @@ use llvm_sys::core as llvm;
 
 use crate::ctx::CodeGenCtx;
 
-impl<'b, 'm> ConstValueBuilderMethods<'b> for CodeGenCtx<'b, 'm> {
+impl<'b> ConstValueBuilderMethods<'b> for CodeGenCtx<'b, '_> {
     fn const_undef(&self, ty: Self::Type) -> Self::Value {
         let ty: BasicTypeEnum = ty.try_into().unwrap();
         match ty {

--- a/compiler/hash-codegen-llvm/src/translation/debug_info.rs
+++ b/compiler/hash-codegen-llvm/src/translation/debug_info.rs
@@ -9,7 +9,7 @@ use hash_source::{identifier::Identifier, location::Span};
 
 use super::LLVMBuilder;
 
-impl<'b, 'm> DebugInfoBuilderMethods for LLVMBuilder<'_, 'b, 'm> {
+impl DebugInfoBuilderMethods for LLVMBuilder<'_, '_, '_> {
     fn create_debug_info_scope_for_fn(
         &self,
         _fn_abi: &FnAbi,

--- a/compiler/hash-codegen-llvm/src/translation/declare.rs
+++ b/compiler/hash-codegen-llvm/src/translation/declare.rs
@@ -10,7 +10,7 @@ use inkwell::{
 use super::abi::ExtendedFnAbiMethods;
 use crate::ctx::CodeGenCtx;
 
-impl<'b, 'm> CodeGenCtx<'b, 'm> {
+impl<'m> CodeGenCtx<'_, 'm> {
     /// Standard function to declare a C-like function. This should only be used
     /// for declaring FFI functions or various LLVM intrinsics.
     ///

--- a/compiler/hash-codegen-llvm/src/translation/intrinsics.rs
+++ b/compiler/hash-codegen-llvm/src/translation/intrinsics.rs
@@ -18,7 +18,7 @@ use inkwell::{
 
 use super::LLVMBuilder;
 
-impl<'b, 'm> LLVMBuilder<'_, 'b, 'm> {
+impl<'m> LLVMBuilder<'_, '_, 'm> {
     /// Call an intrinsic function with the specified arguments.
     pub(crate) fn call_intrinsic(
         &mut self,
@@ -319,7 +319,7 @@ impl<'b, 'm> LLVMBuilder<'_, 'b, 'm> {
     }
 }
 
-impl<'b, 'm> IntrinsicBuilderMethods<'b> for LLVMBuilder<'_, 'b, 'm> {
+impl<'b> IntrinsicBuilderMethods<'b> for LLVMBuilder<'_, 'b, '_> {
     fn codegen_intrinsic_call(
         &mut self,
         ty: ReprTyId,

--- a/compiler/hash-codegen-llvm/src/translation/layouts.rs
+++ b/compiler/hash-codegen-llvm/src/translation/layouts.rs
@@ -25,7 +25,7 @@ impl<'b> LayoutMethods<'b> for CodeGenCtx<'b, '_> {
     }
 }
 
-impl<'b, 'm> LayoutMethods<'b> for LLVMBuilder<'_, 'b, 'm> {
+impl<'b> LayoutMethods<'b> for LLVMBuilder<'_, 'b, '_> {
     fn backend_field_index(&self, info: TyInfo, index: usize) -> u64 {
         self.ctx.backend_field_index(info, index)
     }

--- a/compiler/hash-codegen-llvm/src/translation/misc.rs
+++ b/compiler/hash-codegen-llvm/src/translation/misc.rs
@@ -18,7 +18,7 @@ use inkwell::{
 use super::abi::ExtendedFnAbiMethods;
 use crate::ctx::CodeGenCtx;
 
-impl<'b, 'm> CodeGenCtx<'b, 'm> {
+impl<'m> CodeGenCtx<'_, 'm> {
     /// Generate code for a reference to a function or method item. The
     /// [Instance] specifies the function reference to generate, and any
     /// attributes that need to be applied to the function. If the function
@@ -61,7 +61,7 @@ impl<'b, 'm> CodeGenCtx<'b, 'm> {
     }
 }
 
-impl<'b, 'm> MiscBuilderMethods<'b> for CodeGenCtx<'b, 'm> {
+impl<'b> MiscBuilderMethods<'b> for CodeGenCtx<'b, '_> {
     fn get_fn(&self, instance: InstanceId) -> Self::Function {
         self.get_fn_or_create_ref(instance)
     }

--- a/compiler/hash-codegen-llvm/src/translation/statics.rs
+++ b/compiler/hash-codegen-llvm/src/translation/statics.rs
@@ -9,7 +9,7 @@ use inkwell::values::{AnyValue, AnyValueEnum, BasicValueEnum, GlobalValue, Unnam
 
 use crate::ctx::CodeGenCtx;
 
-impl<'b, 'm> CodeGenCtx<'b, 'm> {
+impl<'m> CodeGenCtx<'_, 'm> {
     // Define a global static variable within the current [LLVMModule]. This
     // function is only invoked if the static variable has not already been
     // defined.
@@ -35,7 +35,7 @@ impl<'b, 'm> CodeGenCtx<'b, 'm> {
     }
 }
 
-impl<'b, 'm> StaticMethods for CodeGenCtx<'b, 'm> {
+impl StaticMethods for CodeGenCtx<'_, '_> {
     fn static_addr_of(&self, cv: Self::Value, align: Alignment) -> Self::Value {
         // Check if we've already created the global
         if let Some(global) = self.global_consts.borrow().get(&cv) {

--- a/compiler/hash-codegen-llvm/src/translation/ty.rs
+++ b/compiler/hash-codegen-llvm/src/translation/ty.rs
@@ -45,7 +45,7 @@ pub fn convert_basic_ty_to_any(ty: BasicTypeEnum) -> AnyTypeEnum {
     }
 }
 
-impl<'b, 'm> CodeGenCtx<'b, 'm> {
+impl<'m> CodeGenCtx<'_, 'm> {
     /// Create a [VectorType] from a [`AbiRepresentation::Vector`].
     pub(crate) fn type_vector(&self, element_ty: AnyTypeEnum<'m>, len: u64) -> AnyTypeEnum<'m> {
         // @@PatchInkwell: we should allow creating a vector type from a
@@ -82,7 +82,7 @@ impl<'b, 'm> CodeGenCtx<'b, 'm> {
     }
 }
 
-impl<'b, 'm> TypeBuilderMethods<'b> for CodeGenCtx<'b, 'm> {
+impl<'b> TypeBuilderMethods<'b> for CodeGenCtx<'b, '_> {
     fn type_i1(&self) -> Self::Type {
         self.ll_ctx.bool_type().into()
     }

--- a/compiler/hash-codegen-vm/src/lib.rs
+++ b/compiler/hash-codegen-vm/src/lib.rs
@@ -41,7 +41,7 @@ pub struct VMBackend<'b> {
     metrics: &'b mut StageMetrics,
 }
 
-impl<'b> HasMutMetrics for VMBackend<'b> {
+impl HasMutMetrics for VMBackend<'_> {
     fn metrics(&mut self) -> &mut StageMetrics {
         self.metrics
     }

--- a/compiler/hash-codegen/src/lower/locals.rs
+++ b/compiler/hash-codegen/src/lower/locals.rs
@@ -144,8 +144,8 @@ struct LocalKindAnalyser<'ir, 'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> {
     locals: IndexVec<Local, LocalMemoryKind>,
 }
 
-impl<'ir, 'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> fmt::Display
-    for LocalKindAnalyser<'ir, 'a, 'b, Builder>
+impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> fmt::Display
+    for LocalKindAnalyser<'_, 'a, 'b, Builder>
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // compute the longest local name, and align all of the
@@ -171,7 +171,7 @@ impl<'ir, 'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> fmt::Display
     }
 }
 
-impl<'ir, 'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> LocalKindAnalyser<'ir, 'a, 'b, Builder> {
+impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> LocalKindAnalyser<'_, 'a, 'b, Builder> {
     /// Perform an "assignment" to a particular local. This will
     /// change the previous kind of memory with the following rules:
     ///

--- a/compiler/hash-const-eval/src/eval.rs
+++ b/compiler/hash-const-eval/src/eval.rs
@@ -23,7 +23,7 @@ pub struct ConstFolder<'ctx> {
 
 type OverflowingOp = fn(i128, i128) -> (i128, bool);
 
-impl<'ctx> ConstFolder<'ctx> {
+impl ConstFolder<'_> {
     /// Attempt to evaluate two [Const]s and a binary operator.
     pub fn try_fold_bin_op(&self, op: BinOp, lhs: &Const, rhs: &Const) -> Option<Const> {
         // If the two constants are non-scalar, then we abort the folding...

--- a/compiler/hash-const-eval/src/lib.rs
+++ b/compiler/hash-const-eval/src/lib.rs
@@ -1,7 +1,6 @@
 //! This is the main compiler sources for constant value management. This
 //! representation is used across the compiler from AST all of the way to
 //! the executable construction and or VM execution.v
-#![feature(const_option)]
 
 pub mod error;
 pub mod eval;

--- a/compiler/hash-exhaustiveness/src/lib.rs
+++ b/compiler/hash-exhaustiveness/src/lib.rs
@@ -151,7 +151,7 @@ impl<E: ExhaustivenessEnv> HasTarget for ExhaustivenessChecker<'_, E> {
     }
 }
 
-impl<'env, E: ExhaustivenessEnv> TyLowerEnv for ExhaustivenessChecker<'env, E> {}
+impl<E: ExhaustivenessEnv> TyLowerEnv for ExhaustivenessChecker<'_, E> {}
 
 impl<'env, E: ExhaustivenessEnv> ExhaustivenessChecker<'env, E> {
     /// Create a new checker.

--- a/compiler/hash-exhaustiveness/src/storage.rs
+++ b/compiler/hash-exhaustiveness/src/storage.rs
@@ -44,7 +44,7 @@ impl ExhaustivenessCtx {
     }
 }
 
-impl<'env, E: ExhaustivenessEnv> ExhaustivenessChecker<'env, E> {
+impl<E: ExhaustivenessEnv> ExhaustivenessChecker<'_, E> {
     pub(crate) fn get_ctor(&self, id: DeconstructedCtorId) -> &DeconstructedCtor {
         &self.ecx.dc[id]
     }

--- a/compiler/hash-ir/src/ir.rs
+++ b/compiler/hash-ir/src/ir.rs
@@ -709,7 +709,7 @@ pub struct SwitchTargetsIter<'a> {
     inner: iter::Zip<slice::Iter<'a, u128>, slice::Iter<'a, BasicBlock>>,
 }
 
-impl<'a> Iterator for SwitchTargetsIter<'a> {
+impl Iterator for SwitchTargetsIter<'_> {
     type Item = (u128, BasicBlock);
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/compiler/hash-ir/src/ir.rs
+++ b/compiler/hash-ir/src/ir.rs
@@ -840,7 +840,7 @@ impl BasicBlockData {
     /// the terminator is of kind [TerminatorKind::Unreachable].
     pub fn is_empty_and_unreachable(&self) -> bool {
         self.statements.is_empty()
-            && self.terminator.as_ref().map_or(false, |t| t.kind == TerminatorKind::Unreachable)
+            && self.terminator.as_ref().is_some_and(|t| t.kind == TerminatorKind::Unreachable)
     }
 }
 

--- a/compiler/hash-ir/src/lib.rs
+++ b/compiler/hash-ir/src/lib.rs
@@ -5,8 +5,7 @@
     type_alias_impl_trait,
     decl_macro,
     box_patterns,
-    variant_count,
-    const_option
+    variant_count
 )]
 
 pub mod basic_blocks;

--- a/compiler/hash-ir/src/traversal.rs
+++ b/compiler/hash-ir/src/traversal.rs
@@ -295,4 +295,4 @@ impl<'ir> Iterator for ReversePostOrder<'ir> {
     }
 }
 
-impl<'ir> ExactSizeIterator for ReversePostOrder<'ir> {}
+impl ExactSizeIterator for ReversePostOrder<'_> {}

--- a/compiler/hash-link/src/linker/gcc.rs
+++ b/compiler/hash-link/src/linker/gcc.rs
@@ -35,7 +35,7 @@ pub struct GccLinker<'ctx> {
     pub static_hint: bool,
 }
 
-impl<'ctx> GccLinker<'ctx> {
+impl GccLinker<'_> {
     /// Passes an arbitrary argument directly to the linker.
     fn linker_arg(&mut self, arg: impl AsRef<OsStr>) -> &mut Self {
         self.linker_args(&[arg]);
@@ -101,7 +101,7 @@ impl<'ctx> GccLinker<'ctx> {
     }
 }
 
-impl<'ctx> Linker for GccLinker<'ctx> {
+impl Linker for GccLinker<'_> {
     fn cmd(&mut self) -> &mut LinkCommand {
         &mut self.command
     }

--- a/compiler/hash-link/src/linker/mold.rs
+++ b/compiler/hash-link/src/linker/mold.rs
@@ -23,7 +23,7 @@ pub struct MoldLinker<'ctx> {
     settings: &'ctx CompilerSettings,
 }
 
-impl<'ctx> MoldLinker<'ctx> {
+impl MoldLinker<'_> {
     /// Passes a collection of argument directly to the linker.
     fn linker_args(&mut self, args: &[impl AsRef<OsStr>]) -> &mut Self {
         args.iter().for_each(|arg| {
@@ -34,7 +34,7 @@ impl<'ctx> MoldLinker<'ctx> {
     }
 }
 
-impl<'ctx> Linker for MoldLinker<'ctx> {
+impl Linker for MoldLinker<'_> {
     fn cmd(&mut self) -> &mut LinkCommand {
         &mut self.command
     }

--- a/compiler/hash-link/src/linker/msvc.rs
+++ b/compiler/hash-link/src/linker/msvc.rs
@@ -19,7 +19,7 @@ pub struct MsvcLinker<'ctx> {
     pub settings: &'ctx CompilerSettings,
 }
 
-impl<'ctx> Linker for MsvcLinker<'ctx> {
+impl Linker for MsvcLinker<'_> {
     fn cmd(&mut self) -> &mut LinkCommand {
         &mut self.command
     }

--- a/compiler/hash-lower/src/build/constant.rs
+++ b/compiler/hash-lower/src/build/constant.rs
@@ -9,7 +9,7 @@ use hash_tir::tir::{self, HasAstNodeId};
 
 use super::BodyBuilder;
 
-impl<'tcx> BodyBuilder<'tcx> {
+impl BodyBuilder<'_> {
     /// Lower a literal value into a [constant::Const].
     pub(crate) fn lit_as_const(&self, lit: tir::LitId) -> ir::Const {
         match *lit.value() {

--- a/compiler/hash-lower/src/build/into.rs
+++ b/compiler/hash-lower/src/build/into.rs
@@ -30,7 +30,7 @@ use hash_utils::itertools::Itertools;
 
 use super::{ty::FnCallTermKind, unpack, BlockAnd, BlockAndExtend, BodyBuilder, LoopBlockInfo};
 
-impl<'tcx> BodyBuilder<'tcx> {
+impl BodyBuilder<'_> {
     /// Compile the given [Term] and place the value of the [Term]
     /// into the specified destination [Place].
     pub(crate) fn term_into_dest(

--- a/compiler/hash-lower/src/build/matches/candidate.rs
+++ b/compiler/hash-lower/src/build/matches/candidate.rs
@@ -172,7 +172,7 @@ pub(super) enum BindingMode {
     ByRef,
 }
 
-impl<'tcx> BodyBuilder<'tcx> {
+impl BodyBuilder<'_> {
     /// This function attempts to simplify a [Candidate] so that all match pairs
     /// can be tested. This method will also split the candidate in which
     /// the only match pair is a `or` pattern, in order for matches like:

--- a/compiler/hash-lower/src/build/matches/declarations.rs
+++ b/compiler/hash-lower/src/build/matches/declarations.rs
@@ -15,7 +15,7 @@ use hash_tir::tir::{
 use super::{candidate::Candidate, BlockAnd, BodyBuilder};
 use crate::build::{place::PlaceBuilder, unpack, BlockAndExtend};
 
-impl<'tcx> BodyBuilder<'tcx> {
+impl BodyBuilder<'_> {
     /// Push a [LocalDecl] in the current [BodyBuilder] with the associated
     /// [Symbol]. This will put the [LocalDecl] into the declarations, and
     /// create an entry in the lookup map so that the [Local] can be looked up

--- a/compiler/hash-lower/src/build/matches/optimise.rs
+++ b/compiler/hash-lower/src/build/matches/optimise.rs
@@ -16,7 +16,7 @@ use hash_utils::smallvec::SmallVec;
 use super::candidate::{Candidate, MatchPair};
 use crate::build::{place::PlaceBuilder, BodyBuilder};
 
-impl<'tcx> BodyBuilder<'tcx> {
+impl BodyBuilder<'_> {
     /// Attempt to optimise the sub-candidates of a provided [Candidate]. This
     /// only performs a trivial merge, so we avoid generating exponential
     pub(super) fn merge_sub_candidates(&mut self, candidate: &mut Candidate, origin: AstNodeId) {

--- a/compiler/hash-lower/src/build/matches/test.rs
+++ b/compiler/hash-lower/src/build/matches/test.rs
@@ -118,7 +118,7 @@ impl Test {
     }
 }
 
-impl<'tcx> BodyBuilder<'tcx> {
+impl BodyBuilder<'_> {
     pub(super) fn test_or_pat(
         &mut self,
         candidate: &mut Candidate,

--- a/compiler/hash-lower/src/build/place.rs
+++ b/compiler/hash-lower/src/build/place.rs
@@ -75,7 +75,7 @@ impl From<Local> for PlaceBuilder {
     }
 }
 
-impl<'tcx> BodyBuilder<'tcx> {
+impl BodyBuilder<'_> {
     pub(crate) fn as_place(
         &mut self,
         mut block: BasicBlock,

--- a/compiler/hash-lower/src/build/rvalue.rs
+++ b/compiler/hash-lower/src/build/rvalue.rs
@@ -24,7 +24,7 @@ use super::{
 };
 use crate::build::category::RValueKind;
 
-impl<'tcx> BodyBuilder<'tcx> {
+impl BodyBuilder<'_> {
     /// Construct an [RValue] from the given [ast::Expr].
     pub(crate) fn as_rvalue(&mut self, mut block: BasicBlock, term: TermId) -> BlockAnd<RValue> {
         let span = self.span_of_term(term);

--- a/compiler/hash-lower/src/build/temp.rs
+++ b/compiler/hash-lower/src/build/temp.rs
@@ -9,7 +9,7 @@ use hash_tir::tir::TermId;
 use super::{BlockAnd, BodyBuilder};
 use crate::build::{unpack, BlockAndExtend};
 
-impl<'tcx> BodyBuilder<'tcx> {
+impl BodyBuilder<'_> {
     /// Compile an "term" into a freshly created temporary [Place].
     pub(crate) fn term_into_temp(
         &mut self,

--- a/compiler/hash-lower/src/build/ty.rs
+++ b/compiler/hash-lower/src/build/ty.rs
@@ -52,7 +52,7 @@ pub enum FnCallTermKind {
     UnaryOp(UnOp, TermId),
 }
 
-impl<'tcx> BodyBuilder<'tcx> {
+impl BodyBuilder<'_> {
     /// Get the [ReprTyId] from a given [TermId]. This function will internally
     /// cache results of lowering a [TermId] into an [ReprTyId] to avoid
     /// duplicate work.

--- a/compiler/hash-lower/src/build/utils.rs
+++ b/compiler/hash-lower/src/build/utils.rs
@@ -22,7 +22,7 @@ use hash_tir::tir::{
 
 use super::BodyBuilder;
 
-impl<'tcx> BodyBuilder<'tcx> {
+impl BodyBuilder<'_> {
     /// Get a reference to a [IrCtx].
     pub(crate) fn ctx(&self) -> &IrCtx {
         self.ctx.lcx

--- a/compiler/hash-lower/src/optimise/cleanup_locals.rs
+++ b/compiler/hash-lower/src/optimise/cleanup_locals.rs
@@ -259,7 +259,7 @@ impl LocalUpdater {
     }
 }
 
-impl<'ir> ModifyingIrVisitor<'ir> for LocalUpdater {
+impl ModifyingIrVisitor<'_> for LocalUpdater {
     /// Perform a remapping of the [Local] within the [Place] to a new [Local].
     fn visit_local(&self, local: &mut Local, _: PlaceCtx, _: IrRef) {
         if let Some(new_local) = self.remap[*local] {

--- a/compiler/hash-lower/src/ty.rs
+++ b/compiler/hash-lower/src/ty.rs
@@ -14,7 +14,7 @@ use hash_tir_utils::lower::{ShouldCache, TyLower};
 
 use crate::ctx::BuilderCtx;
 
-impl<'ir> BuilderCtx<'ir> {
+impl BuilderCtx<'_> {
     pub(crate) fn repr_ty_from_tir_ty(&self, id: TyId) -> ReprTyId {
         let lower = TyLower::new(self);
         lower.repr_ty_from_tir_ty(id)

--- a/compiler/hash-parser/src/diagnostics/mod.rs
+++ b/compiler/hash-parser/src/diagnostics/mod.rs
@@ -13,7 +13,7 @@ use crate::parser::AstGen;
 /// Shorthand for the parser diagnostics.
 pub type ParserDiagnostics = DiagnosticStore<ParseError, ParseWarning>;
 
-impl<'s> HasDiagnosticsMut for AstGen<'s> {
+impl HasDiagnosticsMut for AstGen<'_> {
     type Diagnostics = ParserDiagnostics;
 
     fn diagnostics(&mut self) -> &mut Self::Diagnostics {

--- a/compiler/hash-parser/src/parser/block.rs
+++ b/compiler/hash-parser/src/parser/block.rs
@@ -8,7 +8,7 @@ use hash_utils::thin_vec::thin_vec;
 use super::{AstGen, ParseResult};
 use crate::diagnostics::error::ParseErrorKind;
 
-impl<'s> AstGen<'s> {
+impl AstGen<'_> {
     /// Parse a block.
     #[inline]
     pub(crate) fn parse_block(&mut self) -> ParseResult<AstNode<Block>> {

--- a/compiler/hash-parser/src/parser/definitions.rs
+++ b/compiler/hash-parser/src/parser/definitions.rs
@@ -6,7 +6,7 @@ use hash_token::{delimiter::Delimiter, keyword::Keyword, TokenKind};
 use super::AstGen;
 use crate::diagnostics::error::{ParseErrorKind, ParseResult};
 
-impl<'s> AstGen<'s> {
+impl AstGen<'_> {
     /// Construct the [Params] from the parsed [`AstNodes<Param>`]. This is
     /// just a utility function to wrap the nodes in the [Params] struct.
     pub fn make_params(&self, params: AstNodes<Param>, origin: ParamOrigin) -> AstNode<Params> {

--- a/compiler/hash-parser/src/parser/expr.rs
+++ b/compiler/hash-parser/src/parser/expr.rs
@@ -13,7 +13,7 @@ use crate::diagnostics::{
     warning::{ParseWarning, WarningKind},
 };
 
-impl<'s> AstGen<'s> {
+impl AstGen<'_> {
     /// Parse a top level [Expr] that are optionally terminated with a
     /// semi-colon.
     #[profiling::function]

--- a/compiler/hash-parser/src/parser/lit.rs
+++ b/compiler/hash-parser/src/parser/lit.rs
@@ -8,7 +8,7 @@ use hash_utils::thin_vec::thin_vec;
 use super::AstGen;
 use crate::diagnostics::error::ParseResult;
 
-impl<'s> AstGen<'s> {
+impl AstGen<'_> {
     /// Parse a primitive literal, which means it can be either a `char`,
     /// `integer`, `float` or a `string`.
     pub(crate) fn parse_primitive_lit(&mut self) -> AstNode<Lit> {

--- a/compiler/hash-parser/src/parser/macros.rs
+++ b/compiler/hash-parser/src/parser/macros.rs
@@ -13,7 +13,7 @@ use crate::diagnostics::{
     expected::ExpectedItem,
 };
 
-impl<'s> AstGen<'s> {
+impl AstGen<'_> {
     /// Parse a macro prefix character, which depending on [MacroKind] is either
     /// a `#` or a `@`.
     ///

--- a/compiler/hash-parser/src/parser/name.rs
+++ b/compiler/hash-parser/src/parser/name.rs
@@ -10,7 +10,7 @@ use crate::diagnostics::{
     expected::ExpectedItem,
 };
 
-impl<'s> AstGen<'s> {
+impl AstGen<'_> {
     /// Parse a singular [Name] from the current token stream.
     #[inline]
     pub fn parse_name(&mut self) -> ParseResult<AstNode<Name>> {

--- a/compiler/hash-parser/src/parser/operator.rs
+++ b/compiler/hash-parser/src/parser/operator.rs
@@ -5,7 +5,7 @@ use hash_token::{keyword::Keyword, TokenKind};
 
 use super::AstGen;
 
-impl<'s> AstGen<'s> {
+impl AstGen<'_> {
     /// This function is used to pickup 'glued' operator tokens to form more
     /// complex binary operators that might be made up of multiple tokens.
     /// The function will peek ahead (2 tokens at most since all binary

--- a/compiler/hash-parser/src/parser/pat.rs
+++ b/compiler/hash-parser/src/parser/pat.rs
@@ -12,7 +12,7 @@ use crate::diagnostics::{
     expected::ExpectedItem,
 };
 
-impl<'s> AstGen<'s> {
+impl AstGen<'_> {
     /// Parse a compound [Pat]. A compound [Pat] means that this could
     /// be a pattern that might be a combination of multiple patterns.
     /// Additionally, compound patterns are allowed to have `if-guard`

--- a/compiler/hash-parser/src/parser/ty.rs
+++ b/compiler/hash-parser/src/parser/ty.rs
@@ -13,7 +13,7 @@ use crate::diagnostics::{
     warning::{ParseWarning, WarningKind},
 };
 
-impl<'s> AstGen<'s> {
+impl AstGen<'_> {
     /// Parse a [Ty]. This includes all forms of a [Ty]. This function
     /// does not deal with any kind of [Ty] annotation or [ImplicitFnDef]
     /// syntax.

--- a/compiler/hash-reporting/src/macros.rs
+++ b/compiler/hash-reporting/src/macros.rs
@@ -36,12 +36,11 @@ pub macro panic_on_span {
 /// Examples of use:
 ///
 /// ```rust
-/// 
 /// // Don't print on `prelude` module.
-/// note_on_span!(@no_prelude: true, item.span(), "compiling `item`");
+/// note_on_span(item.span(), "compiling `item`");
 ///
 /// // Always print.
-/// note_on_span!(item.span(), "compiling `item`");
+/// note_on_span(item.span(), "compiling `item`");
 /// ```
 #[track_caller]
 pub fn note_on_span(location: impl Into<Span>, message: impl ToString) {

--- a/compiler/hash-repr/src/compute.rs
+++ b/compiler/hash-repr/src/compute.rs
@@ -123,7 +123,7 @@ impl HasDataLayout for LayoutComputer<'_> {
     }
 }
 
-impl<'l> LayoutComputer<'l> {
+impl LayoutComputer<'_> {
     /// Returns a reference to the [LayoutStorage].
     pub fn ctx(&self) -> &LayoutStorage {
         self.ctx

--- a/compiler/hash-repr/src/lib.rs
+++ b/compiler/hash-repr/src/lib.rs
@@ -1,7 +1,7 @@
 //! Defines all logic regarding computing the layout of types, and
 //! representing the said layouts in a way that is usable by the
 //! code generation backends.
-#![feature(let_chains, const_option)]
+#![feature(let_chains)]
 
 pub mod compute;
 pub mod constant;

--- a/compiler/hash-semantics/src/lib.rs
+++ b/compiler/hash-semantics/src/lib.rs
@@ -168,7 +168,7 @@ impl HasTyCache for SemanticEnvImpl<'_> {
     }
 }
 
-impl<'env> SemanticEnv for SemanticEnvImpl<'env> {
+impl SemanticEnv for SemanticEnvImpl<'_> {
     fn storage(&self) -> &SemanticStorage {
         self.ctx.semantic_storage
     }

--- a/compiler/hash-semantics/src/passes/discovery/discriminants.rs
+++ b/compiler/hash-semantics/src/passes/discovery/discriminants.rs
@@ -25,7 +25,7 @@ use crate::{
     env::SemanticEnv,
 };
 
-impl<'env, E: SemanticEnv> DiscoveryPass<'env, E> {
+impl<E: SemanticEnv> DiscoveryPass<'_, E> {
     /// Compute the type of the discriminant from a given [`ast::EnumDef`].
     ///
     /// The algorithm follows the following rules:

--- a/compiler/hash-semantics/src/passes/discovery/params.rs
+++ b/compiler/hash-semantics/src/passes/discovery/params.rs
@@ -6,7 +6,7 @@ use hash_tir::tir::{Node, NodeOrigin, NodesId, Param, ParamId, ParamIndex, Param
 use super::DiscoveryPass;
 use crate::env::SemanticEnv;
 
-impl<'env, E: SemanticEnv> DiscoveryPass<'env, E> {
+impl<E: SemanticEnv> DiscoveryPass<'_, E> {
     /// Create a parameter list from the given AST generic parameter list, where
     /// the type of each parameter is a hole.
     pub(super) fn create_hole_params_from<T>(

--- a/compiler/hash-semantics/src/passes/mod.rs
+++ b/compiler/hash-semantics/src/passes/mod.rs
@@ -22,7 +22,7 @@ pub struct Analyser<'env, E: SemanticEnv> {
     env: &'env E,
 }
 
-impl<'env, E: SemanticEnv> Analyser<'env, E> {
+impl<E: SemanticEnv> Analyser<'_, E> {
     /// Visits the source passed in as an argument to [Self::new_in_source]
     pub fn visit_source(&self, source: SourceId) -> SemanticResult<()> {
         // AST info for discovery and resolution passes.

--- a/compiler/hash-source/src/lib.rs
+++ b/compiler/hash-source/src/lib.rs
@@ -1,5 +1,5 @@
 //! Hash Compiler source location definitions.
-#![feature(path_file_prefix, let_chains, const_trait_impl, box_patterns, const_option)]
+#![feature(path_file_prefix, let_chains, const_trait_impl, box_patterns)]
 
 pub mod constant;
 pub mod entry_point;

--- a/compiler/hash-storage/src/arena/brick.rs
+++ b/compiler/hash-storage/src/arena/brick.rs
@@ -43,7 +43,7 @@ impl<'c, T> Brick<'c, T> {
     }
 }
 
-impl<'c, T: Clone> Brick<'c, T> {
+impl<T: Clone> Brick<'_, T> {
     /// Clone the value inside the `Brick`, and return the cloned value itself.
     pub fn clone_out(&self) -> T {
         (*self).clone()

--- a/compiler/hash-storage/src/arena/row.rs
+++ b/compiler/hash-storage/src/arena/row.rs
@@ -242,7 +242,7 @@ impl<'c, T> Row<'c, T> {
     }
 }
 
-impl<'c, T: Clone> Row<'c, T> {
+impl<T: Clone> Row<'_, T> {
     /// Clone the data inside `self` into a [`Vec`].
     pub fn clone_vec(&self) -> Vec<T> {
         self.iter().cloned().collect()
@@ -347,7 +347,7 @@ impl<T> BorrowMut<[T]> for Row<'_, T> {
     }
 }
 
-impl<'r, 'c, T> IntoIterator for &'r Row<'c, T> {
+impl<'r, T> IntoIterator for &'r Row<'_, T> {
     type Item = &'r T;
     type IntoIter = std::slice::Iter<'r, T>;
 
@@ -356,7 +356,7 @@ impl<'r, 'c, T> IntoIterator for &'r Row<'c, T> {
     }
 }
 
-impl<'r, 'c, T> IntoIterator for &'r mut Row<'c, T> {
+impl<'r, T> IntoIterator for &'r mut Row<'_, T> {
     type Item = &'r mut T;
     type IntoIter = std::slice::IterMut<'r, T>;
 

--- a/compiler/hash-tir-utils/src/upcast.rs
+++ b/compiler/hash-tir-utils/src/upcast.rs
@@ -24,7 +24,7 @@ pub struct TyUpCast<'tc, E> {
     env: &'tc E,
 }
 
-impl<'tc, E: HasTarget> TyUpCast<'tc, E> {
+impl<E: HasTarget> TyUpCast<'_, E> {
     /// Convert a [ReprTyId] into a [TyId].
     pub fn ty_from_repr_ty(&self, ty: ReprTyId, origin: impl Into<NodeOrigin>) -> Option<TyId> {
         match ty.value() {

--- a/compiler/hash-token/src/lib.rs
+++ b/compiler/hash-token/src/lib.rs
@@ -319,15 +319,9 @@ pub enum TokenKind {
     /// Identifier.
     Ident(Identifier),
 
-    /// Tree - The index is set as a `u32` since it isn't going
-    /// to be the case that the index will or should ever really
-    /// reach `2^32` since the index is per module and not per project.
-    ///
-    /// @@Todo: rather than using an index into the token trees, we should
-    /// use it as a index into the token stream to denote where the
-    /// token tree ends. This means that we can have a flat token
-    /// stream which removes the need for storing token trees
-    /// separately.
+    /// Tree a token indicating the start of a token tree, i.e. some
+    /// delimited block of tokens. The `u32` is the length of the tokens
+    /// within the tree excluding the delimiters.
     Tree(Delimiter, u32),
 
     /// Keyword

--- a/compiler/hash-typecheck/src/lib.rs
+++ b/compiler/hash-typecheck/src/lib.rs
@@ -11,7 +11,7 @@
 //! that defines all the required items for the typechecker to work, provided by
 //! the greater compiler context.
 
-#![feature(control_flow_enum, let_chains)]
+#![feature(let_chains)]
 
 pub mod diagnostics;
 pub mod env;

--- a/compiler/hash-utils/src/graph/dominators.rs
+++ b/compiler/hash-utils/src/graph/dominators.rs
@@ -74,7 +74,7 @@ pub struct DominatorsIter<'dom, Node: Idx> {
     node: Option<Node>,
 }
 
-impl<'dom, Node: Idx> Iterator for DominatorsIter<'dom, Node> {
+impl<Node: Idx> Iterator for DominatorsIter<'_, Node> {
     type Item = Node;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/compiler/hash-utils/src/graph/dominators.rs
+++ b/compiler/hash-utils/src/graph/dominators.rs
@@ -119,7 +119,7 @@ fn from_fn_n<I: Idx, T>(func: impl FnMut(I) -> T, n: usize) -> IndexVec<I, T> {
 }
 
 fn is_processed(node: PreOrderIndex, last_linked: Option<PreOrderIndex>) -> bool {
-    last_linked.map_or(false, |last_linked| node >= last_linked)
+    last_linked.is_some_and(|last_linked| node >= last_linked)
 }
 
 fn compress(

--- a/compiler/hash-utils/src/graph/visit.rs
+++ b/compiler/hash-utils/src/graph/visit.rs
@@ -30,7 +30,7 @@ pub fn post_order_from_to<G: DirectedGraph + WithSuccessors>(
 
         visited[node] = true;
 
-        if end_node.map_or(true, |end_node| node != end_node) {
+        if end_node != Some(node) {
             stack.push(node);
             for successor in graph.successors(node) {
                 stack.push(successor);

--- a/compiler/hash-utils/src/tree_writing.rs
+++ b/compiler/hash-utils/src/tree_writing.rs
@@ -142,7 +142,7 @@ pub struct TreeWriter<'t, 'cfg> {
     config: Cow<'cfg, TreeWriterConfig>,
 }
 
-impl<'t, 'cfg> TreeWriter<'t, 'cfg> {
+impl<'t> TreeWriter<'t, '_> {
     /// Create a new [TreeWriter] with the given [TreeNode] and default
     /// configuration.
     pub fn new(tree: &'t TreeNode) -> Self {


### PR DESCRIPTION
## Description

This PR is an aggregation of a few observed issues and improvements. These are:

- Adjustments to documentation for several parts, tokenisation and error
reporting.

- Upgrade all dependencies

- Upgrade to the latest nightly compiler and fix any detected issues by the
  accompanying clippy lints.

- Fix a CLI cosmetic issue where benign messages such as "help" or "version" were being treated as fatal errors.

## Commits

- **token: Update documentation of `TokenKind::Tree(...)` variant**
- **reporting: update documentation on `note_on_span` utility**
- **pipeline: gracefully handle benign clap errors, i.e. printing the help message**
- **Fix lifetime elision clippy warnings**
- **Avoid uses of `map_or` for simpler comparison calls**
- **Avoid specifying `#![feature(...)]`s that are stabilised on the current stable release**
- **chore: update compiler dependencies**
