### PR TITLE
Refactor and simplify syncingspan maps

### DIFF
--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -80,20 +80,15 @@ static SPAN_MAP: Lazy<RwLock<Vec<Span>>> = Lazy::new(|| {
 /// added to the global [`SPAN_MAP`] later.
 ///
 /// ##Note: This is only used by the parser in order to reduce contention for [`SPAN_MAP`].
+#[derive(Default)]
 pub struct LocalSpanMap {
     map: Vec<(AstNodeId, ByteRange)>,
-    source: SourceId,
 }
 
 impl LocalSpanMap {
-    /// Create a new [LocalSpanMap].
-    pub fn new(source: SourceId) -> Self {
-        Self { map: vec![], source }
-    }
-
     /// Create a new [LocalSpanMap] with a given capacity.
-    pub fn with_capacity(source: SourceId, capacity: usize) -> Self {
-        Self { map: Vec::with_capacity(capacity), source }
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self { map: Vec::with_capacity(capacity) }
     }
 
     /// Add a new node to the map.
@@ -156,7 +151,7 @@ impl SpanMap {
     }
 
     /// Merge a [LocalSpanMap] into the [`SPAN_MAP`].
-    pub fn add_local_map(local: LocalSpanMap) {
+    pub fn add_local_map(source: SourceId, local: LocalSpanMap) {
         // If no nodes were added, don't do anything!
         if local.map.is_empty() {
             return;
@@ -173,7 +168,7 @@ impl SpanMap {
 
         // Now we write all of the items into the map.
         for (id, range) in local.map {
-            writer[id.to_usize()] = Span::new(range, local.source);
+            writer[id.to_usize()] = Span::new(range, source);
         }
     }
 }

--- a/compiler/hash-parser/src/parser/mod.rs
+++ b/compiler/hash-parser/src/parser/mod.rs
@@ -108,12 +108,6 @@ impl<'s> AstGenFrame<'s> {
         let pos = self.previous_pos().end() + 1;
         ByteRange::new(pos, pos)
     }
-
-    /// Check whether the frame has encountered an error.
-    #[inline(always)]
-    pub(crate) fn has_error(&self) -> bool {
-        self.error.get()
-    }
 }
 
 /// The [AstGen] struct it the primary parser for the Hash compiler. It

--- a/compiler/hash-parser/src/parser/ty.rs
+++ b/compiler/hash-parser/src/parser/ty.rs
@@ -1,7 +1,7 @@
 //! Hash Compiler AST generation sources. This file contains the sources to the
 //! logic that transforms tokens into an AST.
 use hash_ast::ast::*;
-use hash_reporting::diagnostic::HasDiagnosticsMut;
+use hash_reporting::diagnostic::{DiagnosticsMut, HasDiagnosticsMut};
 use hash_source::identifier::IDENTS;
 use hash_token::{delimiter::Delimiter, keyword::Keyword, Token, TokenKind};
 use hash_utils::thin_vec::thin_vec;
@@ -331,7 +331,7 @@ impl AstGen<'_> {
             // Abort early if we encountered some kind of error along the way,
             // although I would think when the `gen` is consumed then we can
             // send up all of the errors to the parent generator?
-            if gen.has_error() {
+            if gen.diagnostics.has_errors() {
                 let err = gen.diagnostics.errors.pop().unwrap();
                 return Err(err);
             }

--- a/tests/cases/parser/types/tuple_type_args.hash
+++ b/tests/cases/parser/types/tuple_type_args.hash
@@ -1,0 +1,8 @@
+// run=pass, stage=parse
+
+set := (data: char) -> Result<void, IoError> => {
+    match (intrinsic_char_set(data) as Result<void, (i32, str)>) {
+        Err(e) => Err(_conv_ioerr_prim(e)),
+        Ok(r) => Ok(r)
+    }
+};


### PR DESCRIPTION
## Description

This PR removes the `source_id` field from the `LocalSpanMap` struct. This field was used to store the `source_id` of the span that was being parsed, but it was not being used anywhere. This PR also ensures that we abort parsing type arguments when there is an actual error.

## Commits

- **Remove `source_id` from `LocalSpanMap`**
- **Ensure we abort parsing type arguments when there is an actual error**
