### PR TITLE
parser: fix erroneus emission of " useless paren" warning for  directive invocations

### DIFF
--- a/compiler/hash-parser/src/parser/expr.rs
+++ b/compiler/hash-parser/src/parser/expr.rs
@@ -759,14 +759,18 @@ impl AstGen<'_> {
             // set to `None` and that there are no extra tokens that are left within
             // the token tree...
             if entry.name.is_none() && !gen.has_token() {
-                let expr = entry.into_body().value;
+                let body = entry.into_body();
+                let expr = body.value;
+                let has_macro_invocations = body.macros.is_some();
 
                 // We want to emit a redundant parentheses warning if it is not a binary-like
                 // expression since it does not affect the precedence...
-                if !matches!(
-                    expr.body(),
-                    Expr::BinaryExpr(_) | Expr::Cast(_) | Expr::FnDef(_) | Expr::Deref(_)
-                ) {
+                if !has_macro_invocations
+                    && !matches!(
+                        expr.body(),
+                        Expr::BinaryExpr(_) | Expr::Cast(_) | Expr::FnDef(_) | Expr::Deref(_)
+                    )
+                {
                     gen.add_warning(ParseWarning::new(
                         WarningKind::RedundantParenthesis(expr.body().into()),
                         gen.make_span(gen.range()),

--- a/tests/cases/parser/attributes/parenthesised_attribute_calls.hash
+++ b/tests/cases/parser/attributes/parenthesised_attribute_calls.hash
@@ -1,4 +1,4 @@
-// stage=parse, run=pass, warnings=compare
+// stage=parse, run=pass, warnings=disallow
 
 
 priv create_buf := <T> => (size: usize) -> [T] => {

--- a/tests/cases/parser/attributes/parenthesised_attribute_calls.hash
+++ b/tests/cases/parser/attributes/parenthesised_attribute_calls.hash
@@ -1,0 +1,10 @@
+// stage=parse, run=pass, warnings=compare
+
+
+priv create_buf := <T> => (size: usize) -> [T] => {
+    // We should not get an warning about redundant parens here since
+    // this has a useful effect of clarifying the application of the
+    // function.
+    buf := libc::malloc((#size_of T) * size);
+    transmute<_, [T]>(buf)
+}

--- a/tests/cases/parser/attributes/parenthesised_attribute_calls.stderr
+++ b/tests/cases/parser/attributes/parenthesised_attribute_calls.stderr
@@ -1,6 +1,0 @@
-warn: unnecessary parentheses around expression
- --> $DIR/parenthesised_attribute_calls.hash:8:25
-7 |       // function.
-8 |       buf := libc::malloc((#size_of T) * size);
-  |                           ^^^^^^^^^^^^ 
-9 |       transmute<_, [T]>(buf)

--- a/tests/cases/parser/attributes/parenthesised_attribute_calls.stderr
+++ b/tests/cases/parser/attributes/parenthesised_attribute_calls.stderr
@@ -1,0 +1,6 @@
+warn: unnecessary parentheses around expression
+ --> $DIR/parenthesised_attribute_calls.hash:8:25
+7 |       // function.
+8 |       buf := libc::malloc((#size_of T) * size);
+  |                           ^^^^^^^^^^^^ 
+9 |       transmute<_, [T]>(buf)

--- a/tests/runner.rs
+++ b/tests/runner.rs
@@ -268,7 +268,8 @@ fn handle_pass_case(
 
     if !did_pass {
         panic!(
-            "\ntest case did not pass:\n{}",
+            "\ntest case did not pass:\nconfiguration: {:?}\n\n{}",
+            test.metadata,
             diagnostics
                 .into_iter()
                 .map(|report| format!("{}", report))


### PR DESCRIPTION
We prevent the parser from emitting useless parenthesis warnings for macro invocations:
```
warn: unnecessary parentheses around expression
 --> tests/cases/parser/attributes/parenthesised_attribute_calls.hash:8:25
7 |       // function.
8 |       buf := libc::malloc((#size_of T) * size);
  |                           ^^^^^^^^^^^^ 
9 |       transmute<_, [T]>(buf)
```

After this PR, we no longer emit these.