### PR TITLE
Implement `input` prelude function

### DIFF
--- a/compiler/hash-codegen/src/lower/rvalue.rs
+++ b/compiler/hash-codegen/src/lower/rvalue.rs
@@ -345,6 +345,12 @@ impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
                     (CastTy::Int(in_ty), CastTy::Int(_)) => {
                         builder.int_cast(value, out_ty, in_ty.is_signed())
                     }
+                    (CastTy::Ref, CastTy::Int(IntCastKind::UInt)) => {
+                        builder.ptr_to_int(value, out_ty)
+                    }
+                    (CastTy::Int(IntCastKind::UInt), CastTy::Ref) => {
+                        builder.int_to_ptr(value, out_ty)
+                    }
                     (CastTy::Int(in_ty), CastTy::Float) => {
                         if in_ty.is_signed() {
                             builder.si_to_fp(value, out_ty)
@@ -367,6 +373,9 @@ impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
                             Ordering::Greater => builder.fp_truncate(value, out_ty),
                             Ordering::Equal => value,
                         }
+                    }
+                    _ => {
+                        unreachable!("invalid cast from `{:?}` to `{:?}`", in_cast_ty, out_cast_ty)
                     }
                 };
 

--- a/stdlib/prelude.hash
+++ b/stdlib/prelude.hash
@@ -55,6 +55,50 @@ println := (message: str) => {
     print("\n")
 }
 
+/// The `input` function, this allows for reading of strings from the
+/// standard input.
+input := (prompt: Option<str>) -> str => {
+    STDIN := 0 // We need top level constants!
+
+    match prompt {
+        Option::Some(value) => print(value),
+        Option::None => {}
+    }
+
+    buf := libc::malloc(1024);
+    mut offset := 0usize
+
+    // Now let's read in an input using syscall.
+    loop {
+        left := libc::read(STDIN, buf, 1024)
+
+        if left <= 0 {
+            break;
+        }
+
+        offset += cast<_, usize>(left)
+
+        // if the last read character was a `\n`, then we want to
+        // break.
+        //
+        // @@Todo: we need to be able to index into an array.
+        arr := transmute<_, [u8]>(SizedPointer(buf, offset));
+        last_char := cast<_, char>(arr[offset - 1]);
+        if last_char == '\n' {
+            break;
+        }
+    }
+
+    // Don't remove the newline in the end.
+    if offset > 1 {
+        offset -= 1
+    }
+
+    // Now transmute the buffer into a string
+    raw_str := SizedPointer(buf, offset);
+    transmute<SizedPointer, str>(raw_str)
+}
+
 refl := <T, a: T> => () -> {a ~ a} => {
     Equal::Refl(a)
 }


### PR DESCRIPTION
Add `input` function implementation to the prelude.

In order for this implementation to work, we needed to implement the
ability for the compiler to support `ref` to `int` and `int` to `ref` casts.
