### PR TITLE
Upgrade compiler toolchain & dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
@@ -34,9 +34,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -49,44 +49,44 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
- "once_cell",
- "windows-sys",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.97"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
 name = "arrayvec"
@@ -96,15 +96,15 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -112,7 +112,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -123,15 +123,15 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bumpalo-herd"
@@ -144,9 +144,9 @@ dependencies = [
 
 [[package]]
 name = "bytecount"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "byteorder"
@@ -168,18 +168,19 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.19"
+version = "1.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
+checksum = "65193589c6404eb80b450d618eaf9a2cafaaafd57ecce47370519ef674a7bd44"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "ciborium"
@@ -210,9 +211,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.36"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2df961d8c8a0d08aa9945718ccf584145eee3f3aa06cddbeac12933781102e04"
+checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -220,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.36"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "132dbda40fb6753878316a489d5a1242a8ef2f0d9e47ba01c951ea8aa7d013a5"
+checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -232,27 +233,27 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.32"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "const_format"
@@ -294,25 +295,22 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
 dependencies = [
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "num-traits",
- "once_cell",
  "oorandom",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -320,12 +318,12 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
 dependencies = [
  "cast",
- "itertools 0.10.5",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -364,9 +362,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "darling"
@@ -389,7 +387,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.100",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -400,7 +398,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -435,7 +433,7 @@ dependencies = [
  "convert_case 0.7.1",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.106",
  "unicode-xid",
 ]
 
@@ -447,9 +445,9 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -475,12 +473,12 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -488,6 +486,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
 
 [[package]]
 name = "fixedbitset"
@@ -512,22 +516,23 @@ dependencies = [
 
 [[package]]
 name = "generator"
-version = "0.8.4"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6bd114ceda131d3b1d665eba35788690ad37f5916457286b32ab6fd3c438dd"
+checksum = "605183a538e3e2a9c1038635cc5c2d194e2ee8fd0d1b66b8349fad7dbacce5a2"
 dependencies = [
+ "cc",
  "cfg-if",
  "libc",
  "log",
  "rustversion",
- "windows 0.58.0",
+ "windows 0.61.3",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "libc",
@@ -994,7 +999,7 @@ dependencies = [
  "proc-macro-error",
  "quote",
  "regex",
- "syn 2.0.100",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1083,7 +1088,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1155,7 +1160,7 @@ dependencies = [
  "smallvec",
  "stacker",
  "thin-vec",
- "windows 0.61.1",
+ "windows 0.62.0",
 ]
 
 [[package]]
@@ -1175,9 +1180,9 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
 name = "hashc"
@@ -1192,7 +1197,7 @@ dependencies = [
  "hash-target",
  "hash-utils",
  "profiling",
- "tracy-client 0.18.0",
+ "tracy-client",
 ]
 
 [[package]]
@@ -1203,15 +1208,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.9"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
-
-[[package]]
-name = "hermit-abi"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "html-escape"
@@ -1236,12 +1235,12 @@ checksum = "44faf5bb8861a9c72e20d3fb0fdbd59233e43056e2b80475ab0aacdc2e781355"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "206a8042aec68fa4a62e8d3f7aa4ceb508177d9324faf261e1959e495b7a1921"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.5",
  "serde",
 ]
 
@@ -1265,18 +1264,7 @@ source = "git+https://github.com/hash-org/inkwell.git?branch=master#0e93c469ea78
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
-dependencies = [
- "hermit-abi 0.5.0",
- "libc",
- "windows-sys",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1287,9 +1275,9 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -1311,9 +1299,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "0c0b063578492ceec17683ef2f8c5e89121fbd0b172cbc280635ab7567db2738"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1327,9 +1315,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "line-span"
@@ -1339,9 +1327,9 @@ checksum = "29fc123b2f6600099ca18248f69e3ee02b09c4188c0d98e9a690d90dec3e408a"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "llvm-sys"
@@ -1359,9 +1347,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1369,9 +1357,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 dependencies = [
  "serde",
  "value-bag",
@@ -1392,36 +1380,35 @@ dependencies = [
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
 ]
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1442,7 +1429,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1465,33 +1452,34 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
 ]
 
 [[package]]
 name = "num_enum"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
 dependencies = [
  "num_enum_derive",
+ "rustversion",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1510,22 +1498,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
 name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
-
-[[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1533,15 +1521,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1552,42 +1540,43 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "phf"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
  "phf_macros",
  "phf_shared",
+ "serde",
 ]
 
 [[package]]
 name = "phf_generator"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
+ "fastrand",
  "phf_shared",
- "rand",
 ]
 
 [[package]]
 name = "phf_macros"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
  "phf_generator",
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "phf_shared"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]
@@ -1671,38 +1660,38 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "profiling"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afbdc74edc00b6f6a218ca6a5364d6226a259d4b8ea1af4a0ea063f27e179f4d"
+checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
 dependencies = [
  "profiling-procmacros",
- "tracy-client 0.17.6",
+ "tracy-client",
 ]
 
 [[package]]
 name = "profiling-procmacros"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a65f2e60fbf1063868558d69c6beacf412dc755f9fc020f514b7955fc914fe30"
+checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
 dependencies = [
  "quote",
- "syn 2.0.100",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "psm"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58e5423e24c18cc840e1c98370b3993c6649cd1678b4d24318bcf0a083cbe88"
+checksum = "6e944464ec8536cd1beb0bbfd96987eb5e3b72f2ecdafdc5c769a37f1fa2ae1f"
 dependencies = [
  "cc",
 ]
@@ -1724,30 +1713,15 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rayon"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
@@ -1755,9 +1729,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -1765,93 +1739,98 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.11"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.1.10"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
 
 [[package]]
 name = "regex-lite"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+checksum = "943f41321c63ef1c92fd763bfe054d2668f7f225a5c29f0105903dc2fc04ba30"
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.29"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "replace_with"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a8614ee435691de62bcffcf4a66d91b3594bf1428a5722e79103249a095690"
+checksum = "51743d3e274e2b18df81c4dc6caf8a5b8e15dbe799e0dca05c7617380094e884"
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustix"
-version = "1.0.5"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-fork"
@@ -1882,12 +1861,13 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.22"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
 dependencies = [
  "dyn-clone",
  "indexmap",
+ "ref-cast",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -1895,14 +1875,14 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.22"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+checksum = "33d020396d1d138dc19f1165df7545479dcd58d93810dc5d646a16e55abefa80"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.100",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1940,7 +1920,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1951,7 +1931,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1965,9 +1945,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
  "itoa",
  "memchr",
@@ -1998,9 +1978,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smawk"
@@ -2010,15 +1990,15 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "stacker"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601f9201feb9b09c00266478bf459952b9ef9a6b94edb2f21eba14ab681a60a9"
+checksum = "cddb07e32ddb770749da91081d8d0ac3a16f1a569a18b20348cd371f5dead06b"
 dependencies = [
  "cc",
  "cfg-if",
  "libc",
  "psm",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2029,15 +2009,14 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum_macros"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "rustversion",
- "syn 2.0.100",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2130,9 +2109,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2141,15 +2120,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.19.1"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+checksum = "84fa4d11fadde498443cca10fd3ac23c951f0dc59e080e9f4b93d4df4e4eea53"
 dependencies = [
  "fastrand",
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -2186,17 +2165,16 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -2211,9 +2189,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2226,15 +2204,15 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 
 [[package]]
 name = "toml_edit"
-version = "0.22.24"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -2253,9 +2231,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
@@ -2274,14 +2252,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -2292,20 +2270,9 @@ dependencies = [
 
 [[package]]
 name = "tracy-client"
-version = "0.17.6"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73202d787346a5418f8222eddb5a00f29ea47caf3c7d38a8f2f69f8455fa7c7e"
-dependencies = [
- "loom",
- "once_cell",
- "tracy-client-sys",
-]
-
-[[package]]
-name = "tracy-client"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d90a2c01305b02b76fdd89ac8608bae27e173c829a35f7d76a345ab5d33836db"
+checksum = "ef54005d3d760186fd662dad4b7bb27ecd5531cdef54d1573ebd3f20a9205ed7"
 dependencies = [
  "loom",
  "once_cell",
@@ -2314,32 +2281,32 @@ dependencies = [
 
 [[package]]
 name = "tracy-client-sys"
-version = "0.24.3"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69fff37da548239c3bf9e64a12193d261e8b22b660991c6fd2df057c168f435f"
+checksum = "319c70195101a93f56db4c74733e272d720768e13471f400c78406a326b172b0"
 dependencies = [
  "cc",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "typed-builder"
-version = "0.21.0"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce63bcaf7e9806c206f7d7b9c1f38e0dce8bb165a80af0898161058b19248534"
+checksum = "fef81aec2ca29576f9f6ae8755108640d0a86dd3161b2e8bca6cfa554e98f77d"
 dependencies = [
  "typed-builder-macro",
 ]
 
 [[package]]
 name = "typed-builder-macro"
-version = "0.21.0"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60d8d828da2a3d759d3519cdf29a5bac49c77d039ad36d0782edadbf9cd5415b"
+checksum = "1ecb9ecf7799210407c14a8cfdfe0173365780968dc57973ed082211958e0b18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2350,9 +2317,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "unicode-linebreak"
@@ -2377,9 +2344,9 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "unicode-xid"
@@ -2408,7 +2375,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2480,44 +2447,54 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+version = "0.14.5+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "a4494f6290a82f5fe584817a676a34b9d6763e8d9d18204009fb31dceca98fd4"
 dependencies = [
- "wit-bindgen-rt",
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.0+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03fa2761397e5bd52002cd7e73110c71af2109aca4e521a9f40473fe685b0a24"
+dependencies = [
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "7e14915cadd45b529bb8d1f343c4ed0ac1de926144b746e2710f9cd05df6603b"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+checksum = "e28d1ba982ca7923fd01448d5c30c6864d0a14109560296a162f80f305fb93bb"
 dependencies = [
  "bumpalo",
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.106",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "7c3d463ae3eff775b0c45df9da45d68837702ac35af998361e2c84e7c5ec1b0d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2525,88 +2502,69 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "7bb4ce89b08211f923caf51d527662b75bdc9c9c7aab40f86dcb9fb85ac552aa"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.106",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "f143854a3b13752c6950862c906306adb27c7e839f7414cec8fea35beab624c1"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "77e4b637749ff0d92b8fad63aa1f7cff3cbe125fd49c175cd6345e7272638b12"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
-]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
-dependencies = [
- "windows-core 0.58.0",
- "windows-targets",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
 name = "windows"
-version = "0.61.1"
+version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5ee8f3d025738cb02bad7868bbb5f8a6327501e870bf51f1b455b0a2454a419"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
- "windows-core 0.61.0",
- "windows-future",
- "windows-link",
- "windows-numerics",
+ "windows-collections 0.2.0",
+ "windows-core 0.61.2",
+ "windows-future 0.2.1",
+ "windows-link 0.1.3",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9579d0e6970fd5250aa29aba5994052385ff55cf7b28a059e484bb79ea842e42"
+dependencies = [
+ "windows-collections 0.3.0",
+ "windows-core 0.62.0",
+ "windows-future 0.3.0",
+ "windows-link 0.2.0",
+ "windows-numerics 0.3.0",
 ]
 
 [[package]]
@@ -2615,54 +2573,64 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core 0.61.0",
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a90dd7a7b86859ec4cdf864658b311545ef19dbcf17a672b52ab7cefe80c336f"
+dependencies = [
+ "windows-core 0.62.0",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.58.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement 0.58.0",
- "windows-interface 0.58.0",
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
- "windows-targets",
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.61.0"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
+checksum = "57fe7168f7de578d2d8a05b07fd61870d2e73b4020e9f49aa00da8471723497c"
 dependencies = [
- "windows-implement 0.60.0",
- "windows-interface 0.59.1",
- "windows-link",
- "windows-result 0.3.2",
- "windows-strings 0.4.0",
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.0",
+ "windows-result 0.4.0",
+ "windows-strings 0.5.0",
 ]
 
 [[package]]
 name = "windows-future"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1d6bbefcb7b60acd19828e1bc965da6fcf18a7e39490c5f8be71e54a19ba32"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core 0.61.0",
- "windows-link",
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading 0.1.0",
 ]
 
 [[package]]
-name = "windows-implement"
-version = "0.58.0"
+name = "windows-future"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+checksum = "b2194dee901458cb79e1148a4e9aac2b164cc95fa431891e7b296ff0b2f1d8a6"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
+ "windows-core 0.62.0",
+ "windows-link 0.2.0",
+ "windows-threading 0.2.0",
 ]
 
 [[package]]
@@ -2673,18 +2641,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2695,14 +2652,20 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 
 [[package]]
 name = "windows-numerics"
@@ -2710,45 +2673,63 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core 0.61.0",
- "windows-link",
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ce3498fe0aba81e62e477408383196b4b0363db5e0c27646f932676283b43d8"
+dependencies = [
+ "windows-core 0.62.0",
+ "windows-link 0.2.0",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.2.0"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-targets",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
-dependencies = [
- "windows-result 0.2.0",
- "windows-targets",
-]
-
-[[package]]
-name = "windows-strings"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.0",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
+dependencies = [
+ "windows-link 0.2.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2757,7 +2738,25 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+dependencies = [
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -2766,14 +2765,49 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab47f085ad6932defa48855254c758cdd0e2f2d48e62a34118a268d8f345e118"
+dependencies = [
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -2783,10 +2817,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2795,10 +2841,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2807,10 +2865,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2819,28 +2889,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "0.7.6"
+name = "windows_x86_64_msvc"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wit-bindgen"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags",
-]
+checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,58 +69,58 @@ hash-testing-internal = { path = "tests/testing-internal" }
 hash-testing-macros = { path = "tests/testing-macros" }
 
 # External dependencies
-arrayvec = "0.7.2"
+arrayvec = "0.7.6"
 backtrace = "0.3"
-bimap = "0.6.2"
-bitflags = "2.4.0"
-bumpalo = "3.7"
+bimap = "0.6.3"
+bitflags = "2.9.4"
+bumpalo = "3.19"
 bumpalo-herd = "0.1"
-bytecount = "0.6.3"
-cc = "1.0.69"
-clap = { version = "4.3.8", features = ["derive"] }
-const_format = "0.2.30"                                           # for concatenating strings together at compile time.
+bytecount = "0.6.9"
+cc = "1.2.37"
+clap = { version = "4.5.47", features = ["derive"] }
+const_format = "0.2.34"
 convert_case = "0.8"
-crossbeam-channel = "0.5.1"
+crossbeam-channel = "0.5.15"
 dashmap = "6.1"
 derive_more = { version = "2.0", features = ["full"] }
 fixedbitset = "0.5.7"
 fnv = "1.0.7"
 fxhash = "0.2.1"
-html-escape = "0.2.12"
-index_vec = "0.1.3"
-indexmap = { version = "2.9.0", features = ["serde"] }
+html-escape = "0.2.13"
+index_vec = "0.1.4"
+indexmap = { version = "2.11.1", features = ["serde"] }
 itertools = "0.14.0"
-lazy_static = "1.4.0"
+lazy_static = "1.5.0"
 libc = "0.2"
 line-span = "0.1.5"
 log = { version = "0.4", features = ["kv_unstable", "kv_serde"] }
-num_cpus = "1.13.0"
+num_cpus = "1.17.0"
 num_enum = "0.7"
 num-bigint = "0.4"
-num-derive = "0.4.0"
-num-traits = "0.2.15"
-once_cell = "1.17"
+num-derive = "0.4.2"
+num-traits = "0.2.19"
+once_cell = "1.21"
 parking_lot = "0.12"
-paste = "1.0.14"
-phf = { version = "0.11", features = ["macros"] }
-proc-macro2 = "1.0.63"
-profiling = "1.0.6"
+paste = "1.0.15"
+phf = { version = "0.13.1", features = ["macros"] }
+proc-macro2 = "1.0.101"
+profiling = "1.0.17"
 quote = "1.0"
-rayon = "1.5.0"
-replace_with = "0.1.7"
-schemars = { version = "0.8.16", features = ["indexmap2"] }
-serde = { version = "1.0.202", features = ["derive"] }
-serde_json = "1.0.117"
-smallvec = "1.11.0"
-stacker = "0.1.15"
+rayon = "1.11.0"
+replace_with = "0.1.8"
+schemars = { version = "1.0.4", features = ["indexmap2"] }
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.143"
+smallvec = "1.15.1"
+stacker = "0.1.21"
 strum_macros = "0.27"
 syn = { version = "2.0", features = ["extra-traits", "full"] }
 textwrap = "0.16"
-thin-vec = "0.2.10"
-tracy-client = "0.18.0"
+thin-vec = "0.2.14"
+tracy-client = "0.18.2"
 typed-builder = "0.21"
-unicode-normalization = "0.1.22"
+unicode-normalization = "0.1.24"
 utility-types = "0.0.4"
-proc-macro-error = "1.0.0"
-regex = "1.5"
-pretty_assertions = "1.2.1"
+proc-macro-error = "1.0.4"
+regex = "1.11"
+pretty_assertions = "1.4.1"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -24,12 +24,12 @@ This will build the compiler without the `llvm` feature, and hence you won't hav
 ### Linux, macOS
 
 You can download this version of LLVM from
-[here](https://github.com/llvm/llvm-project/releases/tag/llvmorg-15.0.6) for
+[here](https://github.com/llvm/llvm-project/releases/tag/llvmorg-18.1.8) for
 your specific OS. Additionally, you need to install `zstd`  (which can be
 aquired using a package manager or from
 [here](https://github.com/facebook/zstd/releases/tag/v1.5.5)).
 
-Once LLVM 15.0.6 and `zstd` are installed, you need to set the following
+Once LLVM 18.1.8 and `zstd` are installed, you need to set the following
 environment variables, replacing `$PATH_TO_LLVM` and `$PATH_TO_ZSTD`
 appropriately for your system depending on your installation:
 
@@ -40,7 +40,7 @@ export DYLD_LIBRARY_PATH="$DYLD_LIBRARY_PATH:$PATH_TO_LLVM/lib"
 export LDFLAGS="-L$PATH_TO_LLVM/lib"
 export CPPFLAGS="-I$PATH_TO_LLVM/include"
 export PATH="$PATH:$PATH_TO_LLVM/bin"
-export LLVM_SYS_150_PREFIX="$PATH_TO_LLVM"
+export LLVM_SYS_181_PREFIX="$PATH_TO_LLVM"
 ```
 
 This can be put in your shell script startup file
@@ -55,7 +55,7 @@ To install on Windows, the simplest way to install it is using
 [Chocolatey](https://chocolatey.org/):
 
 ```pwsh
-choco install llvm --version 15.0.6
+choco install llvm --version 18.1.8
 ```
 
 Alternatively, you can download the pre-built binaries from the [LLVM

--- a/compiler/hash-ast-desugaring/src/lib.rs
+++ b/compiler/hash-ast-desugaring/src/lib.rs
@@ -32,7 +32,7 @@ pub struct AstDesugaringCtx<'a> {
 }
 
 pub trait AstDesugaringCtxQuery: CompilerInterface {
-    fn data(&mut self) -> AstDesugaringCtx;
+    fn data(&mut self) -> AstDesugaringCtx<'_>;
 }
 
 impl<Ctx: AstDesugaringCtxQuery> CompilerStage<Ctx> for AstDesugaringPass {

--- a/compiler/hash-ast-expand/src/lib.rs
+++ b/compiler/hash-ast-expand/src/lib.rs
@@ -47,7 +47,7 @@ pub struct AstExpansionCtx<'ctx> {
 /// A trait that allows the [AstExpansionPass] stage to query the
 /// pipeline for the required information.
 pub trait AstExpansionCtxQuery: CompilerInterface {
-    fn data(&mut self) -> AstExpansionCtx;
+    fn data(&mut self) -> AstExpansionCtx<'_>;
 }
 
 impl<Ctx: AstExpansionCtxQuery> CompilerStage<Ctx> for AstExpansionPass {

--- a/compiler/hash-ast-expand/src/lib.rs
+++ b/compiler/hash-ast-expand/src/lib.rs
@@ -1,7 +1,6 @@
 //! Hash AST expanding passes crate. This crate holds an implementation for the
 //! visitor pattern on the AST in order to expand any directives or macros that
 //! need to run after the parsing stage. Currently this function does not have
-#![feature(let_chains)]
 
 use diagnostics::ExpansionDiagnostic;
 use expander::AstExpander;

--- a/compiler/hash-ast-utils/src/lib.rs
+++ b/compiler/hash-ast-utils/src/lib.rs
@@ -2,7 +2,6 @@
 //! crate defines AST printing functionalities, including the `tree` view
 //! and the `pretty` printing view, in addition to the implementation of
 //! the `#dump_ast` directive.
-#![feature(let_chains)]
 #![allow(dead_code)]
 
 pub mod attr;

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -238,12 +238,12 @@ impl<T> AstNode<T> {
     }
 
     /// Create an [AstNodeRef] from this [AstNode].
-    pub fn ast_ref(&self) -> AstNodeRef<T> {
+    pub fn ast_ref(&self) -> AstNodeRef<'_, T> {
         AstNodeRef { body: self.body.as_ref(), id: self.id }
     }
 
     /// Create an [AstNodeRefMut] from this [AstNode].
-    pub fn ast_ref_mut(&mut self) -> AstNodeRefMut<T> {
+    pub fn ast_ref_mut(&mut self) -> AstNodeRefMut<'_, T> {
         AstNodeRefMut { body: self.body.as_mut(), id: self.id }
     }
 
@@ -350,7 +350,7 @@ impl<'t, T> AstNodeRefMut<'t, T> {
     }
 
     /// Get this node as an immutable reference
-    pub fn immutable(&self) -> AstNodeRef<T> {
+    pub fn immutable(&self) -> AstNodeRef<'_, T> {
         AstNodeRef::new(self.body, self.id)
     }
 }
@@ -378,12 +378,12 @@ pub trait OwnsAstNode<T> {
     fn node_mut(&mut self) -> &mut AstNode<T>;
 
     /// Get a [AstNodeRef<T>].
-    fn node_ref(&self) -> AstNodeRef<T> {
+    fn node_ref(&self) -> AstNodeRef<'_, T> {
         self.node().ast_ref()
     }
 
     /// Get a [AstNodeRefMut<T>].
-    fn node_ref_mut(&mut self) -> AstNodeRefMut<T> {
+    fn node_ref_mut(&mut self) -> AstNodeRefMut<'_, T> {
         self.node_mut().ast_ref_mut()
     }
 }
@@ -452,7 +452,7 @@ impl<T> AstNodes<T> {
     }
 
     /// Iterate over each child whilst wrapping it in a [AstNodeRef].
-    pub fn ast_ref_iter(&self) -> impl Iterator<Item = AstNodeRef<T>> {
+    pub fn ast_ref_iter(&self) -> impl Iterator<Item = AstNodeRef<'_, T>> {
         self.nodes.iter().map(|x| x.ast_ref())
     }
 }
@@ -1596,7 +1596,7 @@ define_tree! {
     impl BodyBlock {
         /// Get the members of the body block: the list of statements as well as the
         /// optional ending expression.
-        pub fn members(&self) -> impl Iterator<Item = AstNodeRef<Expr>> + '_ {
+        pub fn members(&self) -> impl Iterator<Item = AstNodeRef<'_, Expr>> + '_ {
             self.statements.ast_ref_iter().chain(self.expr.as_ref().map(|x| x.ast_ref()))
         }
     }

--- a/compiler/hash-ast/src/lib.rs
+++ b/compiler/hash-ast/src/lib.rs
@@ -1,6 +1,6 @@
 //! Hash Compiler AST library file
 
-#![feature(box_into_inner, iter_intersperse, let_chains)]
+#![feature(box_into_inner, iter_intersperse)]
 
 pub mod ast;
 pub mod node_map;

--- a/compiler/hash-ast/src/node_map.rs
+++ b/compiler/hash-ast/src/node_map.rs
@@ -186,12 +186,12 @@ impl NodeMap {
     }
 
     /// /// Create an [Iter] over the currently stores modules within [NodeMap]
-    pub fn iter_modules(&self) -> Iter<ModuleId, ModuleEntry> {
+    pub fn iter_modules(&self) -> Iter<'_, ModuleId, ModuleEntry> {
         self.modules.iter()
     }
 
     /// Create an [IterMut] over the currently stores modules within [NodeMap].
-    pub fn iter_mut_modules(&mut self) -> IterMut<ModuleId, ModuleEntry> {
+    pub fn iter_mut_modules(&mut self) -> IterMut<'_, ModuleId, ModuleEntry> {
         self.modules.iter_mut()
     }
 }

--- a/compiler/hash-attrs/src/lib.rs
+++ b/compiler/hash-attrs/src/lib.rs
@@ -1,6 +1,6 @@
 //! All of the defined logic and data structures for attribute management in the
 //! Hash compiler.
-#![feature(let_chains, macro_metavar_expr)]
+#![feature(macro_metavar_expr)]
 
 pub mod attr;
 pub mod builtin;

--- a/compiler/hash-attrs/src/ty.rs
+++ b/compiler/hash-attrs/src/ty.rs
@@ -173,10 +173,10 @@ fn repr_ty_from_primitive_ctor(ctor: PrimitiveCtorInfo) -> Option<ReprTyId> {
 /// attributes can only be literals, therefore we can rely on this method to
 /// lower the supported subset of types.
 pub fn repr_ty_from_primitive_ty(ty: TyId) -> Option<ReprTyId> {
-    if let Ty::DataTy(DataTy { data_def, .. }) = ty.value().data {
-        if let DataDefCtors::Primitive(ctor) = data_def.value().ctors {
-            return repr_ty_from_primitive_ctor(ctor);
-        }
+    if let Ty::DataTy(DataTy { data_def, .. }) = ty.value().data
+        && let DataDefCtors::Primitive(ctor) = data_def.value().ctors
+    {
+        return repr_ty_from_primitive_ctor(ctor);
     }
 
     None

--- a/compiler/hash-codegen-llvm/Cargo.toml
+++ b/compiler/hash-codegen-llvm/Cargo.toml
@@ -11,7 +11,7 @@ doctest = false
 # We make an exclusion to the `{ workspace = true }` rule as we want to fully encapsulate
 # the LLVM dependency in this crate. This is to enforce no other crate to depend on
 # LLVM directly, as we want to keep the dependency tree clean and avoid version conflicts.
-llvm-sys = "181.1.0"
+llvm-sys = "181.2.0"
 inkwell = { git = "https://github.com/hash-org/inkwell.git", branch = "master", features = [
     "llvm18-0",
 ] }

--- a/compiler/hash-codegen-llvm/src/lib.rs
+++ b/compiler/hash-codegen-llvm/src/lib.rs
@@ -5,7 +5,6 @@
 //! which is the actual implementation of the LLVM backend. It is expected that
 //! the backend performs it's work in the [LLVMBackend::run] method, and saves
 //! the results of each module in the [Workspace].
-#![feature(let_chains)]
 
 mod ctx;
 mod error;

--- a/compiler/hash-codegen-llvm/src/translation/abi.rs
+++ b/compiler/hash-codegen-llvm/src/translation/abi.rs
@@ -410,18 +410,18 @@ impl<'b, 'm> ExtendedFnAbiMethods<'b, 'm> for FnAbi {
 
         let abi = self.ret_abi.info.layout.borrow().abi;
 
-        if let AbiRepresentation::Scalar(scalar) = abi {
-            if let ScalarKind::Int { .. } = scalar.kind() {
-                // ##Hack: if the value is boolean, the range metadata would become
-                // 0..0 due to the fact that the type of it is `i1`. This would be rejected
-                // by the LLVM IR verifier... so we don't add the range metadata for
-                // boolean types.
-                if !scalar.is_bool() && !scalar.is_always_valid(builder) {
-                    builder.add_range_metadata_to(
-                        call_site.as_any_value_enum(),
-                        scalar.valid_range(builder),
-                    )
-                }
+        if let AbiRepresentation::Scalar(scalar) = abi
+            && let ScalarKind::Int { .. } = scalar.kind()
+        {
+            // ##Hack: if the value is boolean, the range metadata would become
+            // 0..0 due to the fact that the type of it is `i1`. This would be rejected
+            // by the LLVM IR verifier... so we don't add the range metadata for
+            // boolean types.
+            if !scalar.is_bool() && !scalar.is_always_valid(builder) {
+                builder.add_range_metadata_to(
+                    call_site.as_any_value_enum(),
+                    scalar.valid_range(builder),
+                )
             }
         }
 

--- a/compiler/hash-codegen-llvm/src/translation/builder.rs
+++ b/compiler/hash-codegen-llvm/src/translation/builder.rs
@@ -1285,10 +1285,9 @@ fn load_scalar_value_metadata<'m>(
             // Compute the layout of the pointee_ty
             if let Some(pointee_info) =
                 builder.layouts().compute_layout_info_of_pointee_at(info, offset)
+                && pointee_info.kind.is_some()
             {
-                if pointee_info.kind.is_some() {
-                    builder.set_alignment(load, pointee_info.alignment);
-                }
+                builder.set_alignment(load, pointee_info.alignment);
             }
         }
     }

--- a/compiler/hash-codegen-llvm/src/translation/constants.rs
+++ b/compiler/hash-codegen-llvm/src/translation/constants.rs
@@ -222,7 +222,7 @@ impl<'b> ConstValueBuilderMethods<'b> for CodeGenCtx<'b, '_> {
             if sign_extend {
                 val.get_sign_extended_constant().map(|v| {
                     // upcast to i128, and then convert into u128
-                    unsafe { std::mem::transmute::<i128, u128>(v as i128) }
+                    i128::cast_unsigned(v as i128)
                 })
             } else {
                 val.get_zero_extended_constant().map(|v| v as u128)

--- a/compiler/hash-codegen-llvm/src/translation/ty.rs
+++ b/compiler/hash-codegen-llvm/src/translation/ty.rs
@@ -346,13 +346,13 @@ impl<'m> ExtendedTyBuilderMethods<'m> for TyInfo {
 
                                     // If we have a specific variant for this layout, then we
                                     // can be more precise about the type name..
-                                    if let Variants::Single { index } = &layout.variants {
-                                        if adt.flags.is_enum() {
-                                            return Some(format!(
-                                                "{}::{}",
-                                                name, adt.variants[*index].name
-                                            ));
-                                        }
+                                    if let Variants::Single { index } = &layout.variants
+                                        && adt.flags.is_enum()
+                                    {
+                                        return Some(format!(
+                                            "{}::{}",
+                                            name, adt.variants[*index].name
+                                        ));
                                     }
 
                                     Some(format!("{name}"))

--- a/compiler/hash-codegen/src/lib.rs
+++ b/compiler/hash-codegen/src/lib.rs
@@ -18,7 +18,7 @@
 //! artifacts since it will run the bytecode directly using the VM. On the other
 //! hand, LLVM backend will emit a runnable executable after the code is
 //! generated.
-#![feature(let_chains, box_patterns, variant_count)]
+#![feature(box_patterns, variant_count)]
 
 pub mod backend;
 pub mod common;

--- a/compiler/hash-codegen/src/lower/rvalue.rs
+++ b/compiler/hash-codegen/src/lower/rvalue.rs
@@ -660,15 +660,15 @@ impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
     /// [Place]. This computes the value and returns a [`Builder::Value`]
     /// from it.
     fn evaluate_array_len(&mut self, builder: &mut Builder, place: ir::Place) -> Builder::Value {
-        if let Some(local) = place.as_local() {
-            if let LocalRef::Operand(Some(op)) = self.locals[local] {
-                let size = op.info.ty.map(|ty| {
-                    if let ty::ReprTy::Array { length: size, .. } = ty { Some(*size) } else { None }
-                });
+        if let Some(local) = place.as_local()
+            && let LocalRef::Operand(Some(op)) = self.locals[local]
+        {
+            let size = op.info.ty.map(|ty| {
+                if let ty::ReprTy::Array { length: size, .. } = ty { Some(*size) } else { None }
+            });
 
-                if let Some(size) = size {
-                    return builder.const_usize(size as u64);
-                }
+            if let Some(size) = size {
+                return builder.const_usize(size as u64);
             }
         }
 

--- a/compiler/hash-driver/src/lib.rs
+++ b/compiler/hash-driver/src/lib.rs
@@ -285,25 +285,25 @@ impl CompilerInterface for Compiler {
 }
 
 impl ParserCtxQuery for Compiler {
-    fn data(&mut self) -> ParserCtx {
+    fn data(&mut self) -> ParserCtx<'_> {
         ParserCtx { workspace: &mut self.workspace, pool: &self.pool }
     }
 }
 
 impl AstDesugaringCtxQuery for Compiler {
-    fn data(&mut self) -> AstDesugaringCtx {
+    fn data(&mut self) -> AstDesugaringCtx<'_> {
         AstDesugaringCtx { workspace: &mut self.workspace, pool: &self.pool }
     }
 }
 
 impl UntypedSemanticAnalysisCtxQuery for Compiler {
-    fn data(&mut self) -> UntypedSemanticAnalysisCtx {
+    fn data(&mut self) -> UntypedSemanticAnalysisCtx<'_> {
         UntypedSemanticAnalysisCtx { workspace: &mut self.workspace, pool: &self.pool }
     }
 }
 
 impl AstExpansionCtxQuery for Compiler {
-    fn data(&mut self) -> AstExpansionCtx {
+    fn data(&mut self) -> AstExpansionCtx<'_> {
         AstExpansionCtx {
             workspace: &mut self.workspace,
             settings: &self.settings,
@@ -314,7 +314,7 @@ impl AstExpansionCtxQuery for Compiler {
 }
 
 impl SemanticAnalysisCtxQuery for Compiler {
-    fn data(&mut self) -> SemanticAnalysisCtx {
+    fn data(&mut self) -> SemanticAnalysisCtx<'_> {
         SemanticAnalysisCtx {
             workspace: &mut self.workspace,
             semantic_storage: &mut self.semantic_storage,
@@ -326,7 +326,7 @@ impl SemanticAnalysisCtxQuery for Compiler {
 }
 
 impl LoweringCtxQuery for Compiler {
-    fn data(&mut self) -> LoweringCtx {
+    fn data(&mut self) -> LoweringCtx<'_> {
         LoweringCtx {
             semantic_storage: &self.semantic_storage,
             workspace: &mut self.workspace,
@@ -339,7 +339,7 @@ impl LoweringCtxQuery for Compiler {
 }
 
 impl BackendCtxQuery for Compiler {
-    fn data(&mut self) -> BackendCtx {
+    fn data(&mut self) -> BackendCtx<'_> {
         BackendCtx {
             codegen_storage: &self.codegen_storage,
             workspace: &mut self.workspace,

--- a/compiler/hash-driver/src/lib.rs
+++ b/compiler/hash-driver/src/lib.rs
@@ -7,7 +7,7 @@
 //! methods for "selecting" the information that is needed by the stage.
 //! This creates a clear separation between the stages and the global state,
 //! keeping the crate dependency graph clean.
-#![feature(let_chains, thread_id_value)]
+#![feature(thread_id_value)]
 pub mod driver;
 
 use std::collections::HashSet;

--- a/compiler/hash-exhaustiveness/src/lib.rs
+++ b/compiler/hash-exhaustiveness/src/lib.rs
@@ -45,7 +45,7 @@
 //! inspired by and based off of the Rust Compiler implementation:
 //!
 //! <https://github.com/rust-lang/rust/tree/master/compiler/rustc_mir_build/src/thir/pattern/usefulness.rs>
-#![feature(let_chains, if_let_guard)]
+#![feature(if_let_guard)]
 
 // ##GeneratedOrigin(crate): This crate only produces TIR nodes which are
 // printed, and never shown as a span in any diagnostics. Therefore, all origins

--- a/compiler/hash-exhaustiveness/src/usefulness.rs
+++ b/compiler/hash-exhaustiveness/src/usefulness.rs
@@ -333,18 +333,18 @@ impl<E: ExhaustivenessEnv> ExhaustivenessChecker<'_, E> {
 
             // check that int ranges don't overlap here, in case
             // they're partially covered by other ranges.
-            if let DeconstructedCtor::IntRange(range) = self.get_ctor(v_ctor) {
-                if let Some(pat) = head.id {
-                    let ty = self.ty_lower().repr_ty_from_tir_ty(*ty);
+            if let DeconstructedCtor::IntRange(range) = self.get_ctor(v_ctor)
+                && let Some(pat) = head.id
+            {
+                let ty = self.ty_lower().repr_ty_from_tir_ty(*ty);
 
-                    self.check_for_overlapping_endpoints(
-                        pat,
-                        *range,
-                        matrix.heads(),
-                        matrix.column_count().unwrap_or(0),
-                        ty,
-                    );
-                }
+                self.check_for_overlapping_endpoints(
+                    pat,
+                    *range,
+                    matrix.heads(),
+                    matrix.column_count().unwrap_or(0),
+                    ty,
+                );
             }
 
             // We split the head constructor of `v`.

--- a/compiler/hash-ir-utils/src/lib.rs
+++ b/compiler/hash-ir-utils/src/lib.rs
@@ -6,7 +6,6 @@
 //! One of the main uses of this crate uses `hash-layout` to provide needed
 //! information about data representation when constructing and destructing
 //! Hash IR constants into various representations.
-#![feature(let_chains)]
 pub mod graphviz;
 pub mod pretty;
 

--- a/compiler/hash-ir/src/basic_blocks.rs
+++ b/compiler/hash-ir/src/basic_blocks.rs
@@ -163,7 +163,7 @@ impl<'s> graph::GraphSuccessors<'s> for BasicBlocks {
 }
 
 impl graph::WithSuccessors for BasicBlocks {
-    fn successors(&self, node: BasicBlock) -> <Self as graph::GraphSuccessors>::Iter {
+    fn successors(&self, node: BasicBlock) -> <Self as graph::GraphSuccessors<'_>>::Iter {
         self.blocks[node].terminator().successors()
     }
 }

--- a/compiler/hash-ir/src/ir.rs
+++ b/compiler/hash-ir/src/ir.rs
@@ -681,10 +681,10 @@ impl SwitchTargets {
             }
         }
 
-        if let Some(otherwise) = self.otherwise {
-            if otherwise == successor {
-                self.otherwise = Some(replacement);
-            }
+        if let Some(otherwise) = self.otherwise
+            && otherwise == successor
+        {
+            self.otherwise = Some(replacement);
         }
     }
 

--- a/compiler/hash-ir/src/lib.rs
+++ b/compiler/hash-ir/src/lib.rs
@@ -96,22 +96,22 @@ impl IrCtx {
     }
 
     /// Get a reference to the [Intrinsics] map.
-    pub fn intrinsics(&self) -> Ref<Intrinsics> {
+    pub fn intrinsics(&self) -> Ref<'_, Intrinsics> {
         self.intrinsics.borrow()
     }
 
     /// Get a mutable reference to the [Intrinsics] map.
-    pub fn intrinsics_mut(&self) -> RefMut<Intrinsics> {
+    pub fn intrinsics_mut(&self) -> RefMut<'_, Intrinsics> {
         self.intrinsics.borrow_mut()
     }
 
     /// Get a reference to the [LangItems] map.
-    pub fn lang_items(&self) -> Ref<LangItems> {
+    pub fn lang_items(&self) -> Ref<'_, LangItems> {
         self.lang_items.borrow()
     }
 
     /// Get a mutable reference to the [LangItems] map.
-    pub fn lang_items_mut(&self) -> RefMut<LangItems> {
+    pub fn lang_items_mut(&self) -> RefMut<'_, LangItems> {
         self.lang_items.borrow_mut()
     }
 }

--- a/compiler/hash-ir/src/lib.rs
+++ b/compiler/hash-ir/src/lib.rs
@@ -1,5 +1,5 @@
 //! Hash Compiler Intermediate Representation (IR) crate.
-#![feature(let_chains, type_alias_impl_trait, decl_macro, box_patterns, variant_count)]
+#![feature(type_alias_impl_trait, decl_macro, box_patterns, variant_count)]
 
 pub mod basic_blocks;
 pub mod cast;

--- a/compiler/hash-lexer/Cargo.toml
+++ b/compiler/hash-lexer/Cargo.toml
@@ -15,7 +15,7 @@ hash-target = { workspace = true }
 hash-utils = { workspace = true }
 
 [dev-dependencies]
-criterion = "0.5.1"
+criterion = "0.7.0"
 
 [[bench]]
 name = "bench"

--- a/compiler/hash-lexer/src/lib.rs
+++ b/compiler/hash-lexer/src/lib.rs
@@ -1,5 +1,5 @@
 //! Hash Compiler Lexer crate.
-#![feature(cell_update, let_chains, if_let_guard)]
+#![feature(if_let_guard)]
 
 use std::cell::Cell;
 

--- a/compiler/hash-link/src/linker/mod.rs
+++ b/compiler/hash-link/src/linker/mod.rs
@@ -126,38 +126,38 @@ pub(super) fn get_linker<'a>(
 
     // Due to Windows being crazy^TM, we need tell MSVC to link with the default
     // libraries (vcruntime, msvcrt, etc).
-    if flavour.is_msvc_like() {
-        if let Some(tool) = msvc_tool {
-            // For UWP(Windows Store) apps, we need to comply with the Windows App
-            // Certification Kit, which means that we need to link with the
-            // Windows Store libraries.
-            if target.vendor == "uwp" {
-                let tool_path = tool.path();
+    if flavour.is_msvc_like()
+        && let Some(tool) = msvc_tool
+    {
+        // For UWP(Windows Store) apps, we need to comply with the Windows App
+        // Certification Kit, which means that we need to link with the
+        // Windows Store libraries.
+        if target.vendor == "uwp" {
+            let tool_path = tool.path();
 
-                if let Some(root_path) = tool_path.ancestors().nth(4) {
-                    // We need to add the store library path to the linker search path.
-                    let arch = match target.arch {
-                        TargetArch::X86 => Some("x64"),
-                        TargetArch::X86_64 => Some("x86"),
-                        TargetArch::Aarch64 => Some("arm64"),
-                        TargetArch::Arm => Some("arm"),
-                        TargetArch::Unknown => None,
-                    };
+            if let Some(root_path) = tool_path.ancestors().nth(4) {
+                // We need to add the store library path to the linker search path.
+                let arch = match target.arch {
+                    TargetArch::X86 => Some("x64"),
+                    TargetArch::X86_64 => Some("x86"),
+                    TargetArch::Aarch64 => Some("arm64"),
+                    TargetArch::Arm => Some("arm"),
+                    TargetArch::Unknown => None,
+                };
 
-                    if let Some(arch_name) = arch {
-                        let mut arg = OsString::from("/LIBPATH:");
-                        arg.push(format!("{}\\lib\\{}\\store", root_path.display(), arch_name));
-                        command.arg(&arg);
-                    }
+                if let Some(arch_name) = arch {
+                    let mut arg = OsString::from("/LIBPATH:");
+                    arg.push(format!("{}\\lib\\{}\\store", root_path.display(), arch_name));
+                    command.arg(&arg);
                 }
             }
+        }
 
-            command.args(tool.args());
+        command.args(tool.args());
 
-            // Add any environment variables that the tool provides to our command
-            for (key, value) in tool.env() {
-                command.env(key, value);
-            }
+        // Add any environment variables that the tool provides to our command
+        for (key, value) in tool.env() {
+            command.env(key, value);
         }
     }
 

--- a/compiler/hash-lower/src/build/matches/mod.rs
+++ b/compiler/hash-lower/src/build/matches/mod.rs
@@ -104,14 +104,13 @@ impl<'tcx> BodyBuilder<'tcx> {
 
         // If this is a `&&`, we can create a `then-else` block sequence
         // that respects the short-circuiting behaviour of `&&`.
-        if let Term::Call(ref fn_call) = *expr.value() {
-            if let FnCallTermKind::LogicalBinOp(LogicalBinOp::And, lhs, rhs) =
+        if let Term::Call(ref fn_call) = *expr.value()
+            && let FnCallTermKind::LogicalBinOp(LogicalBinOp::And, lhs, rhs) =
                 self.classify_fn_call_term(fn_call)
-            {
-                let lhs_then_block = unpack!(self.then_else_break(block, else_block, lhs));
-                let rhs_then_block = unpack!(self.then_else_break(lhs_then_block, else_block, rhs));
-                return rhs_then_block.unit();
-            }
+        {
+            let lhs_then_block = unpack!(self.then_else_break(block, else_block, lhs));
+            let rhs_then_block = unpack!(self.then_else_break(lhs_then_block, else_block, rhs));
+            return rhs_then_block.unit();
         }
 
         let place = unpack!(block = self.as_place(block, expr, Mutability::Mutable));

--- a/compiler/hash-lower/src/ctx.rs
+++ b/compiler/hash-lower/src/ctx.rs
@@ -108,7 +108,7 @@ impl<'ir> BuilderCtx<'ir> {
 
     /// Get a [LayoutComputer] which can be used to compute layouts and
     /// other layout related operations.
-    pub fn layout_computer(&self) -> LayoutComputer {
+    pub fn layout_computer(&self) -> LayoutComputer<'_> {
         LayoutComputer::new(self.layouts)
     }
 

--- a/compiler/hash-lower/src/lib.rs
+++ b/compiler/hash-lower/src/lib.rs
@@ -3,7 +3,7 @@
 //! the Hash IR builder crate contains implemented passes that will optimise the
 //! IR, performing optimisations such as constant folding or dead code
 //! elimination.
-#![feature(decl_macro, let_chains, never_type, unwrap_infallible)]
+#![feature(decl_macro, never_type, unwrap_infallible)]
 
 mod build;
 mod cfg;

--- a/compiler/hash-parser/src/diagnostics/error.rs
+++ b/compiler/hash-parser/src/diagnostics/error.rs
@@ -180,11 +180,11 @@ impl From<ParseError> for Reports {
         // `AstGenErrorKind::Expected` format the error message in their own way,
         // whereas all the other error types follow a conformed order to
         // formatting expected tokens
-        if !matches!(&err.kind, ParseErrorKind::UnExpected) {
-            if let Some(kind) = err.received {
-                let atom_msg = format!(", however received {}", kind.as_error_string());
-                base_message.push_str(&atom_msg);
-            }
+        if !matches!(&err.kind, ParseErrorKind::UnExpected)
+            && let Some(kind) = err.received
+        {
+            let atom_msg = format!(", however received {}", kind.as_error_string());
+            base_message.push_str(&atom_msg);
         }
 
         // If the generated error has suggested tokens that aren't empty.

--- a/compiler/hash-parser/src/lib.rs
+++ b/compiler/hash-parser/src/lib.rs
@@ -1,6 +1,5 @@
 //! Self hosted hash parser, this function contains the implementations for
 //! `hash-ast` which provides a general interface to write a parser.
-#![feature(cell_update, let_chains)]
 
 mod diagnostics;
 mod import_resolver;

--- a/compiler/hash-parser/src/lib.rs
+++ b/compiler/hash-parser/src/lib.rs
@@ -72,7 +72,7 @@ pub struct ParserCtx<'p> {
 }
 
 pub trait ParserCtxQuery: CompilerInterface {
-    fn data(&mut self) -> ParserCtx;
+    fn data(&mut self) -> ParserCtx<'_>;
 }
 
 impl<Ctx: ParserCtxQuery> CompilerStage<Ctx> for Parser {

--- a/compiler/hash-repr/src/lib.rs
+++ b/compiler/hash-repr/src/lib.rs
@@ -619,5 +619,5 @@ impl LayoutId {
 
 /// Interface to access information about the representations and layout.
 pub trait HasLayout {
-    fn layout_computer(&self) -> LayoutComputer;
+    fn layout_computer(&self) -> LayoutComputer<'_>;
 }

--- a/compiler/hash-repr/src/lib.rs
+++ b/compiler/hash-repr/src/lib.rs
@@ -1,7 +1,6 @@
 //! Defines all logic regarding computing the layout of types, and
 //! representing the said layouts in a way that is usable by the
 //! code generation backends.
-#![feature(let_chains)]
 
 pub mod compute;
 pub mod constant;

--- a/compiler/hash-semantics/src/diagnostics/reporting.rs
+++ b/compiler/hash-semantics/src/diagnostics/reporting.rs
@@ -77,12 +77,12 @@ impl SemanticReporter {
                     format!("tried to look for {noun} `{search_name}` in {def_name}",),
                 );
 
-                if let ContextKind::Access(_, def) = looking_in {
-                    if let Some(location) = def.span() {
-                        error.add_span(location).add_info(format!(
-                            "{def_name} is defined here, and has no member `{search_name}`",
-                        ));
-                    }
+                if let ContextKind::Access(_, def) = looking_in
+                    && let Some(location) = def.span()
+                {
+                    error.add_span(location).add_info(format!(
+                        "{def_name} is defined here, and has no member `{search_name}`",
+                    ));
                 }
             }
             SemanticError::CannotUseModuleInValuePosition { location } => {

--- a/compiler/hash-semantics/src/lib.rs
+++ b/compiler/hash-semantics/src/lib.rs
@@ -66,7 +66,7 @@ pub struct SemanticAnalysisCtx<'env> {
 }
 
 pub trait SemanticAnalysisCtxQuery: CompilerInterface {
-    fn data(&mut self) -> SemanticAnalysisCtx;
+    fn data(&mut self) -> SemanticAnalysisCtx<'_>;
 }
 
 impl<Ctx: SemanticAnalysisCtxQuery> CompilerStage<Ctx> for SemanticAnalysis {
@@ -151,7 +151,7 @@ impl HasTarget for SemanticEnvImpl<'_> {
 }
 
 impl HasLayout for SemanticEnvImpl<'_> {
-    fn layout_computer(&self) -> LayoutComputer {
+    fn layout_computer(&self) -> LayoutComputer<'_> {
         LayoutComputer::new(self.ctx.lcx)
     }
 }

--- a/compiler/hash-semantics/src/lib.rs
+++ b/compiler/hash-semantics/src/lib.rs
@@ -3,7 +3,7 @@
 //! This brings light to the world by ensuring the correctness of the crude and
 //! dangerous Hash program that is given as input to the compiler.
 
-#![feature(decl_macro, slice_pattern, let_chains, if_let_guard, cell_update, try_blocks)]
+#![feature(decl_macro, slice_pattern, if_let_guard, try_blocks)]
 
 use diagnostics::{
     definitions::{SemanticError, SemanticWarning},

--- a/compiler/hash-semantics/src/passes/evaluation/mod.rs
+++ b/compiler/hash-semantics/src/passes/evaluation/mod.rs
@@ -124,13 +124,13 @@ impl<E: SemanticEnv> AnalysisPass for EvaluationPass<'_, E> {
             dump_tir(mod_def_id);
         }
 
-        if settings.eval_tir {
-            if let Some(term) = main_call_term {
-                let context = Context::new();
-                let tc = env.checker(&context);
-                tc.normalisation_opts.mode.set(NormalisationMode::Full);
-                let _ = tc.normalise_node_no_signals(term)?;
-            }
+        if settings.eval_tir
+            && let Some(term) = main_call_term
+        {
+            let context = Context::new();
+            let tc = env.checker(&context);
+            tc.normalisation_opts.mode.set(NormalisationMode::Full);
+            let _ = tc.normalise_node_no_signals(term)?;
         }
 
         Ok(())

--- a/compiler/hash-semantics/src/passes/resolution/mod.rs
+++ b/compiler/hash-semantics/src/passes/resolution/mod.rs
@@ -103,12 +103,12 @@ impl<'env, E: SemanticEnv + 'env> ResolutionPass<'env, E> {
     }
 
     /// Get a new pattern binder checker.
-    fn pat_binds_validator(&self) -> PatBindsChecker<E> {
+    fn pat_binds_validator(&self) -> PatBindsChecker<'_, E> {
         PatBindsChecker::new(self.env)
     }
 
     /// Get access to the current scoping state and operations.
-    fn scoping(&self) -> &Scoping<E> {
+    fn scoping(&self) -> &Scoping<'_, E> {
         &self.scoping
     }
 }

--- a/compiler/hash-semantics/src/passes/tc_env_impl.rs
+++ b/compiler/hash-semantics/src/passes/tc_env_impl.rs
@@ -57,7 +57,7 @@ impl<E: SemanticEnv> HasTarget for TcEnvImpl<'_, E> {
 }
 
 impl<E: SemanticEnv> HasLayout for TcEnvImpl<'_, E> {
-    fn layout_computer(&self) -> LayoutComputer {
+    fn layout_computer(&self) -> LayoutComputer<'_> {
         self.env.layout_computer()
     }
 }

--- a/compiler/hash-source/src/lib.rs
+++ b/compiler/hash-source/src/lib.rs
@@ -274,11 +274,11 @@ impl Source {
                 let prefix = path.file_prefix().unwrap();
 
                 // deal with `index.hash` case...
-                if prefix == "index" {
-                    if let Some(parent) = path.parent() {
-                        // Now we should be at the `parent` direct
-                        return parent.file_name().unwrap_or(prefix).to_str().unwrap();
-                    }
+                if prefix == "index"
+                    && let Some(parent) = path.parent()
+                {
+                    // Now we should be at the `parent` direct
+                    return parent.file_name().unwrap_or(prefix).to_str().unwrap();
                 }
 
                 // If it is a normal filename, then just use the resultant prefix, or default

--- a/compiler/hash-source/src/lib.rs
+++ b/compiler/hash-source/src/lib.rs
@@ -1,5 +1,5 @@
 //! Hash Compiler source location definitions.
-#![feature(path_file_prefix, let_chains, const_trait_impl, box_patterns)]
+#![feature(const_trait_impl, box_patterns)]
 
 pub mod constant;
 pub mod entry_point;

--- a/compiler/hash-storage/src/arena/mod.rs
+++ b/compiler/hash-storage/src/arena/mod.rs
@@ -35,7 +35,7 @@ impl Castle {
 
     /// Create a new [`Wall`] inside this `Castle`. The created [`Wall`] lives
     /// as long as the reference to this `Castle`.
-    pub fn wall(&self) -> Wall {
+    pub fn wall(&self) -> Wall<'_> {
         Wall::with_member(self.herd.get(), self)
     }
 }

--- a/compiler/hash-storage/src/store/base.rs
+++ b/compiler/hash-storage/src/store/base.rs
@@ -228,6 +228,14 @@ impl<K: StoreKey, V: Clone> Store<K, V> for DefaultStore<K, V> {
 
 #[cfg(test)]
 mod test_super {
+    use crate::store::StoreKey;
+
     // Ensuring macros expand correctly:
     new_store_key!(pub TestK);
+
+    #[test]
+    fn test_construct_testk() {
+        let _key = unsafe { TestK::from_index_unchecked(0usize) };
+        assert_eq!(_key.to_index(), 0);
+    }
 }

--- a/compiler/hash-tir-utils/src/lib.rs
+++ b/compiler/hash-tir-utils/src/lib.rs
@@ -1,6 +1,5 @@
 //! Various utilities that are asssociated with TIR operations but cannot
 //! be defined in the [hash_tir] crate.
-#![feature(let_chains)]
 
 pub mod lower;
 pub mod upcast;

--- a/compiler/hash-tir/src/context.rs
+++ b/compiler/hash-tir/src/context.rs
@@ -209,7 +209,7 @@ impl Context {
     }
 
     /// Get a reference to the current scope.
-    pub fn get_current_scope_ref(&self) -> Ref<Scope> {
+    pub fn get_current_scope_ref(&self) -> Ref<'_, Scope> {
         Ref::map(self.scopes.borrow(), |scopes| {
             scopes.last().unwrap_or_else(|| {
                 panic!("tried to get the scope kind of a context with no scopes");
@@ -223,7 +223,7 @@ impl Context {
     }
 
     /// Get the closest stack scope and its index.
-    pub fn get_closest_stack_scope_ref(&self) -> Ref<Scope> {
+    pub fn get_closest_stack_scope_ref(&self) -> Ref<'_, Scope> {
         Ref::map(self.scopes.borrow(), |scopes| {
             scopes
                 .iter()
@@ -235,7 +235,7 @@ impl Context {
         })
     }
 
-    pub fn get_scope_ref_at_index(&self, index: usize) -> Ref<Scope> {
+    pub fn get_scope_ref_at_index(&self, index: usize) -> Ref<'_, Scope> {
         Ref::map(self.scopes.borrow(), |scopes| {
             scopes.get(index).unwrap_or_else(|| {
                 panic!("tried to get the scope kind of a context with no scopes");
@@ -251,7 +251,7 @@ impl Context {
     }
 
     /// Get information about the scope with the given index.
-    pub fn get_scope(&self, index: usize) -> Ref<Scope> {
+    pub fn get_scope(&self, index: usize) -> Ref<'_, Scope> {
         Ref::map(self.scopes.borrow(), |scopes| &scopes[index])
     }
 

--- a/compiler/hash-tir/src/lib.rs
+++ b/compiler/hash-tir/src/lib.rs
@@ -4,7 +4,7 @@
 //! It is used to perform semantic analysis and type checking. After this
 //! stage, the TIR is lowered into the IR, which continues on down the
 //! pipeline.
-#![feature(let_chains, decl_macro, trait_alias, never_type, unwrap_infallible, macro_metavar_expr)]
+#![feature(decl_macro, trait_alias, never_type, unwrap_infallible, macro_metavar_expr)]
 #![recursion_limit = "128"]
 
 pub mod atom_info;

--- a/compiler/hash-tir/src/tir/mods.rs
+++ b/compiler/hash-tir/src/tir/mods.rs
@@ -119,10 +119,10 @@ impl ModDef {
     pub fn get_mod_fn_member_by_ident(&self, name: impl Into<Identifier>) -> Option<FnDefId> {
         let name = name.into();
         self.members.iter().find_map(|member| {
-            if let ModMemberValue::Fn(fn_def_id) = member.borrow().value {
-                if member.borrow().name.borrow().name.is_some_and(|sym| sym == name) {
-                    return Some(fn_def_id);
-                }
+            if let ModMemberValue::Fn(fn_def_id) = member.borrow().value
+                && member.borrow().name.borrow().name.is_some_and(|sym| sym == name)
+            {
+                return Some(fn_def_id);
             }
             None
         })

--- a/compiler/hash-tree-def/src/emit.rs
+++ b/compiler/hash-tree-def/src/emit.rs
@@ -191,12 +191,11 @@ fn emit_visitor(tree_def: &TreeDef, nodes_mut: bool, self_mut: bool) -> TokenStr
 
 /// If the given `ty` represents a node, return the name of the node.
 fn is_node_ty(ty: &syn::Type, tree_def: &TreeDef) -> Option<syn::Ident> {
-    if let syn::Type::Path(path) = ty {
-        if let Some(ident) = path.path.get_ident() {
-            if tree_def.nodes.contains_key(ident) {
-                return Some(ident.clone());
-            }
-        }
+    if let syn::Type::Path(path) = ty
+        && let Some(ident) = path.path.get_ident()
+        && tree_def.nodes.contains_key(ident)
+    {
+        return Some(ident.clone());
     }
     None
 }

--- a/compiler/hash-tree-def/src/parse.rs
+++ b/compiler/hash-tree-def/src/parse.rs
@@ -176,13 +176,13 @@ fn parse_path_field(fields: &FieldsNamed, field_name: &str) -> Result<Path, syn:
         .named
         .iter()
         .find_map(|field| {
-            if let Some(ident) = &field.ident {
-                if ident == field_name {
-                    if let Type::Path(path) = &field.ty {
-                        return Some(Ok(path.path.clone()));
-                    }
-                    return Some(Err(syn::Error::new(field.ty.span(), "Expected a path")));
+            if let Some(ident) = &field.ident
+                && ident == field_name
+            {
+                if let Type::Path(path) = &field.ty {
+                    return Some(Ok(path.path.clone()));
                 }
+                return Some(Err(syn::Error::new(field.ty.span(), "Expected a path")));
             }
             None
         })
@@ -201,18 +201,15 @@ fn parse_ident_field(fields: &FieldsNamed, field_name: &str) -> Result<Ident, sy
         .named
         .iter()
         .find_map(|field| {
-            if let Some(ident) = &field.ident {
-                if ident == field_name {
-                    if let Type::Path(path) = &field.ty {
-                        if let Some(name) = path.path.get_ident() {
-                            return Some(Ok(name.clone()));
-                        }
-                    }
-                    return Some(Err(syn::Error::new(
-                        field.ty.span(),
-                        "Expected a type identifier",
-                    )));
+            if let Some(ident) = &field.ident
+                && ident == field_name
+            {
+                if let Type::Path(path) = &field.ty
+                    && let Some(name) = path.path.get_ident()
+                {
+                    return Some(Ok(name.clone()));
                 }
+                return Some(Err(syn::Error::new(field.ty.span(), "Expected a type identifier")));
             }
             None
         })

--- a/compiler/hash-typecheck/src/lib.rs
+++ b/compiler/hash-typecheck/src/lib.rs
@@ -11,8 +11,6 @@
 //! that defines all the required items for the typechecker to work, provided by
 //! the greater compiler context.
 
-#![feature(let_chains)]
-
 pub mod diagnostics;
 pub mod env;
 pub mod operations;

--- a/compiler/hash-typecheck/src/operations/arrays.rs
+++ b/compiler/hash-typecheck/src/operations/arrays.rs
@@ -176,13 +176,13 @@ impl<E: TcEnv> OperationsOn<ArrayTerm> for Tc<'_, E> {
         };
 
         // Ensure the array lengths match if given
-        if let Some(len) = array_len {
-            if !self.nodes_are_equal(len, inferred_len_term) {
-                return Err(TcError::MismatchingArrayLengths {
-                    expected_len: len,
-                    got_len: inferred_len_term,
-                });
-            }
+        if let Some(len) = array_len
+            && !self.nodes_are_equal(len, inferred_len_term)
+        {
+            return Err(TcError::MismatchingArrayLengths {
+                expected_len: len,
+                got_len: inferred_len_term,
+            });
         }
 
         // Either create  a default type, or apply a substitution to the annotation

--- a/compiler/hash-typecheck/src/operations/matching.rs
+++ b/compiler/hash-typecheck/src/operations/matching.rs
@@ -55,14 +55,14 @@ impl<E: TcEnv> OperationsOn<MatchTerm> for Tc<'_, E> {
                 let new_unified_ty =
                     Ty::expect_is(case_data.value, self.visitor().copy(unified_ty));
 
-                if let Some(match_subject_var) = match_subject_var {
-                    if let Some(pat_term) = case_data.bind_pat.try_use_as_term() {
-                        self.context().add_assignment(
-                            match_subject_var.symbol,
-                            subject_ty_copy,
-                            pat_term,
-                        );
-                    }
+                if let Some(match_subject_var) = match_subject_var
+                    && let Some(pat_term) = case_data.bind_pat.try_use_as_term()
+                {
+                    self.context().add_assignment(
+                        match_subject_var.symbol,
+                        subject_ty_copy,
+                        pat_term,
+                    );
                 }
 
                 match match_annotation_ty {

--- a/compiler/hash-typecheck/src/tc.rs
+++ b/compiler/hash-typecheck/src/tc.rs
@@ -54,7 +54,7 @@ impl<E: TcEnv> Tc<'_, E> {
     }
 
     /// Create a substituter for this typechecker.
-    pub fn substituter(&self) -> Substituter<E> {
+    pub fn substituter(&self) -> Substituter<'_, E> {
         Substituter::new(self)
     }
 }

--- a/compiler/hash-typecheck/src/utils/exhaustiveness.rs
+++ b/compiler/hash-typecheck/src/utils/exhaustiveness.rs
@@ -10,7 +10,10 @@ use crate::{env::TcEnv, tc::Tc};
 impl<T: TcEnv> Tc<'_, T> {
     /// Create a new [ExhaustivenessChecker] so it can be used to check
     /// refutability or exhaustiveness of patterns.
-    pub fn exhaustiveness_checker<U: HasAstNodeId>(&self, subject: U) -> ExhaustivenessChecker<T> {
+    pub fn exhaustiveness_checker<U: HasAstNodeId>(
+        &self,
+        subject: U,
+    ) -> ExhaustivenessChecker<'_, T> {
         let location = subject.span().unwrap();
         ExhaustivenessChecker::new(location, self.env, self.context)
     }

--- a/compiler/hash-typecheck/src/utils/intrinsic_abilities.rs
+++ b/compiler/hash-typecheck/src/utils/intrinsic_abilities.rs
@@ -37,7 +37,7 @@ impl<T: TcEnv> HasTarget for IntrinsicAbilitiesImpl<'_, T> {
 }
 
 impl<T: TcEnv> HasLayout for IntrinsicAbilitiesImpl<'_, T> {
-    fn layout_computer(&self) -> LayoutComputer {
+    fn layout_computer(&self) -> LayoutComputer<'_> {
         self.tc.layout_computer()
     }
 }

--- a/compiler/hash-typecheck/src/utils/substitution.rs
+++ b/compiler/hash-typecheck/src/utils/substitution.rs
@@ -211,11 +211,11 @@ impl<'a, T: TcEnv> Substituter<'a, T> {
                 return seen;
             }
             seen.remove(&param.name);
-            if let Some(default) = param.default {
-                if self.contains_vars(default, &seen) {
-                    *can_apply = true;
-                    return seen;
-                }
+            if let Some(default) = param.default
+                && self.contains_vars(default, &seen)
+            {
+                *can_apply = true;
+                return seen;
             }
         }
         seen

--- a/compiler/hash-untyped-semantics/src/lib.rs
+++ b/compiler/hash-untyped-semantics/src/lib.rs
@@ -34,7 +34,7 @@ pub struct UntypedSemanticAnalysisCtx<'s> {
 /// A trait that allows the [SemanticAnalysis] stage to query the
 /// pipeline for the required information.
 pub trait UntypedSemanticAnalysisCtxQuery: CompilerInterface {
-    fn data(&mut self) -> UntypedSemanticAnalysisCtx;
+    fn data(&mut self) -> UntypedSemanticAnalysisCtx<'_>;
 }
 
 impl<Ctx: UntypedSemanticAnalysisCtxQuery> CompilerStage<Ctx> for UntypedSemanticAnalysis {

--- a/compiler/hash-untyped-semantics/src/lib.rs
+++ b/compiler/hash-untyped-semantics/src/lib.rs
@@ -1,7 +1,7 @@
 //! Hash AST semantic passes crate. This crate holds an implementation for the
 //! visitor pattern on the AST to perform semantic checking and analysis on the
 //! de-sugared AST.
-#![feature(let_chains, if_let_guard)]
+#![feature(if_let_guard)]
 
 pub mod analysis;
 pub(crate) mod diagnostics;

--- a/compiler/hash-untyped-semantics/src/visitor.rs
+++ b/compiler/hash-untyped-semantics/src/visitor.rs
@@ -269,13 +269,13 @@ impl AstVisitorMutSelf for SemanticAnalyser {
         // constant scope, then we should check if binding contains a visibility
         // modifier which is disallowed within body blocks.
         if self.is_in_constant_block() {
-            if let Some(mut_annotation) = mutability {
-                if *mut_annotation.body() == ast::Mutability::Mutable {
-                    self.append_error(
-                        AnalysisErrorKind::IllegalBindingMutability,
-                        mut_annotation.ast_ref(),
-                    );
-                }
+            if let Some(mut_annotation) = mutability
+                && *mut_annotation.body() == ast::Mutability::Mutable
+            {
+                self.append_error(
+                    AnalysisErrorKind::IllegalBindingMutability,
+                    mut_annotation.ast_ref(),
+                );
             }
         } else if let Some(visibility_annotation) = visibility {
             self.append_error(

--- a/compiler/hash-utils/Cargo.toml
+++ b/compiler/hash-utils/Cargo.toml
@@ -37,5 +37,5 @@ stacker = { workspace = true }
 thin-vec = { workspace = true }
 
 [target.'cfg(windows)'.dependencies.windows]
-version = "0.61.1"
+version = "0.62.0"
 features = ["Win32_Foundation", "Win32_Storage_FileSystem", "Win32_System_IO", "Win32_System_ProcessStatus", "Win32_System_Threading"]

--- a/compiler/hash-utils/src/graph/mod.rs
+++ b/compiler/hash-utils/src/graph/mod.rs
@@ -37,7 +37,7 @@ pub trait WithPredecessors: DirectedGraph
 where
     Self: for<'graph> GraphPredecessors<'graph, Item = <Self as DirectedGraph>::Node>,
 {
-    fn predecessors(&self, node: Self::Node) -> <Self as GraphPredecessors>::Iter;
+    fn predecessors(&self, node: Self::Node) -> <Self as GraphPredecessors<'_>>::Iter;
 }
 
 pub trait GraphSuccessors<'graph> {
@@ -52,7 +52,7 @@ where
     Self: for<'graph> GraphSuccessors<'graph, Item = <Self as DirectedGraph>::Node>,
 {
     /// Get the successors of a node.
-    fn successors(&self, node: Self::Node) -> <Self as GraphSuccessors>::Iter;
+    fn successors(&self, node: Self::Node) -> <Self as GraphSuccessors<'_>>::Iter;
 
     /// Create a [DepthFirstSearch] iterator that starts at the given
     /// node.

--- a/compiler/hash-utils/src/graph/tests/mod.rs
+++ b/compiler/hash-utils/src/graph/tests/mod.rs
@@ -79,7 +79,7 @@ impl super::GraphPredecessors<'_> for TestGraph {
 }
 
 impl WithPredecessors for TestGraph {
-    fn predecessors(&self, node: TestNode) -> <Self as super::GraphPredecessors>::Iter {
+    fn predecessors(&self, node: TestNode) -> <Self as super::GraphPredecessors<'_>>::Iter {
         let nodes = self.predecessors[&node.index()]
             .clone()
             .into_iter()
@@ -96,7 +96,7 @@ impl super::GraphSuccessors<'_> for TestGraph {
 }
 
 impl super::WithSuccessors for TestGraph {
-    fn successors(&self, node: TestNode) -> <Self as super::GraphSuccessors>::Iter {
+    fn successors(&self, node: TestNode) -> <Self as super::GraphSuccessors<'_>>::Iter {
         let nodes = self.successors[&node.index()]
             .clone()
             .into_iter()

--- a/compiler/hash-utils/src/lib.rs
+++ b/compiler/hash-utils/src/lib.rs
@@ -1,13 +1,5 @@
 //! Hash compiler general utilities
-#![feature(
-    array_windows,
-    cell_update,
-    cfg_match,
-    decl_macro,
-    impl_trait_in_assoc_type,
-    panic_payload_as_str,
-    type_alias_impl_trait
-)]
+#![feature(array_windows, cfg_select, decl_macro, impl_trait_in_assoc_type, type_alias_impl_trait)]
 
 pub mod assert;
 pub mod counter;

--- a/compiler/hash-utils/src/profiling.rs
+++ b/compiler/hash-utils/src/profiling.rs
@@ -195,7 +195,7 @@ impl From<CellStageMetrics> for StageMetrics {
     }
 }
 
-cfg_match! {
+cfg_select! {
     windows => {
         pub fn get_resident_set_size() -> Option<usize> {
             use std::mem;

--- a/compiler/hash-utils/src/range_map.rs
+++ b/compiler/hash-utils/src/range_map.rs
@@ -172,10 +172,10 @@ impl<I: PrimInt + Clone + Copy, V> RangeMap<I, V> {
         // If the store is empty, we can just immediately push the range
         // into the map, and exit early. Otherwise, we ensure that the
         // range does not overlap with the last range in the map.
-        if let Some((last, _)) = self.store.last() {
-            if last.end >= key.start {
-                panic!("keys are not allowed to overlap in a range map")
-            }
+        if let Some((last, _)) = self.store.last()
+            && last.end >= key.start
+        {
+            panic!("keys are not allowed to overlap in a range map")
         }
 
         self.store.push((key, value));

--- a/compiler/hash-utils/src/tree_writing.rs
+++ b/compiler/hash-utils/src/tree_writing.rs
@@ -159,7 +159,7 @@ impl<'t> TreeWriter<'t, '_> {
         child_index == self.tree.children.len() - 1
     }
 
-    fn next_depth(&self, child: &'t TreeNode, child_index: usize) -> TreeWriter {
+    fn next_depth(&self, child: &'t TreeNode, child_index: usize) -> TreeWriter<'_, '_> {
         let vertical_line_or_pad = iter::once(if self.is_last(child_index) {
             self.config.pad
         } else {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2025-04-13"
+channel = "nightly-2025-09-01"
 components = ["rustfmt", "clippy", "rustfmt"]
 profile = "minimal"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -38,5 +38,5 @@ hash-testing-macros = { workspace = true }
 hash-testing-internal = { workspace = true }
 
 [dev-dependencies]
-clap = { version = "4.3.8", features = ["derive"] }
+clap = { version = "4.5.47", features = ["derive"] }
 rusty-fork = "0.3"

--- a/tests/testing-macros/src/lib.rs
+++ b/tests/testing-macros/src/lib.rs
@@ -2,7 +2,7 @@
 //! resources on the disk. This file primarily has the `generate_tests` macro
 //! that will read a directory and generate various test cases from the provided
 //! `case.hash` files and names of the directories that contain the cases.
-#![feature(iter_intersperse, path_file_prefix, try_find, proc_macro_span, track_path)]
+#![feature(iter_intersperse, try_find, track_path)]
 
 extern crate proc_macro;
 

--- a/tests/testing-macros/src/lib.rs
+++ b/tests/testing-macros/src/lib.rs
@@ -218,7 +218,7 @@ pub fn generate_tests(input: TokenStream) -> TokenStream {
     let call_site = Span::call_site();
 
     let file_path = fs::canonicalize(
-        call_site.source_file().path().parent().unwrap().to_owned().join(test_path),
+        call_site.local_file().unwrap().parent().unwrap().to_owned().join(test_path),
     )
     .unwrap();
 


### PR DESCRIPTION
### Changes

- **Update Rust toolchain to "nightly-2025-09-01"**
- **Update `INSTALL.md` to reflect use of LLVM 18.1.8**
- **Add explicit lifetime elisions**
- **Remove un-used `feature_flags`**
- **Use `if let` and `&&` compound expressions**
- **Use `Span::local_file` instead of `Span::source_file`**
- **Use `128::cast_unsigned` rather than `mem::transmute`**
- **Add simple storage test for StoreKey macro**
- **Upgrade all dependencies to their latest versions**
