### PR TITLE
Fix several parser bugs

### DIFF
--- a/compiler/hash-parser/src/parser/expr.rs
+++ b/compiler/hash-parser/src/parser/expr.rs
@@ -752,7 +752,10 @@ impl AstGen<'_> {
 
                 // We want to emit a redundant parentheses warning if it is not a binary-like
                 // expression since it does not affect the precedence...
-                if !matches!(expr.body(), Expr::BinaryExpr(_) | Expr::Cast(_) | Expr::FnDef(_)) {
+                if !matches!(
+                    expr.body(),
+                    Expr::BinaryExpr(_) | Expr::Cast(_) | Expr::FnDef(_) | Expr::Deref(_)
+                ) {
                     gen.add_warning(ParseWarning::new(
                         WarningKind::RedundantParenthesis(expr.body().into()),
                         gen.make_span(gen.range()),

--- a/compiler/hash-parser/src/parser/mod.rs
+++ b/compiler/hash-parser/src/parser/mod.rs
@@ -32,7 +32,7 @@ use crate::{
     import_resolver::ImportResolver,
 };
 
-#[derive(Deref)]
+#[derive(Deref, Debug)]
 pub(crate) struct AstGenFrame<'s> {
     /// The token cursor.
     #[deref]
@@ -107,6 +107,12 @@ impl<'s> AstGenFrame<'s> {
     fn expected_pos(&self) -> ByteRange {
         let pos = self.previous_pos().end() + 1;
         ByteRange::new(pos, pos)
+    }
+
+    /// Check whether the frame has encountered an error.
+    #[inline(always)]
+    pub(crate) fn has_error(&self) -> bool {
+        self.error.get()
     }
 }
 

--- a/compiler/hash-parser/src/parser/ty.rs
+++ b/compiler/hash-parser/src/parser/ty.rs
@@ -328,6 +328,14 @@ impl AstGen<'_> {
                 ),
             };
 
+            // Abort early if we encountered some kind of error along the way,
+            // although I would think when the `gen` is consumed then we can
+            // send up all of the errors to the parent generator?
+            if gen.has_error() {
+                let err = gen.diagnostics.errors.pop().unwrap();
+                return Err(err);
+            }
+
             // Here we check that the token tree has a comma at the end to later determine
             // if this is a `TupleTy`...
             let gen_has_comma = !gen.is_empty() && gen.previous_token().has_kind(TokenKind::Comma);

--- a/compiler/hash-source/src/location.rs
+++ b/compiler/hash-source/src/location.rs
@@ -85,6 +85,20 @@ impl ByteRange {
     pub fn into_location(self, source_id: SourceId) -> Span {
         Span::new(self, source_id)
     }
+
+    /// Check if one span intersects with another one.
+    ///
+    /// We check whether the `current` token touches the other token, if it
+    /// does, then we consider it to be intersecting.
+    /// ```
+    /// 
+    ///  (current token)
+    ///                 (other token)
+    /// ```
+    #[inline(always)]
+    pub fn is_right_before(&self, other: Self) -> bool {
+        self.start() == (other.end() + 1)
+    }
 }
 
 impl Default for ByteRange {

--- a/compiler/hash-token/src/cursor.rs
+++ b/compiler/hash-token/src/cursor.rs
@@ -51,6 +51,7 @@ pub type TokenStream<'t> = &'t [Token];
 
 /// A cursor over a token stream which handles internal traversal logic
 /// and bookkeeping.
+#[derive(Debug)]
 pub struct TokenCursor<'t> {
     /// The raw stream of tokens that is being traversed.
     stream: TokenStream<'t>,

--- a/compiler/hash-token/src/lib.rs
+++ b/compiler/hash-token/src/lib.rs
@@ -53,6 +53,9 @@ impl Token {
     /// order to print literals.
     ///
     /// ##Note: this does not print trees.
+    ///
+    /// @@Todo: make this in a "TokenPrinter" context so that we don't
+    /// need to explicitly make this a method on token.
     pub fn pretty_print(&self, source: SpannedSource<'_>) -> String {
         match self.kind {
             TokenKind::Int(_, _) | TokenKind::Float(_) | TokenKind::Char(_) | TokenKind::Str(_) => {

--- a/tests/cases/parser/blocks/empty_for_loop.hash
+++ b/tests/cases/parser/blocks/empty_for_loop.hash
@@ -4,6 +4,6 @@ main := () => {
     // Test that the parser shouldn't get confused between a struct literal and a for block
     for x in xs {}
 
-    // Test that struct literals are allowed in parenthesees...
-    for x in (Struct ( xs )) {}
+    // Test that struct literals are allowed in parentheses...
+    for x in (Struct( xs )) {}
 }

--- a/tests/cases/parser/constructors/struct_defn.hash
+++ b/tests/cases/parser/constructors/struct_defn.hash
@@ -7,7 +7,7 @@ Point := struct(
 
 // Test that structs can be initialised with default field value and types.
 Triangle := struct(
-    x: Point = Point (x = 0, y = 0),
+    x: Point = Point(x = 0, y = 0),
     y: Point,
     z := Point( x = 0, y = 0), // Type should be inferred from default value?
 );

--- a/tests/cases/parser/misc/while_implicit_call.hash
+++ b/tests/cases/parser/misc/while_implicit_call.hash
@@ -1,0 +1,9 @@
+// run=pass, stage=parse, warnings=compare
+
+#dump_ast 
+main := () => {
+    i := 0;
+    while i < (*arr).len {
+        i += 1;
+    }
+}

--- a/tests/cases/parser/patterns/list_patterns.hash
+++ b/tests/cases/parser/patterns/list_patterns.hash
@@ -6,7 +6,7 @@
 [a, b] := foo();
 [] := foo();
 
-[x, Struct ( name )] = *mu();
+[x, Struct(name)] = *mu();
 
 [(a, 3) | (a, 2), (c, d), (r, m)] := foo();
 

--- a/tests/cases/typecheck/pat_binds/548.hash
+++ b/tests/cases/typecheck/pat_binds/548.hash
@@ -3,12 +3,12 @@
 main := () => {
     // ~ERROR: variable `c` not declared in all patterns
     // ~ERROR: variable `d` not declared in all patterns
-    (c | d) := 2;    
+    (c | d) := 2;
 
     k := (1, 2)
 
     match k {
-        (a, b) | (t, a) => {}
+        (a, b) | (t, a) => {},
         (2, 3) | (a, b) => {}
     }
 }

--- a/tests/cases/typecheck/pat_binds/548.stderr
+++ b/tests/cases/typecheck/pat_binds/548.stderr
@@ -1,51 +1,77 @@
 error[0081]: variable `c` is not bound in all patterns
  --> $DIR/548.hash:6:10
 5 |       // ~ERROR: variable `d` not declared in all patterns
-6 |       (c | d) := 2;    
+6 |       (c | d) := 2;
   |            ^ pattern doesn't bind `c`
 7 |   
 
  --> $DIR/548.hash:6:6
 5 |       // ~ERROR: variable `d` not declared in all patterns
-6 |       (c | d) := 2;    
+6 |       (c | d) := 2;
   |        ^ variable not in all patterns
 7 |   
 
 error[0081]: variable `d` is not bound in all patterns
  --> $DIR/548.hash:6:6
 5 |       // ~ERROR: variable `d` not declared in all patterns
-6 |       (c | d) := 2;    
+6 |       (c | d) := 2;
   |        ^ pattern doesn't bind `d`
 7 |   
 
  --> $DIR/548.hash:6:10
 5 |       // ~ERROR: variable `d` not declared in all patterns
-6 |       (c | d) := 2;    
+6 |       (c | d) := 2;
   |            ^ variable not in all patterns
 7 |   
 
 error[0081]: variable `b` is not bound in all patterns
   --> $DIR/548.hash:11:18
 10 |       match k {
-11 |           (a, b) | (t, a) => {}
+11 |           (a, b) | (t, a) => {},
    |                    ^^^^^^ pattern doesn't bind `b`
 12 |           (2, 3) | (a, b) => {}
 
   --> $DIR/548.hash:11:13
 10 |       match k {
-11 |           (a, b) | (t, a) => {}
+11 |           (a, b) | (t, a) => {},
    |               ^ variable not in all patterns
 12 |           (2, 3) | (a, b) => {}
 
 error[0081]: variable `t` is not bound in all patterns
   --> $DIR/548.hash:11:9
 10 |       match k {
-11 |           (a, b) | (t, a) => {}
+11 |           (a, b) | (t, a) => {},
    |           ^^^^^^ pattern doesn't bind `t`
 12 |           (2, 3) | (a, b) => {}
 
   --> $DIR/548.hash:11:19
 10 |       match k {
-11 |           (a, b) | (t, a) => {}
+11 |           (a, b) | (t, a) => {},
    |                     ^ variable not in all patterns
 12 |           (2, 3) | (a, b) => {}
+
+error[0081]: variable `a` is not bound in all patterns
+  --> $DIR/548.hash:12:9
+11 |           (a, b) | (t, a) => {},
+12 |           (2, 3) | (a, b) => {}
+   |           ^^^^^^ pattern doesn't bind `a`
+13 |       }
+
+  --> $DIR/548.hash:12:19
+11 |           (a, b) | (t, a) => {},
+12 |           (2, 3) | (a, b) => {}
+   |                     ^ variable not in all patterns
+13 |       }
+
+error[0081]: variable `b` is not bound in all patterns
+  --> $DIR/548.hash:12:9
+11 |           (a, b) | (t, a) => {},
+12 |           (2, 3) | (a, b) => {}
+   |           ^^^^^^ pattern doesn't bind `b`
+13 |       }
+
+  --> $DIR/548.hash:12:22
+11 |           (a, b) | (t, a) => {},
+12 |           (2, 3) | (a, b) => {}
+   |                        ^ variable not in all patterns
+13 |       }


### PR DESCRIPTION
## Description

This PR changes a few things:

- The parser's handling of singular expressions, now we consider single expressions as those that must be physically connected.

- Avoid emitting redundant parenthesis warnings on deref expressions, as
  parentheses are required to disambiguate what expression is being dereferenced.

- Fix a panic that would occur when trying to parse malformed implicit arguments.

To elaborate on single expression handling,
i.e. ones that don't have any operators between them. Previously, the
parser would eagerly continue parsing a singular expression until it
matched the legal structure of an expression. Whilst this was legal,
and handled accordingly at later phases of compilation, it certainly
created odd (and unexpected) behaviour in the parser.

Now, we consider singular expressions as a collection of tokens that
must be "physically" connected. For example, before hand we consider:

```rs
foo
()

// Or

foo
 ()
```

as a call to the function `foo`, however, now we consider them as
separate expressions. Now, calling foo can only be done with:
```rs
foo()
```

## Commits

- **parser: fix panic when trying to parse malformed implicit arguments**
- **parser: fix improper "redundant parenthesis" warning on deref expressions**
- **Add @@Todo on `Token::pretty_print`**
- **reporting: Improve `note_on_span*` functionality with `SpanGuard`**
- **parser: consider physically separated chunks as separate singular expressions**
